### PR TITLE
fix(camera): return file URL for path, not system path

### DIFF
--- a/camera/ios/Plugin/CameraPlugin.swift
+++ b/camera/ios/Plugin/CameraPlugin.swift
@@ -211,7 +211,7 @@ private extension CameraPlugin {
                 return
             }
             call?.resolve([
-                "path": fileURL.path,
+                "path": fileURL.absoluteString,
                 "exif": processedImage.exifData,
                 "webPath": webURL.path,
                 "format": "jpeg"


### PR DESCRIPTION
Capacitor 2 used a file:// URL for the path to the photo (https://github.com/ionic-team/capacitor/blob/2.x/ios/Capacitor/Capacitor/Plugins/Camera.swift#L390). It looks like this was changed during a refactor. This PR returns the `absoluteString` which includes the file protocol to avoid a breaking change in the camera plugin when people update from v2 to v3. 

