### PR TITLE
docs(push/local-notifications): Adding information about common notification issues

### DIFF
--- a/local-notifications/README.md
+++ b/local-notifications/README.md
@@ -9,6 +9,10 @@ npm install @capacitor/local-notifications
 npx cap sync
 ```
 
+## Doze
+
+If the device has entered [Doze](https://developer.android.com/training/monitoring-device-state/doze-standby) mode, your application may have restricted capabilities.  If you need your notification to fire even during Doze, schedule your notification by using `allowWhileIdle: true`.  Make use of  `allowWhileIdle` judiciously, as these notifications [can only fire once per 9 minutes, per app.](https://developer.android.com/training/monitoring-device-state/doze-standby#assessing_your_app)
+
 ## API
 
 <docgen-index>

--- a/local-notifications/README.md
+++ b/local-notifications/README.md
@@ -11,7 +11,7 @@ npx cap sync
 
 ## Doze
 
-If the device has entered [Doze](https://developer.android.com/training/monitoring-device-state/doze-standby) mode, your application may have restricted capabilities.  If you need your notification to fire even during Doze, schedule your notification by using `allowWhileIdle: true`.  Make use of  `allowWhileIdle` judiciously, as these notifications [can only fire once per 9 minutes, per app.](https://developer.android.com/training/monitoring-device-state/doze-standby#assessing_your_app)
+If the device has entered [Doze](https://developer.android.com/training/monitoring-device-state/doze-standby) mode, your application may have restricted capabilities. If you need your notification to fire even during Doze, schedule your notification by using `allowWhileIdle: true`. Make use of `allowWhileIdle` judiciously, as these notifications [can only fire once per 9 minutes, per app.](https://developer.android.com/training/monitoring-device-state/doze-standby#assessing_your_app)
 
 ## API
 

--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -68,6 +68,19 @@ An empty Array can be provided if none of the previous options are desired. `pus
 }
 ```
 
+## Silent Push Notifications / Data-only Notifications
+#### iOS
+This plugin does not support iOS Silent Push (Remote Notifications).  We recommend using native code solutions for handling these types of notifications, see [Pushing Background Updates to Your App](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app).
+
+#### Android
+This plugin does support data-only notifications, but will NOT call `pushNotificationReceived` if the app has been killed.  To handle this scenario, you will need to create a service that extends `FirebaseMessagingService`, see [Handling FCM Messages](https://firebase.google.com/docs/cloud-messaging/android/receive). 
+
+## Common Issues
+On Android, there are various system and app states that can affect the delivery of push notifications:
+
+* If the device has entered [Doze](https://developer.android.com/training/monitoring-device-state/doze-standby) mode, your application may have restricted capabilities.  To increase the chance of your notification being received, consider using [FCM high priority messages](https://firebase.google.com/docs/cloud-messaging/concept-options#setting-the-priority-of-a-message).
+* There are differences in behavior between development and production.  Try testing your app outside of being launched by Android Studio.  Read more [here](https://stackoverflow.com/questions/48642423/firebase-push-notification-issue-in-android-when-app-is-closed-killed).
+
 ---
 
 ## API

--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -70,16 +70,16 @@ An empty Array can be provided if none of the previous options are desired. `pus
 
 ## Silent Push Notifications / Data-only Notifications
 #### iOS
-This plugin does not support iOS Silent Push (Remote Notifications).  We recommend using native code solutions for handling these types of notifications, see [Pushing Background Updates to Your App](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app).
+This plugin does not support iOS Silent Push (Remote Notifications). We recommend using native code solutions for handling these types of notifications, see [Pushing Background Updates to Your App](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app).
 
 #### Android
-This plugin does support data-only notifications, but will NOT call `pushNotificationReceived` if the app has been killed.  To handle this scenario, you will need to create a service that extends `FirebaseMessagingService`, see [Handling FCM Messages](https://firebase.google.com/docs/cloud-messaging/android/receive). 
+This plugin does support data-only notifications, but will NOT call `pushNotificationReceived` if the app has been killed. To handle this scenario, you will need to create a service that extends `FirebaseMessagingService`, see [Handling FCM Messages](https://firebase.google.com/docs/cloud-messaging/android/receive). 
 
 ## Common Issues
 On Android, there are various system and app states that can affect the delivery of push notifications:
 
-* If the device has entered [Doze](https://developer.android.com/training/monitoring-device-state/doze-standby) mode, your application may have restricted capabilities.  To increase the chance of your notification being received, consider using [FCM high priority messages](https://firebase.google.com/docs/cloud-messaging/concept-options#setting-the-priority-of-a-message).
-* There are differences in behavior between development and production.  Try testing your app outside of being launched by Android Studio.  Read more [here](https://stackoverflow.com/questions/48642423/firebase-push-notification-issue-in-android-when-app-is-closed-killed).
+* If the device has entered [Doze](https://developer.android.com/training/monitoring-device-state/doze-standby) mode, your application may have restricted capabilities. To increase the chance of your notification being received, consider using [FCM high priority messages](https://firebase.google.com/docs/cloud-messaging/concept-options#setting-the-priority-of-a-message).
+* There are differences in behavior between development and production. Try testing your app outside of being launched by Android Studio. Read more [here](https://stackoverflow.com/a/50238790/1351469).
 
 ---
 


### PR DESCRIPTION
This PR adds notes for dealing with common issues related to handling push and local notifications:

- How to handle notifications during Doze
- Tips on testing the application during development

A note is also added to clarify that silent push notifications, and background (app is killed) data-only notifications are NOT supported in this plugin. Links to more documentation on platform specific workarounds are included.

closes: ionic-team/capacitor-plugins#200
closes: ionic-team/capacitor#3500