### PR TITLE
fix(camera): query IMAGE_CAPTURE intent required by SDK 30

### DIFF
--- a/camera/android/src/main/AndroidManifest.xml
+++ b/camera/android/src/main/AndroidManifest.xml
@@ -1,3 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.capacitorjs.plugins.camera">
+    <queries>
+        <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
When targeting SDK 30, users need to add the intents their app launch in their manifest the intents their app launches.

We can document it and make users do it, or we can put the queries on the plugin's `AndroidManifest.xml` for them as manifest merger will put it in the app's `AndroidManifest.xml` manifest too.

I went with the second approach because I think if users installed the plugin they will need this and they can miss it on the docs, so not having to manually add it is a better user experience.