### PR TITLE
feat(push-notifications): Add USE_PUSH compilation condition

### DIFF
--- a/push-notifications/CapacitorPushNotifications.podspec
+++ b/push-notifications/CapacitorPushNotifications.podspec
@@ -15,4 +15,7 @@ Pod::Spec.new do |s|
   s.dependency 'Capacitor'
   s.static_framework = true
   s.swift_version = '5.1'
+  s.user_target_xcconfig = {
+    'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'USE_PUSH'
+  }
 end


### PR DESCRIPTION
in conjunction with https://github.com/ionic-team/capacitor/pull/4068, adds `USE_PUSH` compilation condition so the `AppDelegate.swift` push code is executed when the plugin is installed.