### PR TITLE
fix(storage): Remove warning on getString usage

### DIFF
--- a/storage/ios/Plugin/StoragePlugin.swift
+++ b/storage/ios/Plugin/StoragePlugin.swift
@@ -40,7 +40,7 @@ public class StoragePlugin: CAPPlugin {
             call.reject("Must provide a key")
             return
         }
-        let value = call.getString("value", "") ?? ""
+        let value = call.getString("value", "")
 
         storage.set(value, for: key)
         call.resolve()


### PR DESCRIPTION
getString doesn't return optional anymore if it has a default value