### PR TITLE
feat(filesystem): Allow the use of absolute urls on iOS and web

### DIFF
--- a/filesystem/ios/Plugin/Filesystem.swift
+++ b/filesystem/ios/Plugin/Filesystem.swift
@@ -136,14 +136,14 @@ import Foundation
     /**
      * Get the SearchPathDirectory corresponding to the JS string
      */
-    @objc public func getDirectory(directory: String) -> FileManager.SearchPathDirectory {
+    public func getDirectory(directory: String?) -> FileManager.SearchPathDirectory? {
         switch directory {
         case "DOCUMENTS":
             return .documentDirectory
         case "CACHE":
             return .cachesDirectory
         default:
-            return .documentDirectory
+            return nil
         }
     }
 
@@ -151,17 +151,15 @@ import Foundation
      * Get the URL for this file, supporting file:// paths and
      * files with directory mappings.
      */
-    @objc public func getFileUrl(at path: String, in directory: String) -> URL? {
-        if path.starts(with: "file://") {
+    @objc public func getFileUrl(at path: String, in directory: String?) -> URL? {
+        if let directory = getDirectory(directory: directory) {
+            guard let dir = FileManager.default.urls(for: directory, in: .userDomainMask).first else {
+                return nil
+            }
+
+            return dir.appendingPathComponent(path)
+        } else {
             return URL(string: path)
         }
-
-        let directory = getDirectory(directory: directory)
-
-        guard let dir = FileManager.default.urls(for: directory, in: .userDomainMask).first else {
-            return nil
-        }
-
-        return dir.appendingPathComponent(path)
     }
 }

--- a/filesystem/ios/Plugin/Filesystem.swift
+++ b/filesystem/ios/Plugin/Filesystem.swift
@@ -137,14 +137,15 @@ import Foundation
      * Get the SearchPathDirectory corresponding to the JS string
      */
     public func getDirectory(directory: String?) -> FileManager.SearchPathDirectory? {
-        switch directory {
-        case "DOCUMENTS":
-            return .documentDirectory
-        case "CACHE":
-            return .cachesDirectory
-        default:
-            return nil
+        if let directory = directory {
+            switch directory {
+            case "CACHE":
+                return .cachesDirectory
+            default:
+                return .documentDirectory
+            }
         }
+        return nil
     }
 
     /**

--- a/filesystem/ios/Plugin/FilesystemPlugin.swift
+++ b/filesystem/ios/Plugin/FilesystemPlugin.swift
@@ -8,7 +8,6 @@ import Capacitor
 @objc(FilesystemPlugin)
 public class FilesystemPlugin: CAPPlugin {
     private let implementation = Filesystem()
-    let defaultDirectory = "DOCUMENTS"
 
     /**
      * Read a file from the filesystem.
@@ -20,7 +19,7 @@ public class FilesystemPlugin: CAPPlugin {
             handleError(call, "path must be provided and must be a string.")
             return
         }
-        let directory = call.getString("directory") ?? defaultDirectory
+        let directory = call.getString("directory")
 
         guard let fileUrl = implementation.getFileUrl(at: file, in: directory) else {
             handleError(call, "Invalid path")
@@ -53,7 +52,7 @@ public class FilesystemPlugin: CAPPlugin {
             return
         }
 
-        let directory = call.getString("directory") ?? defaultDirectory
+        let directory = call.getString("directory")
 
         guard let fileUrl = implementation.getFileUrl(at: file, in: directory) else {
             handleError(call, "Invalid path")
@@ -86,7 +85,7 @@ public class FilesystemPlugin: CAPPlugin {
             return
         }
 
-        let directory = call.getString("directory") ?? defaultDirectory
+        let directory = call.getString("directory")
         guard let fileUrl = implementation.getFileUrl(at: file, in: directory) else {
             handleError(call, "Invalid path")
             return
@@ -108,7 +107,7 @@ public class FilesystemPlugin: CAPPlugin {
             return
         }
 
-        let directory = call.getString("directory") ?? defaultDirectory
+        let directory = call.getString("directory")
         guard let fileUrl = implementation.getFileUrl(at: file, in: directory) else {
             handleError(call, "Invalid path")
             return
@@ -132,7 +131,7 @@ public class FilesystemPlugin: CAPPlugin {
         }
 
         let recursive = call.getBool("recursive") ?? false
-        let directory = call.getString("directory") ?? defaultDirectory
+        let directory = call.getString("directory")
         guard let fileUrl = implementation.getFileUrl(at: path, in: directory) else {
             handleError(call, "Invalid path")
             return
@@ -155,7 +154,7 @@ public class FilesystemPlugin: CAPPlugin {
             return
         }
 
-        let directory = call.getString("directory") ?? defaultDirectory
+        let directory = call.getString("directory")
         guard let fileUrl = implementation.getFileUrl(at: path, in: directory) else {
             handleError(call, "Invalid path")
             return
@@ -180,7 +179,7 @@ public class FilesystemPlugin: CAPPlugin {
             return
         }
 
-        let directory = call.getString("directory") ?? defaultDirectory
+        let directory = call.getString("directory")
         guard let fileUrl = implementation.getFileUrl(at: path, in: directory) else {
             handleError(call, "Invalid path")
             return
@@ -205,7 +204,7 @@ public class FilesystemPlugin: CAPPlugin {
             return
         }
 
-        let directory = call.getString("directory") ?? defaultDirectory
+        let directory = call.getString("directory")
         guard let fileUrl = implementation.getFileUrl(at: path, in: directory) else {
             handleError(call, "Invalid path")
             return
@@ -231,7 +230,7 @@ public class FilesystemPlugin: CAPPlugin {
             return
         }
 
-        let directory = call.getString("directory") ?? defaultDirectory
+        let directory = call.getString("directory")
         guard let fileUrl = implementation.getFileUrl(at: path, in: directory) else {
             handleError(call, "Invalid path")
             return
@@ -252,7 +251,7 @@ public class FilesystemPlugin: CAPPlugin {
             return
         }
 
-        let directory = call.getString("directory") ?? defaultDirectory
+        let directory = call.getString("directory")
         let toDirectory = call.getString("toDirectory") ?? directory
 
         guard let fromUrl = implementation.getFileUrl(at: from, in: directory) else {
@@ -281,7 +280,7 @@ public class FilesystemPlugin: CAPPlugin {
             return
         }
 
-        let directory = call.getString("directory") ?? defaultDirectory
+        let directory = call.getString("directory")
         let toDirectory = call.getString("toDirectory") ?? directory
 
         guard let fromUrl = implementation.getFileUrl(at: from, in: directory) else {

--- a/filesystem/src/web.ts
+++ b/filesystem/src/web.ts
@@ -19,11 +19,10 @@ import type {
   StatResult,
   WriteFileOptions,
   WriteFileResult,
+  Directory,
 } from './definitions';
-import { Directory } from './definitions';
 
 export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
-  DEFAULT_DIRECTORY = Directory.Data;
   DB_VERSION = 1;
   DB_NAME = 'Disc';
 
@@ -105,10 +104,10 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
     directory: Directory | undefined,
     uriPath: string | undefined,
   ): string {
-    directory = directory || this.DEFAULT_DIRECTORY;
     const cleanedUriPath =
       uriPath !== undefined ? uriPath.replace(/^[/]+|[/]+$/g, '') : '';
-    let fsPath = '/' + directory;
+    let fsPath = '';
+    if (directory !== undefined) fsPath += '/' + directory;
     if (uriPath !== '') fsPath += '/' + cleanedUriPath;
     return fsPath;
   }
@@ -253,6 +252,7 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
     const path: string = this.getPath(options.directory, options.path);
     const doRecursive = options.recursive;
     const parentPath = path.substr(0, path.lastIndexOf('/'));
+    console.log('redusie', doRecursive);
 
     const depth = (path.match(/\//g) || []).length;
     const parentEntry = (await this.dbRequest('get', [parentPath])) as EntryObj;
@@ -351,10 +351,8 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
     if (entry === undefined) {
       entry = (await this.dbRequest('get', [path + '/'])) as EntryObj;
     }
-    if (entry === undefined) throw Error('Entry does not exist.');
-
     return {
-      uri: entry.path,
+      uri: entry?.path || path,
     };
   }
 

--- a/filesystem/src/web.ts
+++ b/filesystem/src/web.ts
@@ -252,7 +252,6 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
     const path: string = this.getPath(options.directory, options.path);
     const doRecursive = options.recursive;
     const parentPath = path.substr(0, path.lastIndexOf('/'));
-    console.log('redusie', doRecursive);
 
     const depth = (path.match(/\//g) || []).length;
     const parentEntry = (await this.dbRequest('get', [parentPath])) as EntryObj;


### PR DESCRIPTION
Android allowed using file urls when no directory was passed.
This also allows absolute file urls on iOS and web platforms when no directory is passed instead of using a default directory

closes https://github.com/ionic-team/capacitor-plugins/issues/240