### PR TITLE
fix(local-notifications): Opt out of Capacitor date serialization

### DIFF
--- a/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
+++ b/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
@@ -30,6 +30,7 @@ public class LocalNotificationsPlugin: CAPPlugin {
     override public func load() {
         self.bridge?.notificationRouter.localNotificationHandler = self.notificationDelegationHandler
         self.notificationDelegationHandler.plugin = self
+        self.shouldStringifyDatesInCalls = false
     }
 
     /**


### PR DESCRIPTION
This PR disables the new [Capacitor v3 automatic date serialization](https://github.com/ionic-team/capacitor/pull/4177) in the iOS local-notifications plugin.

