### PR TITLE
chore(haptics): consistent enum naming style

### DIFF
--- a/haptics/README.md
+++ b/haptics/README.md
@@ -162,9 +162,9 @@ For example, call this when a user has lifted their finger from a control
 
 | Members       | Value                  | Description                                                                    | Since |
 | ------------- | ---------------------- | ------------------------------------------------------------------------------ | ----- |
-| **`SUCCESS`** | <code>'SUCCESS'</code> | A notification feedback type indicating that a task has completed successfully | 1.0.0 |
-| **`WARNING`** | <code>'WARNING'</code> | A notification feedback type indicating that a task has produced a warning     | 1.0.0 |
-| **`ERROR`**   | <code>'ERROR'</code>   | A notification feedback type indicating that a task has failed                 | 1.0.0 |
+| **`Success`** | <code>'SUCCESS'</code> | A notification feedback type indicating that a task has completed successfully | 1.0.0 |
+| **`Warning`** | <code>'WARNING'</code> | A notification feedback type indicating that a task has produced a warning     | 1.0.0 |
+| **`Error`**   | <code>'ERROR'</code>   | A notification feedback type indicating that a task has failed                 | 1.0.0 |
 
 
 <!--DOCGEN_API_END-->

--- a/haptics/src/definitions.ts
+++ b/haptics/src/definitions.ts
@@ -104,21 +104,21 @@ export enum HapticsNotificationType {
    *
    * @since 1.0.0
    */
-  SUCCESS = 'SUCCESS',
+  Success = 'SUCCESS',
 
   /**
    * A notification feedback type indicating that a task has produced a warning
    *
    * @since 1.0.0
    */
-  WARNING = 'WARNING',
+  Warning = 'WARNING',
 
   /**
    * A notification feedback type indicating that a task has failed
    *
    * @since 1.0.0
    */
-  ERROR = 'ERROR',
+  Error = 'ERROR',
 }
 
 export interface VibrateOptions {

--- a/haptics/src/web.ts
+++ b/haptics/src/web.ts
@@ -56,11 +56,11 @@ export class HapticsWeb extends WebPlugin implements HapticsPlugin {
   }
 
   private patternForNotification(
-    type: HapticsNotificationType = HapticsNotificationType.SUCCESS,
+    type: HapticsNotificationType = HapticsNotificationType.Success,
   ): number[] {
-    if (type === HapticsNotificationType.WARNING) {
+    if (type === HapticsNotificationType.Warning) {
       return [30, 40, 30, 50, 60];
-    } else if (type === HapticsNotificationType.ERROR) {
+    } else if (type === HapticsNotificationType.Error) {
       return [27, 45, 50];
     }
     return [35, 65, 21];


### PR DESCRIPTION
This would be a breaking change in Haptics if people were using it, so not merging right away (unlike https://github.com/ionic-team/capacitor/pull/3671)
