### PR TITLE
fix(filesystem): support writing files without scheme

### DIFF
--- a/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/FilesystemPlugin.java
+++ b/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/FilesystemPlugin.java
@@ -113,21 +113,27 @@ public class FilesystemPlugin extends Plugin {
                 }
             }
         } else {
-            // check if file://
+            // check file:// or no scheme uris
             Uri u = Uri.parse(path);
-            if ("file".equals(u.getScheme())) {
+            if (u.getScheme() == null || u.getScheme().equals("file")) {
                 File fileObject = new File(u.getPath());
                 // do not know where the file is being store so checking the permission to be secure
                 // TODO to prevent permission checking we need a property from the call
                 if (!isStoragePermissionGranted()) {
                     requestAllPermissions(call);
                 } else {
-                    if (fileObject.getParentFile().exists() || (recursive && fileObject.getParentFile().mkdirs())) {
+                    if (
+                        fileObject.getParentFile() == null ||
+                        fileObject.getParentFile().exists() ||
+                        (recursive && fileObject.getParentFile().mkdirs())
+                    ) {
                         saveFile(call, fileObject, data);
                     } else {
                         call.reject("Parent folder doesn't exist");
                     }
                 }
+            } else {
+                call.reject(u.getScheme() + " scheme not supported");
             }
         }
     }


### PR DESCRIPTION
The test app silently fails on copy and rename buttons because it tries to create a file without scheme and that's not supported.

This PR add support for writing files using file urls without a scheme (`file:///whatever` is equivalent to `whatever` but at the moment first one woks and second silently fail). All other file functions support file scheme and no scheme on file urls.

With the PR, you can write files without having the `file` scheme, and also fails if the user uses a scheme that is not supported (that was also silently failing)

related to https://github.com/ionic-team/capacitor-testapp/issues/102