### PR TITLE
docs(android): document plugin variables

### DIFF
--- a/action-sheet/README.md
+++ b/action-sheet/README.md
@@ -9,6 +9,12 @@ npm install @capacitor/action-sheet
 npx cap sync
 ```
 
+### Variables
+
+This plugin will use the following project variables (defined in your app's `variables.gradle` file):
+
+- `$androidxMaterialVersion`: version of `com.google.android.material:material` (default: `1.3.0-rc01`)
+
 ## Example
 
 ```typescript

--- a/browser/README.md
+++ b/browser/README.md
@@ -17,7 +17,7 @@ npx cap sync
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-- `androidxBrowserVersion` (version of `androidx.browser:browser` to use)
+- `$androidxBrowserVersion`: version of `androidx.browser:browser` (default: `1.3.0`)
 
 ## Example
 

--- a/browser/README.md
+++ b/browser/README.md
@@ -11,6 +11,14 @@ npm install @capacitor/browser
 npx cap sync
 ```
 
+## Android
+
+### Variables
+
+This plugin will use the following project variables (defined in your app's `variables.gradle` file):
+
+- `androidxBrowserVersion` (version of `androidx.browser:browser` to use)
+
 ## Example
 
 ```typescript

--- a/camera/README.md
+++ b/camera/README.md
@@ -9,7 +9,7 @@ npm install @capacitor/camera
 npx cap sync
 ```
 
-## iOS Notes
+## iOS
 
 iOS requires the following usage description be added and filled out for your app in `Info.plist`:
 
@@ -19,7 +19,7 @@ iOS requires the following usage description be added and filled out for your ap
 
 Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode
 
-## Android Notes
+## Android
 
 This API requires the following permissions be added to your `AndroidManifest.xml`:
 
@@ -33,6 +33,12 @@ The storage permissions are for reading/saving photo files.
 Read about [Setting Permissions](https://capacitorjs.com/docs/android/configuration#setting-permissions) in the [Android Guide](https://capacitorjs.com/docs/android) for more information on setting Android permissions.
 
 Additionally, because the Camera API launches a separate Activity to handle taking the photo, you should listen for `appRestoredResult` in the `App` plugin to handle any camera data that was sent in the case your app was terminated by the operating system while the Activity was running.
+
+### Variables
+
+This plugin will use the following project variables (defined in your app's `variables.gradle` file):
+
+- `androidxExifInterfaceVersion` (version of `androidx.exifinterface:exifinterface` to use)
 
 ## PWA Notes
 

--- a/camera/README.md
+++ b/camera/README.md
@@ -39,6 +39,7 @@ Additionally, because the Camera API launches a separate Activity to handle taki
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
 - `$androidxExifInterfaceVersion`: version of `androidx.exifinterface:exifinterface` (default: `1.3.2`)
+- `$androidxMaterialVersion`: version of `com.google.android.material:material` (default: `1.3.0-rc01`)
 
 ## PWA Notes
 

--- a/camera/README.md
+++ b/camera/README.md
@@ -38,7 +38,7 @@ Additionally, because the Camera API launches a separate Activity to handle taki
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-- `androidxExifInterfaceVersion` (version of `androidx.exifinterface:exifinterface` to use)
+- `$androidxExifInterfaceVersion`: version of `androidx.exifinterface:exifinterface` (default: `1.3.2`)
 
 ## PWA Notes
 

--- a/geolocation/README.md
+++ b/geolocation/README.md
@@ -9,7 +9,7 @@ npm install @capacitor/geolocation
 npx cap sync
 ```
 
-## iOS Notes
+## iOS
 
 Apple requires privacy descriptions to be specified in `Info.plist` for location information:
 
@@ -18,7 +18,7 @@ Apple requires privacy descriptions to be specified in `Info.plist` for location
 
 Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode
 
-## Android Notes
+## Android
 
 This API requires the following permissions be added to your `AndroidManifest.xml`:
 
@@ -32,6 +32,12 @@ This API requires the following permissions be added to your `AndroidManifest.xm
 The first two permissions ask for location data, both fine and coarse, and the last line is optional but necessary if your app _requires_ GPS to function. You may leave it out, though keep in mind that this may mean your app is installed on devices lacking GPS hardware.
 
 Read about [Setting Permissions](https://capacitorjs.com/docs/android/configuration#setting-permissions) in the [Android Guide](https://capacitorjs.com/docs/android) for more information on setting Android permissions.
+
+### Variables
+
+This plugin will use the following project variables (defined in your app's `variables.gradle` file):
+
+- `playServicesLocationVersion` (version of `com.google.android.gms:play-services-location` to use)
 
 ## Example
 

--- a/geolocation/README.md
+++ b/geolocation/README.md
@@ -37,7 +37,7 @@ Read about [Setting Permissions](https://capacitorjs.com/docs/android/configurat
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-- `playServicesLocationVersion` (version of `com.google.android.gms:play-services-location` to use)
+- `$playServicesLocationVersion` version of `com.google.android.gms:play-services-location` (default: `17.1.0`)
 
 ## Example
 

--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -31,6 +31,12 @@ func application(_ application: UIApplication, didFailToRegisterForRemoteNotific
 
 The Push Notification API uses [Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging) SDK for handling notifications.  See [Set up a Firebase Cloud Messaging client app on Android](https://firebase.google.com/docs/cloud-messaging/android/client) and follow the instructions for creating a Firebase project and registering your application.  There is no need to add the Firebase SDK to your app or edit your app manifest - the Push Notifications provides that for you.  All that is required is your Firebase project's `google-services.json` file added to the module (app-level) directory of your app.
 
+### Variables
+
+This plugin will use the following project variables (defined in your app's `variables.gradle` file):
+
+- `firebaseMessagingVersion` (version of `com.google.firebase:firebase-messaging` to use)
+
 ---
 
 ## Push Notifications icon

--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -33,7 +33,7 @@ The Push Notification API uses [Firebase Cloud Messaging](https://firebase.googl
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-- `firebaseMessagingVersion` (version of `com.google.firebase:firebase-messaging` to use)
+- `$firebaseMessagingVersion` version of `com.google.firebase:firebase-messaging` (default: `21.0.1`)
 
 ---
 


### PR DESCRIPTION
I'm not sure if we should document ALL the plugin variables in EVERY plugin, or just the unique ones.