### PR TITLE
fix(local-notification): Throw unavailable if Notification API not supported

### DIFF
--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -18,7 +18,7 @@ Additionally, the Filesystem API supports using full `file://` paths, or reading
 ## Example
 
 ```typescript
-import { Filesystem, Directory, Encoding } from '@capacitor/core';
+import { Filesystem, Directory, Encoding } from '@capacitor/filesystem';
 
 const writeSecretFile = async () {
   await Filesystem.writeFile({

--- a/local-notifications/src/web.ts
+++ b/local-notifications/src/web.ts
@@ -30,6 +30,10 @@ export class LocalNotificationsWeb
   }
 
   async schedule(options: ScheduleOptions): Promise<ScheduleResult> {
+    if (!('Notification' in window)) {
+      throw this.unavailable('Notifications not supported in this browser.');
+    }
+
     for (const notification of options.notifications) {
       this.sendNotification(notification);
     }
@@ -67,6 +71,10 @@ export class LocalNotificationsWeb
   }
 
   async requestPermissions(): Promise<PermissionStatus> {
+    if (!('Notification' in window)) {
+      throw this.unavailable('Notifications not supported in this browser.');
+    }
+
     const display = this.transformNotificationPermission(
       await Notification.requestPermission(),
     );

--- a/local-notifications/src/web.ts
+++ b/local-notifications/src/web.ts
@@ -76,7 +76,7 @@ export class LocalNotificationsWeb
 
   async checkPermissions(): Promise<PermissionStatus> {
     if (!('Notification' in window)) {
-      throw this.unimplemented('Not implemented on web.');
+      throw this.unavailable('Notifications not supported in this browser.');
     }
 
     const display = this.transformNotificationPermission(

--- a/local-notifications/src/web.ts
+++ b/local-notifications/src/web.ts
@@ -75,6 +75,10 @@ export class LocalNotificationsWeb
   }
 
   async checkPermissions(): Promise<PermissionStatus> {
+    if (!('Notification' in window)) {
+      throw this.unimplemented('Not implemented on web.');
+    }
+
     const display = this.transformNotificationPermission(
       Notification.permission,
     );


### PR DESCRIPTION
During `checkPermissions`, check to see if the Notifications API is supported by the browser and throws `unavailable` if not.

Closes: https://github.com/ionic-team/capacitor-plugins/issues/254