### PR TITLE
fix(local-notifications): Use the old event names

### DIFF
--- a/local-notifications/README.md
+++ b/local-notifications/README.md
@@ -23,8 +23,8 @@ npx cap sync
 * [`listChannels()`](#listchannels)
 * [`checkPermissions()`](#checkpermissions)
 * [`requestPermissions()`](#requestpermissions)
-* [`addListener('received', ...)`](#addlistenerreceived-)
-* [`addListener('actionPerformed', ...)`](#addlisteneractionperformed-)
+* [`addListener('localNotificationReceived', ...)`](#addlistenerlocalnotificationreceived-)
+* [`addListener('localNotificationActionPerformed', ...)`](#addlistenerlocalnotificationactionperformed-)
 * [`removeAllListeners()`](#removealllisteners)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
@@ -204,17 +204,17 @@ Request permission to display local notifications.
 --------------------
 
 
-### addListener('received', ...)
+### addListener('localNotificationReceived', ...)
 
 ```typescript
-addListener(eventName: 'received', listenerFunc: (notification: LocalNotificationSchema) => void) => PluginListenerHandle
+addListener(eventName: 'localNotificationReceived', listenerFunc: (notification: LocalNotificationSchema) => void) => PluginListenerHandle
 ```
 
 Listen for when notifications are displayed.
 
 | Param              | Type                                                                                                   |
 | ------------------ | ------------------------------------------------------------------------------------------------------ |
-| **`eventName`**    | <code>'received'</code>                                                                                |
+| **`eventName`**    | <code>'localNotificationReceived'</code>                                                               |
 | **`listenerFunc`** | <code>(notification: <a href="#localnotificationschema">LocalNotificationSchema</a>) =&gt; void</code> |
 
 **Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
@@ -224,17 +224,17 @@ Listen for when notifications are displayed.
 --------------------
 
 
-### addListener('actionPerformed', ...)
+### addListener('localNotificationActionPerformed', ...)
 
 ```typescript
-addListener(eventName: 'actionPerformed', listenerFunc: (notificationAction: ActionPerformed) => void) => PluginListenerHandle
+addListener(eventName: 'localNotificationActionPerformed', listenerFunc: (notificationAction: ActionPerformed) => void) => PluginListenerHandle
 ```
 
 Listen for when an action is performed on a notification.
 
 | Param              | Type                                                                                         |
 | ------------------ | -------------------------------------------------------------------------------------------- |
-| **`eventName`**    | <code>'actionPerformed'</code>                                                               |
+| **`eventName`**    | <code>'localNotificationActionPerformed'</code>                                              |
 | **`listenerFunc`** | <code>(notificationAction: <a href="#actionperformed">ActionPerformed</a>) =&gt; void</code> |
 
 **Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
@@ -36,7 +36,7 @@ public class LocalNotificationsPlugin extends Plugin {
         }
         JSObject dataJson = manager.handleNotificationActionPerformed(data, notificationStorage);
         if (dataJson != null) {
-            notifyListeners("actionPerformed", dataJson, true);
+            notifyListeners("localNotificationActionPerformed", dataJson, true);
         }
     }
 

--- a/local-notifications/ios/Plugin/LocalNotificationsHandler.swift
+++ b/local-notifications/ios/Plugin/LocalNotificationsHandler.swift
@@ -26,7 +26,7 @@ public class LocalNotificationsHandler: NSObject, NotificationHandlerProtocol {
     public func willPresent(notification: UNNotification) -> UNNotificationPresentationOptions {
         let notificationData = makeNotificationRequestJSObject(notification.request)
 
-        self.plugin?.notifyListeners("received", data: notificationData)
+        self.plugin?.notifyListeners("localNotificationReceived", data: notificationData)
 
         if let options = notificationRequestLookup[notification.request.identifier] {
             let silent = options["silent"] as? Bool ?? false
@@ -66,7 +66,7 @@ public class LocalNotificationsHandler: NSObject, NotificationHandlerProtocol {
 
         data["notification"] = makeNotificationRequestJSObject(originalNotificationRequest)
 
-        self.plugin?.notifyListeners("actionPerformed", data: data, retainUntilConsumed: true)
+        self.plugin?.notifyListeners("localNotificationActionPerformed", data: data, retainUntilConsumed: true)
     }
 
     /**

--- a/local-notifications/src/definitions.ts
+++ b/local-notifications/src/definitions.ts
@@ -129,7 +129,7 @@ export interface LocalNotificationsPlugin {
    * @since 1.0.0
    */
   addListener(
-    eventName: 'received',
+    eventName: 'localNotificationReceived',
     listenerFunc: (notification: LocalNotificationSchema) => void,
   ): PluginListenerHandle;
 
@@ -139,7 +139,7 @@ export interface LocalNotificationsPlugin {
    * @since 1.0.0
    */
   addListener(
-    eventName: 'actionPerformed',
+    eventName: 'localNotificationActionPerformed',
     listenerFunc: (notificationAction: ActionPerformed) => void,
   ): PluginListenerHandle;
 


### PR DESCRIPTION
`localNotificationActionPerformed` was renamed to `actionPerformed` and `localNotificationReceived` to `received`, but old names weren't deprecated, nor fired anymore, nor documented as breaking change, so this PR brings the old names back.
