### PR TITLE
fix: normalize use of integers for notification IDs

### DIFF
--- a/local-notifications/README.md
+++ b/local-notifications/README.md
@@ -273,7 +273,7 @@ The object that describes a local notification.
 
 | Prop     | Type                | Description                  | Since |
 | -------- | ------------------- | ---------------------------- | ----- |
-| **`id`** | <code>string</code> | The notification identifier. | 1.0.0 |
+| **`id`** | <code>number</code> | The notification identifier. | 1.0.0 |
 
 
 #### ScheduleOptions

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotification.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotification.java
@@ -252,7 +252,12 @@ public class LocalNotification {
         JSArray jsArray = new JSArray();
         for (String id : ids) {
             JSObject notification = new JSObject();
-            notification.put("id", id);
+            try {
+                int intId = Integer.parseInt(id);
+                notification.put("id", intId);
+            } catch (NumberFormatException ex) {
+                notification.put("id", -1);
+            }
             jsArray.put(notification);
         }
         result.put("notifications", jsArray);

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
@@ -63,7 +63,7 @@ public class LocalNotificationsPlugin extends Plugin {
             JSArray jsArray = new JSArray();
             for (int i = 0; i < ids.length(); i++) {
                 try {
-                    JSObject notification = new JSObject().put("id", ids.getString(i));
+                    JSObject notification = new JSObject().put("id", ids.getInt(i));
                     jsArray.put(notification);
                 } catch (Exception ex) {}
             }

--- a/local-notifications/ios/Plugin/LocalNotificationsHandler.swift
+++ b/local-notifications/ios/Plugin/LocalNotificationsHandler.swift
@@ -75,7 +75,7 @@ public class LocalNotificationsHandler: NSObject, NotificationHandlerProtocol {
     func makeNotificationRequestJSObject(_ request: UNNotificationRequest) -> JSObject {
         let notificationRequest = notificationRequestLookup[request.identifier] ?? [:]
         return [
-            "id": request.identifier,
+            "id": Int(request.identifier) ?? -1,
             "title": request.content.title,
             "sound": notificationRequest["sound"]  ?? "",
             "body": request.content.body,

--- a/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
+++ b/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
@@ -88,7 +88,7 @@ public class LocalNotificationsPlugin: CAPPlugin {
 
         let ret = ids.map({ (id) -> JSObject in
             return [
-                "id": id
+                "id": Int(id) ?? -1
             ]
         })
         call.resolve([

--- a/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
+++ b/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
@@ -137,7 +137,14 @@ public class LocalNotificationsPlugin: CAPPlugin {
             return
         }
 
-        let ids = notifications.map { $0["id"] as? String ?? "" }
+        let ids = notifications.map({ (value: JSObject) -> String in
+            if let idString = value["id"] as? String {
+                return idString
+            } else if let idNum = value["id"] as? NSNumber {
+                return idNum.stringValue
+            }
+            return ""
+        })
 
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ids)
         call.resolve()

--- a/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
+++ b/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
@@ -43,15 +43,7 @@ public class LocalNotificationsPlugin: CAPPlugin {
         var ids = [String]()
 
         for notification in notifications {
-            var identifierValue = notification["id"] as? Int
-
-            if identifierValue == nil {
-                if let identifierString = notification["id"] as? String {
-                    identifierValue = Int(identifierString)
-                }
-            }
-
-            guard let identifier = identifierValue else {
+            guard let identifier = notification["id"] as? Int else {
                 call.reject("Notification missing identifier")
                 return
             }
@@ -549,7 +541,7 @@ public class LocalNotificationsPlugin: CAPPlugin {
 
     func makePendingNotificationRequestJSObject(_ request: UNNotificationRequest) -> JSObject {
         return [
-            "id": request.identifier
+            "id": Int(request.identifier) ?? -1
         ]
     }
 

--- a/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
+++ b/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
@@ -43,7 +43,15 @@ public class LocalNotificationsPlugin: CAPPlugin {
         var ids = [String]()
 
         for notification in notifications {
-            guard let identifier = notification["id"] as? Int else {
+            var identifierValue = notification["id"] as? Int
+
+            if identifierValue == nil {
+                if let identifierString = notification["id"] as? String {
+                    identifierValue = Int(identifierString)
+                }
+            }
+
+            guard let identifier = identifierValue else {
                 call.reject("Notification missing identifier")
                 return
             }

--- a/local-notifications/src/definitions.ts
+++ b/local-notifications/src/definitions.ts
@@ -162,7 +162,7 @@ export interface LocalNotificationDescriptor {
    *
    * @since 1.0.0
    */
-  id: number | string;
+  id: number;
 }
 
 export interface ScheduleOptions {
@@ -462,7 +462,7 @@ export interface LocalNotificationSchema {
    *
    * @since 1.0.0
    */
-  id: number | string;
+  id: number;
 
   /**
    * Schedule this notification for a later time.

--- a/local-notifications/src/definitions.ts
+++ b/local-notifications/src/definitions.ts
@@ -162,7 +162,7 @@ export interface LocalNotificationDescriptor {
    *
    * @since 1.0.0
    */
-  id: string;
+  id: number | string;
 }
 
 export interface ScheduleOptions {
@@ -462,7 +462,7 @@ export interface LocalNotificationSchema {
    *
    * @since 1.0.0
    */
-  id: number;
+  id: number | string;
 
   /**
    * Schedule this notification for a later time.

--- a/local-notifications/src/web.ts
+++ b/local-notifications/src/web.ts
@@ -35,7 +35,7 @@ export class LocalNotificationsWeb
 
     return {
       notifications: options.notifications.map(notification => ({
-        id: notification.id.toString(),
+        id: notification.id,
       })),
     };
   }
@@ -43,7 +43,7 @@ export class LocalNotificationsWeb
   async getPending(): Promise<ScheduleResult> {
     return {
       notifications: this.pending.map(notification => ({
-        id: notification.id.toString(),
+        id: notification.id,
       })),
     };
   }
@@ -55,7 +55,7 @@ export class LocalNotificationsWeb
   async cancel(pending: ScheduleResult): Promise<void> {
     this.pending = this.pending.filter(
       notification =>
-        !pending.notifications.find(n => n.id === notification.id.toString()),
+        !pending.notifications.find(n => n.id === notification.id),
     );
   }
 


### PR DESCRIPTION
Scheduling a notification takes an integer ID, yet canceling a notification expects a string (and will do nothing if a integer is sent).
This PR brings consistency to the schedule and cancel methods, now requiring an integer ids for both operations.

closes https://github.com/ionic-team/capacitor-plugins/issues/176