### PR TITLE
Support splash screen background color for dark mode.

### DIFF
--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
@@ -4,6 +4,7 @@ import android.animation.Animator;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.Resources;
+import android.content.res.Configuration;
 import android.graphics.PixelFormat;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
@@ -130,8 +131,19 @@ public class SplashScreen {
             // https://stackoverflow.com/a/21847579/32140
             splashImage.setDrawingCacheEnabled(true);
 
-            if (config.getBackgroundColor() != null) {
-                splashImage.setBackgroundColor(config.getBackgroundColor());
+            int currentNightMode = context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+
+            switch (currentNightMode) {
+                case Configuration.UI_MODE_NIGHT_NO:
+                    if(config.getBackgroundColor() != null){
+                        splashImage.setBackgroundColor(config.getBackgroundColor());
+                    }
+                    break;
+                case Configuration.UI_MODE_NIGHT_YES:
+                    if(config.getBackgroundColorDarkMode() != null){
+                        splashImage.setBackgroundColor(config.getBackgroundColorDarkMode());
+                    }
+                break;
             }
 
             splashImage.setScaleType(config.getScaleType());

--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenConfig.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenConfig.java
@@ -5,6 +5,7 @@ import android.widget.ImageView.ScaleType;
 public class SplashScreenConfig {
 
     private Integer backgroundColor;
+    private Integer backgroundColorDarkMode;
     private Integer spinnerStyle;
     private Integer spinnerColor;
     private boolean showSpinner = false;
@@ -22,6 +23,14 @@ public class SplashScreenConfig {
 
     public void setBackgroundColor(Integer backgroundColor) {
         this.backgroundColor = backgroundColor;
+    }
+        
+    public Integer getBackgroundColorDarkMode() {
+        return backgroundColorDarkMode;
+    }
+
+    public void setBackgroundColorDarkMode(Integer backgroundColorDarkMode) {
+        this.backgroundColorDarkMode = backgroundColorDarkMode;
     }
 
     public Integer getSpinnerStyle() {

--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
@@ -81,6 +81,14 @@ public class SplashScreenPlugin extends Plugin {
                 Logger.debug("Background color not applied");
             }
         }
+        String backgroundColorDarkMode = getConfig().getString("backgroundColorDarkMode");
+        if (backgroundColorDarkMode != null) {
+            try {
+                config.setBackgroundColorDarkMode(WebColor.parseColor(backgroundColorDarkMode));
+            } catch (IllegalArgumentException ex) {
+                Logger.debug("Dark mode background color not applied");
+            }
+        }
         Integer duration = getConfig().getInt("launchShowDuration", config.getLaunchShowDuration());
         config.setLaunchShowDuration(duration);
         Boolean autohide = getConfig().getBoolean("launchAutoHide", config.isLaunchAutoHide());

--- a/splash-screen/src/definitions.ts
+++ b/splash-screen/src/definitions.ts
@@ -26,6 +26,16 @@ declare module '@capacitor/cli' {
        */
       backgroundColor?: string;
 
+            
+      /**
+       * Color of the background of the Splash Screen in hex format, #RRGGBB or #RRGGBBAA (Works only in the dark mode)
+       * 
+       * Only available on Android
+       *
+       * @since 3.0.0
+       */
+      backgroundColorDarkMode?: string;
+
       /**
        * Name of the resource to be used as Splash Screen
        *


### PR DESCRIPTION
I've added a new `backgroundColorDarkMode` value to allow you to edit the splash screen background color with dark mode enabled on your device. With the changes below you will be able to edit the background color directly from the `capacitor.config.json` file, for example:

```
{
  "appId": "someID",
  "appName": "some name",
  "bundledWebRuntime": false,
  "npmClient": "npm",
  "webDir": "www",
  "cordova": {},
  "plugins": {
    "SplashScreen": {
      "backgroundColor": "#ffffff",
      "backgroundColorDarkMode": "#000000"
    }
  }
}
```