### PR TITLE
simplify code

### DIFF
--- a/local-notifications/README.md
+++ b/local-notifications/README.md
@@ -406,9 +406,9 @@ Represents a notification attachment.
 
 #### PendingResult
 
-| Prop                | Type                                       | Description                        | Since |
-| ------------------- | ------------------------------------------ | ---------------------------------- | ----- |
-| **`notifications`** | <code>LocalNotificationDescriptor[]</code> | The list of pending notifications. | 1.0.0 |
+| Prop                | Type                                   | Description                        | Since |
+| ------------------- | -------------------------------------- | ---------------------------------- | ----- |
+| **`notifications`** | <code>LocalNotificationSchema[]</code> | The list of pending notifications. | 1.0.0 |
 
 
 #### RegisterActionTypesOptions

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotification.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotification.java
@@ -247,13 +247,29 @@ public class LocalNotification {
         return notificationsList;
     }
 
-    public static JSObject buildLocalNotificationPendingList(List<String> ids) {
+    public static JSObject buildLocalNotificationPendingList(List<LocalNotification> notifications) {
         JSObject result = new JSObject();
         JSArray jsArray = new JSArray();
-        for (String id : ids) {
-            JSObject notification = new JSObject();
-            notification.put("id", id);
-            jsArray.put(notification);
+        for (LocalNotification notification : notifications) {
+            JSObject jsNotification = new JSObject();
+            jsNotification.put("id", notification.getId());
+            jsNotification.put("title", notification.getTitle());
+            jsNotification.put("body", notification.getBody());
+            LocalNotificationSchedule schedule = notification.getSchedule();
+            if (schedule != null) {
+                JSObject jsSchedule = new JSObject();
+                jsSchedule.put("at", schedule.getAt());
+                jsSchedule.put("every", schedule.getEvery());
+                jsSchedule.put("count", schedule.getCount());
+                jsSchedule.put("on", schedule.getOn());
+                jsNotification.put("schedule", jsSchedule);
+
+                jsNotification.put("repeats", schedule.isRepeating());
+            }
+
+            jsNotification.put("extra", notification.getExtra());
+
+            jsArray.put(jsNotification);
         }
         result.put("notifications", jsArray);
         return result;

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotification.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotification.java
@@ -262,9 +262,8 @@ public class LocalNotification {
                 jsSchedule.put("every", schedule.getEvery());
                 jsSchedule.put("count", schedule.getCount());
                 jsSchedule.put("on", schedule.getOn());
+                jsSchedule.put("repeats", schedule.isRepeating());
                 jsNotification.put("schedule", jsSchedule);
-
-                jsNotification.put("repeats", schedule.isRepeating());
             }
 
             jsNotification.put("extra", notification.getExtra());

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotification.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotification.java
@@ -247,33 +247,6 @@ public class LocalNotification {
         return notificationsList;
     }
 
-    public static JSObject buildLocalNotificationPendingList(List<LocalNotification> notifications) {
-        JSObject result = new JSObject();
-        JSArray jsArray = new JSArray();
-        for (LocalNotification notification : notifications) {
-            JSObject jsNotification = new JSObject();
-            jsNotification.put("id", notification.getId());
-            jsNotification.put("title", notification.getTitle());
-            jsNotification.put("body", notification.getBody());
-            LocalNotificationSchedule schedule = notification.getSchedule();
-            if (schedule != null) {
-                JSObject jsSchedule = new JSObject();
-                jsSchedule.put("at", schedule.getAt());
-                jsSchedule.put("every", schedule.getEvery());
-                jsSchedule.put("count", schedule.getCount());
-                jsSchedule.put("on", schedule.getOn());
-                jsSchedule.put("repeats", schedule.isRepeating());
-                jsNotification.put("schedule", jsSchedule);
-            }
-
-            jsNotification.put("extra", notification.getExtra());
-
-            jsArray.put(jsNotification);
-        }
-        result.put("notifications", jsArray);
-        return result;
-    }
-
     public int getSmallIcon(Context context, int defaultIcon) {
         int resId = AssetUtil.RESOURCE_ID_ZERO_VALUE;
 

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationSchedule.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationSchedule.java
@@ -37,6 +37,9 @@ public class LocalNotificationSchedule {
     private void buildEveryElement(JSObject schedule) {
         // 'year'|'month'|'two-weeks'|'week'|'day'|'hour'|'minute'|'second';
         this.every = schedule.getString("every");
+        if (this.every != null) {
+            this.repeats = true;
+        }
     }
 
     private void buildCountElement(JSObject schedule) {
@@ -44,9 +47,9 @@ public class LocalNotificationSchedule {
     }
 
     private void buildAtElement(JSObject schedule) throws ParseException {
-        this.repeats = schedule.getBool("repeats");
         String dateString = schedule.getString("at");
         if (dateString != null) {
+            this.repeats = schedule.getBool("repeats");
             SimpleDateFormat sdf = new SimpleDateFormat(JS_DATE_FORMAT);
             sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
             this.at = sdf.parse(dateString);

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationSchedule.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationSchedule.java
@@ -37,9 +37,6 @@ public class LocalNotificationSchedule {
     private void buildEveryElement(JSObject schedule) {
         // 'year'|'month'|'two-weeks'|'week'|'day'|'hour'|'minute'|'second';
         this.every = schedule.getString("every");
-        if (this.every != null) {
-            this.repeats = true;
-        }
     }
 
     private void buildCountElement(JSObject schedule) {
@@ -47,9 +44,9 @@ public class LocalNotificationSchedule {
     }
 
     private void buildAtElement(JSObject schedule) throws ParseException {
+        this.repeats = schedule.getBool("repeats");
         String dateString = schedule.getString("at");
         if (dateString != null) {
-            this.repeats = schedule.getBool("repeats");
             SimpleDateFormat sdf = new SimpleDateFormat(JS_DATE_FORMAT);
             sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
             this.at = sdf.parse(dateString);

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
@@ -79,8 +79,8 @@ public class LocalNotificationsPlugin extends Plugin {
 
     @PluginMethod
     public void getPending(PluginCall call) {
-        List<String> ids = notificationStorage.getSavedNotificationIds();
-        JSObject result = LocalNotification.buildLocalNotificationPendingList(ids);
+        List<LocalNotification> notifications = notificationStorage.getSavedNotifications();
+        JSObject result = LocalNotification.buildLocalNotificationPendingList(notifications);
         call.resolve(result);
     }
 

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
@@ -83,8 +83,13 @@ public class LocalNotificationsPlugin extends Plugin {
 
     @PluginMethod
     public void getPending(PluginCall call) {
-        List<LocalNotification> notifications = notificationStorage.getSavedNotifications();
-        JSObject result = LocalNotification.buildLocalNotificationPendingList(notifications);
+        List<JSObject> notifications = notificationStorage.getSavedNotifications();
+        JSObject result = new JSObject();
+        JSArray jsArray = new JSArray();
+        for (JSObject notification : notifications) {
+            jsArray.put(notification);
+        }
+        result.put("notifications", jsArray);
         call.resolve(result);
     }
 

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/NotificationStorage.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/NotificationStorage.java
@@ -54,6 +54,43 @@ public class NotificationStorage {
         return new ArrayList<>();
     }
 
+    public List<LocalNotification> getSavedNotifications() {
+        SharedPreferences storage = getStorage(NOTIFICATION_STORE_ID);
+        Map<String, ?> all = storage.getAll();
+        if (all != null) {
+            ArrayList<LocalNotification> notifications = new ArrayList<>();
+            for (String key : all.keySet()) {
+                String notificationString = (String) all.get(key);
+                JSObject jsNotification = getNotificationFromJSONString(notificationString);
+                if (jsNotification != null) {
+                    try {
+                        LocalNotification notification = LocalNotification.buildNotificationFromJSObject(jsNotification);
+                        notifications.add(notification);
+                    } catch (ParseException ex) {}
+                }
+            }
+
+            return notifications;
+        }
+
+        return new ArrayList<>();
+    }
+
+    public JSObject getNotificationFromJSONString(String notificationString) {
+        if (notificationString == null) {
+            return null;
+        }
+
+        JSObject jsNotification;
+        try {
+            jsNotification = new JSObject(notificationString);
+        } catch (JSONException ex) {
+            return null;
+        }
+
+        return jsNotification;
+    }
+
     public JSObject getSavedNotificationAsJSObject(String key) {
         SharedPreferences storage = getStorage(NOTIFICATION_STORE_ID);
         String notificationString = storage.getString(key, null);

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/NotificationStorage.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/NotificationStorage.java
@@ -51,41 +51,20 @@ public class NotificationStorage {
         return new ArrayList<>();
     }
 
-    public List<LocalNotification> getSavedNotifications() {
+    public List<JSObject> getSavedNotifications() {
         SharedPreferences storage = getStorage(NOTIFICATION_STORE_ID);
         Map<String, ?> all = storage.getAll();
         if (all != null) {
-            ArrayList<LocalNotification> notifications = new ArrayList<>();
+            ArrayList<JSObject> notifications = new ArrayList<>();
             for (String key : all.keySet()) {
-                String notificationString = (String) all.get(key);
-                JSObject jsNotification = getNotificationFromJSONString(notificationString);
-                if (jsNotification != null) {
-                    try {
-                        LocalNotification notification = LocalNotification.buildNotificationFromJSObject(jsNotification);
-                        notifications.add(notification);
-                    } catch (ParseException ex) {}
-                }
+                JSObject jsNotification = getSavedNotificationAsJSObject(key);
+                notifications.add(jsNotification);
             }
 
             return notifications;
         }
 
         return new ArrayList<>();
-    }
-
-    public JSObject getNotificationFromJSONString(String notificationString) {
-        if (notificationString == null) {
-            return null;
-        }
-
-        JSObject jsNotification;
-        try {
-            jsNotification = new JSObject(notificationString);
-        } catch (JSONException ex) {
-            return null;
-        }
-
-        return jsNotification;
     }
 
     public JSObject getSavedNotificationAsJSObject(String key) {

--- a/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
+++ b/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
@@ -548,7 +548,7 @@ public class LocalNotificationsPlugin: CAPPlugin {
         var notification: JSObject = [
             "id": Int(request.identifier) ?? -1,
             "title": request.content.title,
-            "body": request.content.body,
+            "body": request.content.body
         ]
 
         var notificationExtras = request.content.userInfo["cap_extra"] as? [String: Any?]

--- a/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
+++ b/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
@@ -549,7 +549,6 @@ public class LocalNotificationsPlugin: CAPPlugin {
             "id": Int(request.identifier) ?? -1,
             "title": request.content.title,
             "body": request.content.body,
-            "repeats": request.trigger?.repeats ?? false       
         ]
 
         var notificationExtras = request.content.userInfo["cap_extra"] as? [String: Any?]

--- a/local-notifications/src/definitions.ts
+++ b/local-notifications/src/definitions.ts
@@ -163,42 +163,6 @@ export interface LocalNotificationDescriptor {
    * @since 1.0.0
    */
   id: string;
-
-  /**
-   * The title of the notification.
-   *
-   * @since 1.0.0
-   */
-  title?: string;
-
-  /**
-   * The body of the notification, shown below the title.
-   *
-   * @since 1.0.0
-   */
-  body?: string;
-
-  /**
-   * Schedule this notification for a later time.
-   *
-   * @since 1.0.0
-   */
-  schedule?: Schedule;
-
-  /**
-   * Set extra data to store within this notification.
-   *
-   * @since 1.0.0
-   */
-  extra?: any;
-
-  /**
-   * Repeat delivery of this notification at the date and time specified by
-   * `at`.
-   *
-   * @since 1.0.0
-   */
-  repeats?: boolean;
 }
 
 export interface ScheduleOptions {
@@ -225,7 +189,7 @@ export interface PendingResult {
    *
    * @since 1.0.0
    */
-  notifications: LocalNotificationDescriptor[];
+  notifications: LocalNotificationSchema[];
 }
 
 export interface RegisterActionTypesOptions {

--- a/local-notifications/src/definitions.ts
+++ b/local-notifications/src/definitions.ts
@@ -163,6 +163,42 @@ export interface LocalNotificationDescriptor {
    * @since 1.0.0
    */
   id: string;
+
+  /**
+   * The title of the notification.
+   *
+   * @since 1.0.0
+   */
+  title?: string;
+
+  /**
+   * The body of the notification, shown below the title.
+   *
+   * @since 1.0.0
+   */
+  body?: string;
+
+  /**
+   * Schedule this notification for a later time.
+   *
+   * @since 1.0.0
+   */
+  schedule?: Schedule;
+
+  /**
+   * Set extra data to store within this notification.
+   *
+   * @since 1.0.0
+   */
+  extra?: any;
+
+  /**
+   * Repeat delivery of this notification at the date and time specified by
+   * `at`.
+   *
+   * @since 1.0.0
+   */
+  repeats?: boolean;
 }
 
 export interface ScheduleOptions {

--- a/local-notifications/src/web.ts
+++ b/local-notifications/src/web.ts
@@ -6,6 +6,7 @@ import type {
   ListChannelsResult,
   LocalNotificationSchema,
   LocalNotificationsPlugin,
+  PendingResult,
   PermissionStatus,
   ScheduleOptions,
   ScheduleResult,
@@ -40,11 +41,9 @@ export class LocalNotificationsWeb
     };
   }
 
-  async getPending(): Promise<ScheduleResult> {
+  async getPending(): Promise<PendingResult> {
     return {
-      notifications: this.pending.map(notification => ({
-        id: notification.id.toString(),
-      })),
+      notifications: this.pending,
     };
   }
 


### PR DESCRIPTION
I noticed you were getting the notifications as strings, converting to LocalNotification and then the LocalNotification to JSObject, but you can get the notifications as JSObjects directly from NotificationStorage, avoiding the double conversion, that simplifies the code, does less work and avoids the data loss I commented on the original PR