### PR TITLE
refactor: make all plugin methods asynchronous

### DIFF
--- a/action-sheet/package.json
+++ b/action-sheet/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/app-launcher/package.json
+++ b/app-launcher/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/app/README.md
+++ b/app/README.md
@@ -120,7 +120,7 @@ Get the URL the app was launched with, if any.
 ### addListener('appStateChange', ...)
 
 ```typescript
-addListener(eventName: 'appStateChange', listenerFunc: StateChangeListener) => PluginListenerHandle
+addListener(eventName: 'appStateChange', listenerFunc: StateChangeListener) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Listen for changes in the App's active state (whether the app is in the foreground or background)
@@ -130,7 +130,7 @@ Listen for changes in the App's active state (whether the app is in the foregrou
 | **`eventName`**    | <code>'appStateChange'</code>                                       |
 | **`listenerFunc`** | <code><a href="#statechangelistener">StateChangeListener</a></code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -140,7 +140,7 @@ Listen for changes in the App's active state (whether the app is in the foregrou
 ### addListener('appUrlOpen', ...)
 
 ```typescript
-addListener(eventName: 'appUrlOpen', listenerFunc: URLOpenListener) => PluginListenerHandle
+addListener(eventName: 'appUrlOpen', listenerFunc: URLOpenListener) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Listen for url open events for the app. This handles both custom URL scheme links as well
@@ -151,7 +151,7 @@ as URLs your app handles (Universal Links on iOS and App Links on Android)
 | **`eventName`**    | <code>'appUrlOpen'</code>                                   |
 | **`listenerFunc`** | <code><a href="#urlopenlistener">URLOpenListener</a></code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -161,7 +161,7 @@ as URLs your app handles (Universal Links on iOS and App Links on Android)
 ### addListener('appRestoredResult', ...)
 
 ```typescript
-addListener(eventName: 'appRestoredResult', listenerFunc: RestoredListener) => PluginListenerHandle
+addListener(eventName: 'appRestoredResult', listenerFunc: RestoredListener) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 If the app was launched with previously persisted plugin call data, such as on Android
@@ -191,7 +191,7 @@ Activities (for example, Camera) to have this event and process handled.
 | **`eventName`**    | <code>'appRestoredResult'</code>                              |
 | **`listenerFunc`** | <code><a href="#restoredlistener">RestoredListener</a></code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -201,7 +201,7 @@ Activities (for example, Camera) to have this event and process handled.
 ### addListener('backButton', ...)
 
 ```typescript
-addListener(eventName: 'backButton', listenerFunc: BackButtonListener) => PluginListenerHandle
+addListener(eventName: 'backButton', listenerFunc: BackButtonListener) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Listen for the hardware back button event (Android only). Listening for this event will disable the
@@ -213,7 +213,7 @@ If you want to close the app, call `App.exitApp()`.
 | **`eventName`**    | <code>'backButton'</code>                                         |
 | **`listenerFunc`** | <code><a href="#backbuttonlistener">BackButtonListener</a></code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -223,7 +223,7 @@ If you want to close the app, call `App.exitApp()`.
 ### removeAllListeners()
 
 ```typescript
-removeAllListeners() => void
+removeAllListeners() => Promise<void>
 ```
 
 Remove all native listeners for this plugin
@@ -262,9 +262,9 @@ Remove all native listeners for this plugin
 
 #### PluginListenerHandle
 
-| Prop         | Type                       |
-| ------------ | -------------------------- |
-| **`remove`** | <code>() =&gt; void</code> |
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
 
 
 #### URLOpenListenerEvent

--- a/app/package.json
+++ b/app/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/app/src/definitions.ts
+++ b/app/src/definitions.ts
@@ -160,7 +160,7 @@ export interface AppPlugin {
   addListener(
     eventName: 'appStateChange',
     listenerFunc: StateChangeListener,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Listen for url open events for the app. This handles both custom URL scheme links as well
@@ -171,7 +171,7 @@ export interface AppPlugin {
   addListener(
     eventName: 'appUrlOpen',
     listenerFunc: URLOpenListener,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * If the app was launched with previously persisted plugin call data, such as on Android
@@ -201,7 +201,7 @@ export interface AppPlugin {
   addListener(
     eventName: 'appRestoredResult',
     listenerFunc: RestoredListener,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Listen for the hardware back button event (Android only). Listening for this event will disable the
@@ -213,14 +213,14 @@ export interface AppPlugin {
   addListener(
     eventName: 'backButton',
     listenerFunc: BackButtonListener,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Remove all native listeners for this plugin
    *
    * @since 1.0.0
    */
-  removeAllListeners(): void;
+  removeAllListeners(): Promise<void>;
 }
 
 /**

--- a/app/src/web.ts
+++ b/app/src/web.ts
@@ -5,13 +5,11 @@ import type { AppInfo, AppPlugin, AppLaunchUrl, AppState } from './definitions';
 export class AppWeb extends WebPlugin implements AppPlugin {
   constructor() {
     super();
-    if (typeof document !== 'undefined') {
-      document.addEventListener(
-        'visibilitychange',
-        this.handleVisibilityChange.bind(this),
-        false,
-      );
-    }
+    document.addEventListener(
+      'visibilitychange',
+      this.handleVisibilityChange,
+      false,
+    );
   }
 
   exitApp(): never {
@@ -30,11 +28,11 @@ export class AppWeb extends WebPlugin implements AppPlugin {
     return { isActive: document.hidden !== true };
   }
 
-  handleVisibilityChange(): void {
+  private handleVisibilityChange = () => {
     const data = {
       isActive: document.hidden !== true,
     };
 
     this.notifyListeners('appStateChange', data);
-  }
+  };
 }

--- a/browser/README.md
+++ b/browser/README.md
@@ -80,7 +80,7 @@ No-op on other platforms.
 ### addListener('browserFinished', ...)
 
 ```typescript
-addListener(eventName: 'browserFinished', listenerFunc: () => void) => PluginListenerHandle
+addListener(eventName: 'browserFinished', listenerFunc: () => void) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Android & iOS only: Listen for the loading finished event.
@@ -90,7 +90,7 @@ Android & iOS only: Listen for the loading finished event.
 | **`eventName`**    | <code>'browserFinished'</code> |
 | **`listenerFunc`** | <code>() =&gt; void</code>     |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -100,7 +100,7 @@ Android & iOS only: Listen for the loading finished event.
 ### addListener('browserPageLoaded', ...)
 
 ```typescript
-addListener(eventName: 'browserPageLoaded', listenerFunc: () => void) => PluginListenerHandle
+addListener(eventName: 'browserPageLoaded', listenerFunc: () => void) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Android & iOS only: Listen for the page loaded event.
@@ -110,7 +110,7 @@ Android & iOS only: Listen for the page loaded event.
 | **`eventName`**    | <code>'browserPageLoaded'</code> |
 | **`listenerFunc`** | <code>() =&gt; void</code>       |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -120,7 +120,7 @@ Android & iOS only: Listen for the page loaded event.
 ### removeAllListeners()
 
 ```typescript
-removeAllListeners() => void
+removeAllListeners() => Promise<void>
 ```
 
 Remove all native listeners for this plugin.
@@ -147,8 +147,8 @@ Represents the options passed to `open`.
 
 #### PluginListenerHandle
 
-| Prop         | Type                       |
-| ------------ | -------------------------- |
-| **`remove`** | <code>() =&gt; void</code> |
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
 
 </docgen-api>

--- a/browser/package.json
+++ b/browser/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/browser/src/definitions.ts
+++ b/browser/src/definitions.ts
@@ -25,7 +25,7 @@ export interface BrowserPlugin {
   addListener(
     eventName: 'browserFinished',
     listenerFunc: () => void,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Android & iOS only: Listen for the page loaded event.
@@ -35,14 +35,14 @@ export interface BrowserPlugin {
   addListener(
     eventName: 'browserPageLoaded',
     listenerFunc: () => void,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Remove all native listeners for this plugin.
    *
    * @since 1.0.0
    */
-  removeAllListeners(): void;
+  removeAllListeners(): Promise<void>;
 }
 
 /**

--- a/camera/package.json
+++ b/camera/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/clipboard/package.json
+++ b/clipboard/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/device/package.json
+++ b/device/package.json
@@ -45,10 +45,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/dialog/package.json
+++ b/dialog/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/filesystem/package.json
+++ b/filesystem/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/geolocation/README.md
+++ b/geolocation/README.md
@@ -90,7 +90,7 @@ Get the current GPS location of the device
 ### watchPosition(...)
 
 ```typescript
-watchPosition(options: PositionOptions, callback: WatchPositionCallback) => CallbackID
+watchPosition(options: PositionOptions, callback: WatchPositionCallback) => Promise<CallbackID>
 ```
 
 Set up a watch for location changes. Note that watching for location changes
@@ -101,7 +101,7 @@ can consume a large amount of energy. Be smart about listening only when you nee
 | **`options`**  | <code><a href="#positionoptions">PositionOptions</a></code>             |
 | **`callback`** | <code><a href="#watchpositioncallback">WatchPositionCallback</a></code> |
 
-**Returns:** <code>string</code>
+**Returns:** <code>Promise&lt;string&gt;</code>
 
 **Since:** 1.0.0
 

--- a/geolocation/package.json
+++ b/geolocation/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/geolocation/src/definitions.ts
+++ b/geolocation/src/definitions.ts
@@ -23,7 +23,7 @@ export interface GeolocationPlugin {
   watchPosition(
     options: PositionOptions,
     callback: WatchPositionCallback,
-  ): CallbackID;
+  ): Promise<CallbackID>;
 
   /**
    * Clear a given watch

--- a/geolocation/src/web.ts
+++ b/geolocation/src/web.ts
@@ -1,6 +1,7 @@
 import { WebPlugin } from '@capacitor/core';
 
 import type {
+  CallbackID,
   GeolocationPlugin,
   PermissionStatus,
   Position,
@@ -28,10 +29,10 @@ export class GeolocationWeb extends WebPlugin implements GeolocationPlugin {
     });
   }
 
-  watchPosition(
+  async watchPosition(
     options: PositionOptions,
     callback: WatchPositionCallback,
-  ): string {
+  ): Promise<CallbackID> {
     const id = navigator.geolocation.watchPosition(
       pos => {
         callback(pos);

--- a/haptics/package.json
+++ b/haptics/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/keyboard/README.md
+++ b/keyboard/README.md
@@ -195,7 +195,7 @@ This method is only supported on iOS.
 ### addListener('keyboardWillShow', ...)
 
 ```typescript
-addListener(eventName: 'keyboardWillShow', listenerFunc: (info: KeyboardInfo) => void) => PluginListenerHandle
+addListener(eventName: 'keyboardWillShow', listenerFunc: (info: KeyboardInfo) => void) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Listen for when the keyboard is about to be shown.
@@ -205,7 +205,7 @@ Listen for when the keyboard is about to be shown.
 | **`eventName`**    | <code>'keyboardWillShow'</code>                                          |
 | **`listenerFunc`** | <code>(info: <a href="#keyboardinfo">KeyboardInfo</a>) =&gt; void</code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -215,7 +215,7 @@ Listen for when the keyboard is about to be shown.
 ### addListener('keyboardDidShow', ...)
 
 ```typescript
-addListener(eventName: 'keyboardDidShow', listenerFunc: (info: KeyboardInfo) => void) => PluginListenerHandle
+addListener(eventName: 'keyboardDidShow', listenerFunc: (info: KeyboardInfo) => void) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Listen for when the keyboard is shown.
@@ -225,7 +225,7 @@ Listen for when the keyboard is shown.
 | **`eventName`**    | <code>'keyboardDidShow'</code>                                           |
 | **`listenerFunc`** | <code>(info: <a href="#keyboardinfo">KeyboardInfo</a>) =&gt; void</code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -235,7 +235,7 @@ Listen for when the keyboard is shown.
 ### addListener('keyboardWillHide', ...)
 
 ```typescript
-addListener(eventName: 'keyboardWillHide', listenerFunc: () => void) => PluginListenerHandle
+addListener(eventName: 'keyboardWillHide', listenerFunc: () => void) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Listen for when the keyboard is about to be hidden.
@@ -245,7 +245,7 @@ Listen for when the keyboard is about to be hidden.
 | **`eventName`**    | <code>'keyboardWillHide'</code> |
 | **`listenerFunc`** | <code>() =&gt; void</code>      |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -255,7 +255,7 @@ Listen for when the keyboard is about to be hidden.
 ### addListener('keyboardDidHide', ...)
 
 ```typescript
-addListener(eventName: 'keyboardDidHide', listenerFunc: () => void) => PluginListenerHandle
+addListener(eventName: 'keyboardDidHide', listenerFunc: () => void) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Listen for when the keyboard is hidden.
@@ -265,7 +265,7 @@ Listen for when the keyboard is hidden.
 | **`eventName`**    | <code>'keyboardDidHide'</code> |
 | **`listenerFunc`** | <code>() =&gt; void</code>     |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -275,7 +275,7 @@ Listen for when the keyboard is hidden.
 ### removeAllListeners()
 
 ```typescript
-removeAllListeners() => void
+removeAllListeners() => Promise<void>
 ```
 
 Remove all native listeners for this plugin.
@@ -304,9 +304,9 @@ Remove all native listeners for this plugin.
 
 #### PluginListenerHandle
 
-| Prop         | Type                       |
-| ------------ | -------------------------- |
-| **`remove`** | <code>() =&gt; void</code> |
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
 
 
 #### KeyboardInfo

--- a/keyboard/package.json
+++ b/keyboard/package.json
@@ -44,11 +44,11 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/cli": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/cli": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/keyboard/src/definitions.ts
+++ b/keyboard/src/definitions.ts
@@ -162,7 +162,7 @@ export interface KeyboardPlugin {
   addListener(
     eventName: 'keyboardWillShow',
     listenerFunc: (info: KeyboardInfo) => void,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Listen for when the keyboard is shown.
@@ -172,7 +172,7 @@ export interface KeyboardPlugin {
   addListener(
     eventName: 'keyboardDidShow',
     listenerFunc: (info: KeyboardInfo) => void,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Listen for when the keyboard is about to be hidden.
@@ -182,7 +182,7 @@ export interface KeyboardPlugin {
   addListener(
     eventName: 'keyboardWillHide',
     listenerFunc: () => void,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Listen for when the keyboard is hidden.
@@ -192,12 +192,12 @@ export interface KeyboardPlugin {
   addListener(
     eventName: 'keyboardDidHide',
     listenerFunc: () => void,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Remove all native listeners for this plugin.
    *
    * @since 1.0.0
    */
-  removeAllListeners(): void;
+  removeAllListeners(): Promise<void>;
 }

--- a/local-notifications/README.md
+++ b/local-notifications/README.md
@@ -207,7 +207,7 @@ Request permission to display local notifications.
 ### addListener('localNotificationReceived', ...)
 
 ```typescript
-addListener(eventName: 'localNotificationReceived', listenerFunc: (notification: LocalNotificationSchema) => void) => PluginListenerHandle
+addListener(eventName: 'localNotificationReceived', listenerFunc: (notification: LocalNotificationSchema) => void) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Listen for when notifications are displayed.
@@ -217,7 +217,7 @@ Listen for when notifications are displayed.
 | **`eventName`**    | <code>'localNotificationReceived'</code>                                                               |
 | **`listenerFunc`** | <code>(notification: <a href="#localnotificationschema">LocalNotificationSchema</a>) =&gt; void</code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -227,7 +227,7 @@ Listen for when notifications are displayed.
 ### addListener('localNotificationActionPerformed', ...)
 
 ```typescript
-addListener(eventName: 'localNotificationActionPerformed', listenerFunc: (notificationAction: ActionPerformed) => void) => PluginListenerHandle
+addListener(eventName: 'localNotificationActionPerformed', listenerFunc: (notificationAction: ActionPerformed) => void) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Listen for when an action is performed on a notification.
@@ -237,7 +237,7 @@ Listen for when an action is performed on a notification.
 | **`eventName`**    | <code>'localNotificationActionPerformed'</code>                                              |
 | **`listenerFunc`** | <code>(notificationAction: <a href="#actionperformed">ActionPerformed</a>) =&gt; void</code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -247,7 +247,7 @@ Listen for when an action is performed on a notification.
 ### removeAllListeners()
 
 ```typescript
-removeAllListeners() => void
+removeAllListeners() => Promise<void>
 ```
 
 Remove all listeners for this plugin.
@@ -494,9 +494,9 @@ An action that can be taken when a notification is displayed.
 
 #### PluginListenerHandle
 
-| Prop         | Type                       |
-| ------------ | -------------------------- |
-| **`remove`** | <code>() =&gt; void</code> |
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
 
 
 #### ActionPerformed

--- a/local-notifications/package.json
+++ b/local-notifications/package.json
@@ -44,11 +44,11 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/cli": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/cli": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/local-notifications/src/definitions.ts
+++ b/local-notifications/src/definitions.ts
@@ -131,7 +131,7 @@ export interface LocalNotificationsPlugin {
   addListener(
     eventName: 'localNotificationReceived',
     listenerFunc: (notification: LocalNotificationSchema) => void,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Listen for when an action is performed on a notification.
@@ -141,14 +141,14 @@ export interface LocalNotificationsPlugin {
   addListener(
     eventName: 'localNotificationActionPerformed',
     listenerFunc: (notificationAction: ActionPerformed) => void,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Remove all listeners for this plugin.
    *
    * @since 1.0.0
    */
-  removeAllListeners(): void;
+  removeAllListeners(): Promise<void>;
 }
 
 /**

--- a/motion/README.md
+++ b/motion/README.md
@@ -55,7 +55,7 @@ API to understand the data supplied in the 'accel' event.
 ### addListener('accel', ...)
 
 ```typescript
-addListener(eventName: 'accel', listenerFunc: AccelListener) => PluginListenerHandle
+addListener(eventName: 'accel', listenerFunc: AccelListener) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Add a listener for accelerometer data
@@ -65,7 +65,7 @@ Add a listener for accelerometer data
 | **`eventName`**    | <code>'accel'</code>                                    |
 | **`listenerFunc`** | <code><a href="#accellistener">AccelListener</a></code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -75,7 +75,7 @@ Add a listener for accelerometer data
 ### addListener('orientation', ...)
 
 ```typescript
-addListener(eventName: 'orientation', listenerFunc: OrientationListener) => PluginListenerHandle
+addListener(eventName: 'orientation', listenerFunc: OrientationListener) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Add a listener for device orientation change (compass heading, etc.)
@@ -85,7 +85,7 @@ Add a listener for device orientation change (compass heading, etc.)
 | **`eventName`**    | <code>'orientation'</code>                                          |
 | **`listenerFunc`** | <code><a href="#orientationlistener">OrientationListener</a></code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -95,7 +95,7 @@ Add a listener for device orientation change (compass heading, etc.)
 ### removeAllListeners()
 
 ```typescript
-removeAllListeners() => void
+removeAllListeners() => Promise<void>
 ```
 
 Remove all the listeners that are attached to this plugin.
@@ -110,9 +110,9 @@ Remove all the listeners that are attached to this plugin.
 
 #### PluginListenerHandle
 
-| Prop         | Type                       |
-| ------------ | -------------------------- |
-| **`remove`** | <code>() =&gt; void</code> |
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
 
 
 #### AccelListenerEvent

--- a/motion/package.json
+++ b/motion/package.json
@@ -39,10 +39,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "eslint": "^7.11.0",

--- a/motion/src/definitions.ts
+++ b/motion/src/definitions.ts
@@ -9,7 +9,7 @@ export interface MotionPlugin {
   addListener(
     eventName: 'accel',
     listenerFunc: AccelListener,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Add a listener for device orientation change (compass heading, etc.)
@@ -19,14 +19,14 @@ export interface MotionPlugin {
   addListener(
     eventName: 'orientation',
     listenerFunc: OrientationListener,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Remove all the listeners that are attached to this plugin.
    *
    * @since 1.0.0
    */
-  removeAllListeners(): void;
+  removeAllListeners(): Promise<void>;
 }
 
 export type AccelListener = (event: AccelListenerEvent) => void;

--- a/network/README.md
+++ b/network/README.md
@@ -58,7 +58,7 @@ Query the current status of the network connection.
 ### addListener('networkStatusChange', ...)
 
 ```typescript
-addListener(eventName: 'networkStatusChange', listenerFunc: ConnectionStatusChangeListener) => PluginListenerHandle
+addListener(eventName: 'networkStatusChange', listenerFunc: ConnectionStatusChangeListener) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Listen for changes in the network connection.
@@ -68,7 +68,7 @@ Listen for changes in the network connection.
 | **`eventName`**    | <code>'networkStatusChange'</code>                                                        |
 | **`listenerFunc`** | <code><a href="#connectionstatuschangelistener">ConnectionStatusChangeListener</a></code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -78,7 +78,7 @@ Listen for changes in the network connection.
 ### removeAllListeners()
 
 ```typescript
-removeAllListeners() => void
+removeAllListeners() => Promise<void>
 ```
 
 Remove all listeners (including the network status changes) for this plugin.
@@ -103,9 +103,9 @@ Represents the state and type of the network connection.
 
 #### PluginListenerHandle
 
-| Prop         | Type                       |
-| ------------ | -------------------------- |
-| **`remove`** | <code>() =&gt; void</code> |
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
 
 
 ### Type Aliases

--- a/network/package.json
+++ b/network/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/network/src/definitions.ts
+++ b/network/src/definitions.ts
@@ -16,14 +16,14 @@ export interface NetworkPlugin {
   addListener(
     eventName: 'networkStatusChange',
     listenerFunc: ConnectionStatusChangeListener,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Remove all listeners (including the network status changes) for this plugin.
    *
    * @since 1.0.0
    */
-  removeAllListeners(): void;
+  removeAllListeners(): Promise<void>;
 }
 
 /**

--- a/network/src/web.ts
+++ b/network/src/web.ts
@@ -1,8 +1,6 @@
-import type { PluginListenerHandle } from '@capacitor/core';
 import { WebPlugin } from '@capacitor/core';
 
 import type {
-  ConnectionStatusChangeListener,
   ConnectionStatus,
   ConnectionType,
   NetworkPlugin,
@@ -59,6 +57,12 @@ function translatedConnection(): ConnectionType {
 }
 
 export class NetworkWeb extends WebPlugin implements NetworkPlugin {
+  constructor() {
+    super();
+    window.addEventListener('online', this.handleOnline);
+    window.addEventListener('offline', this.handleOffline);
+  }
+
   async getStatus(): Promise<ConnectionStatus> {
     if (!window.navigator) {
       throw this.unavailable(
@@ -70,46 +74,32 @@ export class NetworkWeb extends WebPlugin implements NetworkPlugin {
     const connectionType = translatedConnection();
 
     const status: ConnectionStatus = {
-      connected: connected,
+      connected,
       connectionType: connected ? connectionType : 'none',
     };
 
     return status;
   }
 
-  addListener(
-    eventName: 'networkStatusChange',
-    listenerFunc: ConnectionStatusChangeListener,
-  ): PluginListenerHandle {
-    const thisRef = this;
+  handleOnline = () => {
     const connectionType = translatedConnection();
 
-    const onlineBindFunc = listenerFunc.bind(thisRef, {
+    const status: ConnectionStatus = {
       connected: true,
       connectionType: connectionType,
-    });
-    const offlineBindFunc = listenerFunc.bind(thisRef, {
+    };
+
+    this.notifyListeners('networkStatusChange', status);
+  };
+
+  handleOffline = () => {
+    const status: ConnectionStatus = {
       connected: false,
       connectionType: 'none',
-    });
+    };
 
-    if (eventName.localeCompare('networkStatusChange') === 0) {
-      window.addEventListener('online', onlineBindFunc);
-      window.addEventListener('offline', offlineBindFunc);
-      return {
-        remove: () => {
-          window.removeEventListener('online', onlineBindFunc);
-          window.removeEventListener('offline', offlineBindFunc);
-        },
-      };
-    } else {
-      return {
-        remove: () => {
-          /* do nothing */
-        },
-      };
-    }
-  }
+    this.notifyListeners('networkStatusChange', status);
+  };
 }
 
 const Network = new NetworkWeb();

--- a/network/src/web.ts
+++ b/network/src/web.ts
@@ -81,7 +81,7 @@ export class NetworkWeb extends WebPlugin implements NetworkPlugin {
     return status;
   }
 
-  handleOnline = () => {
+  private handleOnline = () => {
     const connectionType = translatedConnection();
 
     const status: ConnectionStatus = {
@@ -92,7 +92,7 @@ export class NetworkWeb extends WebPlugin implements NetworkPlugin {
     this.notifyListeners('networkStatusChange', status);
   };
 
-  handleOffline = () => {
+  private handleOffline = () => {
     const status: ConnectionStatus = {
       connected: false,
       connectionType: 'none',

--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -246,7 +246,7 @@ Request permission to receive push notifications.
 ### addListener('registration', ...)
 
 ```typescript
-addListener(eventName: 'registration', listenerFunc: (token: Token) => void) => PluginListenerHandle
+addListener(eventName: 'registration', listenerFunc: (token: Token) => void) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Called when the push notification registration finishes without problems.
@@ -258,7 +258,7 @@ Provides the push notification token.
 | **`eventName`**    | <code>'registration'</code>                                 |
 | **`listenerFunc`** | <code>(token: <a href="#token">Token</a>) =&gt; void</code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -268,7 +268,7 @@ Provides the push notification token.
 ### addListener('registrationError', ...)
 
 ```typescript
-addListener(eventName: 'registrationError', listenerFunc: (error: any) => void) => PluginListenerHandle
+addListener(eventName: 'registrationError', listenerFunc: (error: any) => void) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Called when the push notification registration finished with problems.
@@ -280,7 +280,7 @@ Provides an error with the registration problem.
 | **`eventName`**    | <code>'registrationError'</code>     |
 | **`listenerFunc`** | <code>(error: any) =&gt; void</code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -290,7 +290,7 @@ Provides an error with the registration problem.
 ### addListener('pushNotificationReceived', ...)
 
 ```typescript
-addListener(eventName: 'pushNotificationReceived', listenerFunc: (notification: PushNotificationSchema) => void) => PluginListenerHandle
+addListener(eventName: 'pushNotificationReceived', listenerFunc: (notification: PushNotificationSchema) => void) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Called when the device receives a push notification.
@@ -300,7 +300,7 @@ Called when the device receives a push notification.
 | **`eventName`**    | <code>'pushNotificationReceived'</code>                                                              |
 | **`listenerFunc`** | <code>(notification: <a href="#pushnotificationschema">PushNotificationSchema</a>) =&gt; void</code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -310,7 +310,7 @@ Called when the device receives a push notification.
 ### addListener('pushNotificationActionPerformed', ...)
 
 ```typescript
-addListener(eventName: 'pushNotificationActionPerformed', listenerFunc: (notification: ActionPerformed) => void) => PluginListenerHandle
+addListener(eventName: 'pushNotificationActionPerformed', listenerFunc: (notification: ActionPerformed) => void) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Called when an action is performed on a push notification.
@@ -320,7 +320,7 @@ Called when an action is performed on a push notification.
 | **`eventName`**    | <code>'pushNotificationActionPerformed'</code>                                         |
 | **`listenerFunc`** | <code>(notification: <a href="#actionperformed">ActionPerformed</a>) =&gt; void</code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -330,7 +330,7 @@ Called when an action is performed on a push notification.
 ### removeAllListeners()
 
 ```typescript
-removeAllListeners() => void
+removeAllListeners() => Promise<void>
 ```
 
 Remove all native listeners for this plugin.
@@ -398,9 +398,9 @@ Remove all native listeners for this plugin.
 
 #### PluginListenerHandle
 
-| Prop         | Type                       |
-| ------------ | -------------------------- |
-| **`remove`** | <code>() =&gt; void</code> |
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
 
 
 #### Token

--- a/push-notifications/package.json
+++ b/push-notifications/package.json
@@ -44,11 +44,11 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/cli": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/cli": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/push-notifications/src/definitions.ts
+++ b/push-notifications/src/definitions.ts
@@ -112,7 +112,7 @@ export interface PushNotificationsPlugin {
   addListener(
     eventName: 'registration',
     listenerFunc: (token: Token) => void,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Called when the push notification registration finished with problems.
@@ -124,7 +124,7 @@ export interface PushNotificationsPlugin {
   addListener(
     eventName: 'registrationError',
     listenerFunc: (error: any) => void,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Called when the device receives a push notification.
@@ -134,7 +134,7 @@ export interface PushNotificationsPlugin {
   addListener(
     eventName: 'pushNotificationReceived',
     listenerFunc: (notification: PushNotificationSchema) => void,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Called when an action is performed on a push notification.
@@ -144,14 +144,14 @@ export interface PushNotificationsPlugin {
   addListener(
     eventName: 'pushNotificationActionPerformed',
     listenerFunc: (notification: ActionPerformed) => void,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Remove all native listeners for this plugin.
    *
    * @since 1.0.0
    */
-  removeAllListeners(): void;
+  removeAllListeners(): Promise<void>;
 }
 
 export interface PushNotificationSchema {

--- a/screen-reader/README.md
+++ b/screen-reader/README.md
@@ -93,7 +93,7 @@ plugin](https://github.com/capacitor-community/text-to-speech).
 ### addListener('screenReaderStateChange', ...)
 
 ```typescript
-addListener(eventName: 'screenReaderStateChange', listener: StateChangeListener) => PluginListenerHandle
+addListener(eventName: 'screenReaderStateChange', listener: StateChangeListener) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Add a listener
@@ -106,7 +106,7 @@ Readers).
 | **`eventName`** | <code>'screenReaderStateChange'</code>                              |
 | **`listener`**  | <code><a href="#statechangelistener">StateChangeListener</a></code> |
 
-**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 1.0.0
 
@@ -116,7 +116,7 @@ Readers).
 ### removeAllListeners()
 
 ```typescript
-removeAllListeners() => void
+removeAllListeners() => Promise<void>
 ```
 
 Remove all the listeners that are attached to this plugin.
@@ -139,9 +139,9 @@ Remove all the listeners that are attached to this plugin.
 
 #### PluginListenerHandle
 
-| Prop         | Type                       |
-| ------------ | -------------------------- |
-| **`remove`** | <code>() =&gt; void</code> |
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
 
 
 #### ScreenReaderState

--- a/screen-reader/package.json
+++ b/screen-reader/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/screen-reader/src/definitions.ts
+++ b/screen-reader/src/definitions.ts
@@ -69,14 +69,14 @@ export interface ScreenReaderPlugin {
   addListener(
     eventName: 'screenReaderStateChange',
     listener: StateChangeListener,
-  ): PluginListenerHandle;
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
    * Remove all the listeners that are attached to this plugin.
    *
    * @since 1.0.0
    */
-  removeAllListeners(): void;
+  removeAllListeners(): Promise<void>;
 }
 
 /**

--- a/share/package.json
+++ b/share/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/splash-screen/package.json
+++ b/splash-screen/package.json
@@ -44,11 +44,11 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/cli": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/cli": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/status-bar/package.json
+++ b/status-bar/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/storage/package.json
+++ b/storage/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/text-zoom/package.json
+++ b/text-zoom/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/toast/package.json
+++ b/toast/package.json
@@ -44,10 +44,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^3.0.0-beta.1",
-    "@capacitor/core": "^3.0.0-beta.1",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/core": "^3.0.0-beta.2",
     "@capacitor/docgen": "0.0.15",
-    "@capacitor/ios": "^3.0.0-beta.1",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",


### PR DESCRIPTION
- changes the definitions of `addListener()` and `removeAllListeners()` to be asynchronous
- changes the definition of `Geolocation.watchPosition()` to be asynchronous

see https://github.com/ionic-team/capacitor/pull/4128

📝 waiting on 3.0.0-beta.2