### PR TITLE
fix(share): share iOS images as UIImages

### DIFF
--- a/share/ios/Plugin/SharePlugin.swift
+++ b/share/ios/Plugin/SharePlugin.swift
@@ -12,7 +12,11 @@ public class SharePlugin: CAPPlugin {
         }
 
         if let url = call.getString("url"), let urlObj = URL(string: url) {
-            items.append(urlObj)
+            if let imageData = try? Data(contentsOf: urlObj), let image = UIImage(data: imageData) {
+                items.append(image)
+            } else {
+                items.append(urlObj)
+            }
         }
 
         let title = call.getString("title")


### PR DESCRIPTION
At the moment share plugin shares images as urls and some apps are not able to share them properly or don't appear at all like instagram.

This PR try to convert the url to UIImage and if possible share it, otherwise it shares the url as before

closes #156