### PR TITLE
fix(splash-screen): launchAutoHide not working on iOS

### DIFF
--- a/splash-screen/README.md
+++ b/splash-screen/README.md
@@ -35,7 +35,7 @@ By default, the Splash Screen is set to automatically hide after 500 ms.
 
 If you want to be sure the splash screen never disappears before your app is ready, set `launchAutoHide` to `false`; the splash screen will then stay visible until manually hidden. For the best user experience, your app should call `hide()` as soon as possible.
 
-If your you want to show the splash for a fixed amount of time, configure the default duration by setting `launchShowDuration` in your [Capacitor configuration file](https://capacitorjs.com/docs/config).
+If, instead, you want to show the splash screen for a fixed amount of time, set `launchShowDuration` in your [Capacitor configuration file](https://capacitorjs.com/docs/config).
 
 
 ## Background Color

--- a/splash-screen/README.md
+++ b/splash-screen/README.md
@@ -31,7 +31,7 @@ SplashScreen.show({
 
 ## Hiding the Splash Screen
 
-By default, the Splash Screen is set to automatically hide after a certain amount of time (500 ms).
+By default, the Splash Screen is set to automatically hide after 500 ms.
 
 If you want to be sure the splash never hides before the app is fully loaded, set `launchAutoHide` to `false`. You should hide the splash screen when your app is ready to be used by calling `hide()` as soon as possible.
 

--- a/splash-screen/README.md
+++ b/splash-screen/README.md
@@ -33,7 +33,7 @@ SplashScreen.show({
 
 By default, the Splash Screen is set to automatically hide after 500 ms.
 
-If you want to be sure the splash never hides before the app is fully loaded, set `launchAutoHide` to `false`. You should hide the splash screen when your app is ready to be used by calling `hide()` as soon as possible.
+If you want to be sure the splash screen never disappears before your app is ready, set `launchAutoHide` to `false`; the splash screen will then stay visible until manually hidden. For the best user experience, your app should call `hide()` as soon as possible.
 
 If your you want to show the splash for a fixed amount of time, configure the default duration by setting `launchShowDuration` in your [Capacitor configuration file](https://capacitorjs.com/docs/config).
 

--- a/splash-screen/README.md
+++ b/splash-screen/README.md
@@ -31,13 +31,12 @@ SplashScreen.show({
 
 ## Hiding the Splash Screen
 
-By default, the Splash Screen is set to automatically hide after a certain amount of time (3 seconds). However, your app should boot much faster than this!
+By default, the Splash Screen is set to automatically hide after a certain amount of time (500 ms).
 
-To make sure you provide the fastest app loading experience to your users, you should hide the splash screen when your app is ready to be used by calling `hide()` as soon as possible.
+If you want to be sure the splash never hides before the app is fully loaded, set `launchAutoHide` to `false`. You should hide the splash screen when your app is ready to be used by calling `hide()` as soon as possible.
 
-If your app needs longer than 3 seconds to load, configure the default duration by setting `launchShowDuration` in your [Capacitor configuration file](https://capacitorjs.com/docs/config).
+If your you want to show the splash for a fixed amount of time, configure the default duration by setting `launchShowDuration` in your [Capacitor configuration file](https://capacitorjs.com/docs/config).
 
-If you want to be sure the splash never hides before the app is fully loaded, set `launchAutoHide` to `false`.
 
 ## Background Color
 

--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenConfig.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenConfig.java
@@ -8,7 +8,7 @@ public class SplashScreenConfig {
     private Integer spinnerStyle;
     private Integer spinnerColor;
     private boolean showSpinner = false;
-    private Integer launchShowDuration = 0;
+    private Integer launchShowDuration = 500;
     private boolean launchAutoHide = true;
     private Integer launchFadeInDuration = 0;
     private String resourceName = "splash";

--- a/splash-screen/ios/Plugin/SplashScreen.swift
+++ b/splash-screen/ios/Plugin/SplashScreen.swift
@@ -24,6 +24,7 @@ import Capacitor
         var settings = SplashScreenSettings()
         settings.showDuration = config.launchShowDuration
         settings.fadeInDuration = config.launchFadeInDuration
+        settings.autoHide = config.launchAutoHide
         showSplash(settings: settings, completion: {}, isLaunchSplash: true)
     }
 

--- a/splash-screen/ios/Plugin/SplashScreenConfig.swift
+++ b/splash-screen/ios/Plugin/SplashScreenConfig.swift
@@ -5,7 +5,7 @@ public struct SplashScreenConfig {
     var spinnerStyle: UIActivityIndicatorView.Style?
     var spinnerColor: UIColor?
     var showSpinner = false
-    var launchShowDuration = 0
+    var launchShowDuration = 500
     var launchAutoHide = true
     let launchFadeInDuration = 0
 }


### PR DESCRIPTION
launchAutoHide was not working on iOS

also the PR changes the default splash value from 0 to 500ms so the splash always shows

and update the docs accordingly

closes https://github.com/ionic-team/capacitor-plugins/issues/270
closes https://github.com/ionic-team/capacitor-plugins/issues/317
closes https://github.com/ionic-team/capacitor-plugins/issues/300