### PR TITLE
docs(haptis): Update README example to use ImpactStyle

### DIFF
--- a/haptics/README.md
+++ b/haptics/README.md
@@ -12,14 +12,14 @@ npx cap sync
 ## Example
 
 ```typescript
-import { Haptics, HapticsImpactStyle } from '@capacitor/haptics';
+import { Haptics, ImpactStyle } from '@capacitor/haptics';
 
 const hapticsImpactMedium = async () => {
-  await Haptics.impact({ style: HapticsImpactStyle.Medium });
+  await Haptics.impact({ style: ImpactStyle.Medium });
 };
 
 const hapticsImpactLight = async () => {
-  await Haptics.impact({ style: HapticsImpactStyle.Light });
+  await Haptics.impact({ style: ImpactStyle.Light });
 };
 
 const hapticsVibrate = async () => {


### PR DESCRIPTION
Capacitor v3 has deprecated `HapticsImpactStyle` in favor of `ImpactStyle` but the docs were still using the old syntax. VSCode suggested the change but it would be nice of the docs mentioned this change especially as developers migrate from v2 to v3.