### PR TITLE
fix(ios): do not show notifications when in foreground

### DIFF
--- a/push-notifications/ios/Plugin/PushNotificationsHandler.swift
+++ b/push-notifications/ios/Plugin/PushNotificationsHandler.swift
@@ -49,7 +49,7 @@ public class PushNotificationsHandler: NSObject, NotificationHandlerProtocol {
             return presentationOptions
         }
 
-        return [.badge, .sound, .alert]
+        return []
     }
 
     public func didReceive(response: UNNotificationResponse) {


### PR DESCRIPTION
In Capacitor 2, push notifications where not shown when the app was in foreground (by default, but can be configured to show them)
This PR changes the behavior to do the same

closes https://github.com/ionic-team/capacitor-plugins/issues/208

