### PR TITLE
chore(push-notifications): Remove s.static_framework = true from podspec

### DIFF
--- a/push-notifications/CapacitorPushNotifications.podspec
+++ b/push-notifications/CapacitorPushNotifications.podspec
@@ -13,6 +13,5 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '12.0'
   s.dependency 'Capacitor'
-  s.static_framework = true
   s.swift_version = '5.1'
 end


### PR DESCRIPTION
It was probably added because of the firebase dependency, but since it was removed, this is no longer needed.
