### PR TITLE
feat(browser): Add close() method for android

### DIFF
--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
@@ -52,10 +52,14 @@ public class BrowserPlugin extends Plugin {
         call.resolve();
     }
 
-    @PluginMethod
-    public void close(PluginCall call) {
-        call.unimplemented();
-    }
+  @PluginMethod
+  public void close(PluginCall call) {
+    Context context = getActivity().getBaseContext();
+    Intent myIntent = new Intent(context, getActivity().getClass());
+    myIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+    myIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    context.startActivity(myIntent);
+  }
 
     @Override
     protected void handleOnResume() {


### PR DESCRIPTION
I'm new to ionic and capacitor and I had a problem I couldn't solve: Browser cannot be closed on android. I found out that you can't close CustomTabs on android. After searching for a while, I found out an optional workaround for that problem (based on an this answer on StackOverflow: https://stackoverflow.com/a/41596629/5976838).
The workaround works perfectly for me so I uploaded it here.