### PR TITLE
docs(geolocation): use proper function syntax on example

### DIFF
--- a/geolocation/README.md
+++ b/geolocation/README.md
@@ -44,7 +44,7 @@ This plugin will use the following project variables (defined in your app's `var
 ```typescript
 import { Geolocation } from '@capacitor/geolocation';
 
-const printCurrentPosition = async () {
+const printCurrentPosition = async () => {
   const coordinates = await Geolocation.getCurrentPosition();
 
   console.log('Current position:', coordinates);


### PR DESCRIPTION
added missing => to printCurrentPosition  function