### PR TITLE
feat(local-notifications): Adding summary text to grouped notifications

### DIFF
--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
@@ -207,7 +207,6 @@ public class LocalNotificationManager {
         String group = localNotification.getGroup();
         if (group != null) {
             mBuilder.setGroup(group);
-
             if (localNotification.isGroupSummary()) {
                 mBuilder.setSubText(localNotification.getSummaryText());
             }

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
@@ -207,6 +207,10 @@ public class LocalNotificationManager {
         String group = localNotification.getGroup();
         if (group != null) {
             mBuilder.setGroup(group);
+
+            if (localNotification.isGroupSummary()) {
+                mBuilder.setSubText(localNotification.getSummaryText());
+            }
         }
 
         // make sure scheduled time is shown instead of display time


### PR DESCRIPTION
This PR uses the recently added `summaryText` to set `setSubText` on a group notification summary notification.

closes: https://github.com/ionic-team/capacitor-plugins/issues/218