### PR TITLE
docs: add simple installation instructions

### DIFF
--- a/action-sheet/README.md
+++ b/action-sheet/README.md
@@ -2,6 +2,13 @@
 
 The Action Sheet API provides access to native Action Sheets, which come up from the bottom of the screen and display actions a user can take.
 
+## Install
+
+```bash
+npm install @capacitor/action-sheet
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/app-launcher/README.md
+++ b/app-launcher/README.md
@@ -2,6 +2,13 @@
 
 The AppLauncher API allows to open other apps
 
+## Install
+
+```bash
+npm install @capacitor/app-launcher
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/browser/README.md
+++ b/browser/README.md
@@ -2,6 +2,13 @@
 
 The Browser API provides the ability to open an in-app browser and subscribe to browser events.
 
+## Install
+
+```bash
+npm install @capacitor/browser
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/clipboard/README.md
+++ b/clipboard/README.md
@@ -2,6 +2,13 @@
 
 The Clipboard API enables copy and pasting to/from the system clipboard.
 
+## Install
+
+```bash
+npm install @capacitor/clipboard
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/device/README.md
+++ b/device/README.md
@@ -2,6 +2,13 @@
 
 The Device API exposes internal information about the device, such as the model and operating system version, along with user information such as unique ids.
 
+## Install
+
+```bash
+npm install @capacitor/device
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -2,6 +2,13 @@
 
 The Dialog API provides methods for triggering native dialog windows for alerts, confirmations, and input prompts
 
+## Install
+
+```bash
+npm install @capacitor/dialog
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/haptics/README.md
+++ b/haptics/README.md
@@ -2,6 +2,13 @@
 
 The Haptics API provides physical feedback to the user through touch or vibration.
 
+## Install
+
+```bash
+npm install @capacitor/haptics
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/keyboard/README.md
+++ b/keyboard/README.md
@@ -2,6 +2,13 @@
 
 The Keyboard API provides keyboard display and visibility control, along with event tracking when the keyboard shows and hides.
 
+## Install
+
+```bash
+npm install @capacitor/keyboard
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/motion/README.md
+++ b/motion/README.md
@@ -2,6 +2,13 @@
 
 The Motion API tracks accelerometer and device orientation (compass heading, etc.)
 
+## Install
+
+```bash
+npm install @capacitor/motion
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/network/README.md
+++ b/network/README.md
@@ -2,6 +2,13 @@
 
 The Network API provides network and connectivity information.
 
+## Install
+
+```bash
+npm install @capacitor/network
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/screen-reader/README.md
+++ b/screen-reader/README.md
@@ -2,6 +2,13 @@
 
 The Screen Reader API provides access to TalkBack/VoiceOver/etc. and provides simple text-to-speech capabilities for visual accessibility.
 
+## Install
+
+```bash
+npm install @capacitor/screen-reader
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/share/README.md
+++ b/share/README.md
@@ -2,6 +2,13 @@
 
 The Share API provides methods for sharing content in any sharing-enabled apps the user may have installed.
 
+## Install
+
+```bash
+npm install @capacitor/share
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/status-bar/README.md
+++ b/status-bar/README.md
@@ -2,6 +2,13 @@
 
 The StatusBar API Provides methods for configuring the style of the Status Bar, along with showing or hiding it.
 
+## Install
+
+```bash
+npm install @capacitor/status-bar
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/storage/README.md
+++ b/storage/README.md
@@ -2,6 +2,13 @@
 
 The Storage API provides a simple key/value persistent store for lightweight data.
 
+## Install
+
+```bash
+npm install @capacitor/storage
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/text-zoom/README.md
+++ b/text-zoom/README.md
@@ -2,6 +2,13 @@
 
 The Text Zoom API provides the ability to change Web View text size for visual accessibility.
 
+## Install
+
+```bash
+npm install @capacitor/text-zoom
+npx cap sync
+```
+
 ## API
 
 <docgen-index>

--- a/toast/README.md
+++ b/toast/README.md
@@ -2,6 +2,13 @@
 
 The Toast API provides a notification pop up for displaying important information to a user. Just like real toast!
 
+## Install
+
+```bash
+npm install @capacitor/toast
+npx cap sync
+```
+
 ## API
 
 <docgen-index>


### PR DESCRIPTION
This is step 1 in documenting these plugins.
Step 2 is adding usage examples.