### PR TITLE
fix(share): Avoid SecurityError on Android 10 file share

### DIFF
--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -71,6 +71,10 @@ public class SharePlugin extends Plugin {
                 new File(Uri.parse(url).getPath())
             );
             intent.putExtra(Intent.EXTRA_STREAM, fileUrl);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                intent.setData(fileUrl);
+            }
+            intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         }
 
         if (title != null) {


### PR DESCRIPTION
equivalent of https://github.com/ionic-team/capacitor/pull/3655