### PR TITLE
fix(push-notifications): Avoid missing push data on events

### DIFF
--- a/push-notifications/ios/Plugin/PushNotificationsHandler.swift
+++ b/push-notifications/ios/Plugin/PushNotificationsHandler.swift
@@ -83,7 +83,7 @@ public class PushNotificationsHandler: NSObject, NotificationHandlerProtocol {
             "title": request.content.title,
             "sound": notificationRequest["sound"]  ?? "",
             "body": request.content.body,
-            "extra": request.content.userInfo as? JSObject ?? [:],
+            "extra": JSTypes.coerceDictionaryToJSObject(request.content.userInfo) ?? [:],
             "actionTypeId": request.content.categoryIdentifier,
             "attachments": notificationRequest["attachments"]  ?? []
         ]


### PR DESCRIPTION
The cast to `JSObject` makes the push events to miss some data, by using `coerceDictionaryToJSObject` that information is not lost.

closes https://github.com/ionic-team/capacitor-plugins/issues/207