### PR TITLE
fix(browser): don't expose load method

### DIFF
--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
@@ -13,7 +13,6 @@ public class BrowserPlugin extends Plugin {
 
     private Browser implementation;
 
-    @PluginMethod
     public void load() {
         implementation = new Browser(getContext());
         implementation.setBrowserEventListener(this::onBrowserEvent);


### PR DESCRIPTION
load should not have `PluginMethod` annotation