### PR TITLE
fix(filesystem): Convert stat ctime/mtime timestamp to milliseconds

### DIFF
--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -420,13 +420,13 @@ Required on Android, only when using <a href="#directory">`Directory.Documents`<
 
 #### StatResult
 
-| Prop        | Type                | Description               | Since |
-| ----------- | ------------------- | ------------------------- | ----- |
-| **`type`**  | <code>string</code> | Type of the file          | 1.0.0 |
-| **`size`**  | <code>number</code> | Size of the file          | 1.0.0 |
-| **`ctime`** | <code>number</code> | Time of creation          | 1.0.0 |
-| **`mtime`** | <code>number</code> | Time of last modification | 1.0.0 |
-| **`uri`**   | <code>string</code> | The uri of the file       | 1.0.0 |
+| Prop        | Type                | Description                               | Since |
+| ----------- | ------------------- | ----------------------------------------- | ----- |
+| **`type`**  | <code>string</code> | Type of the file                          | 1.0.0 |
+| **`size`**  | <code>number</code> | Size of the file                          | 1.0.0 |
+| **`ctime`** | <code>number</code> | Time of creation in milliseconds          | 1.0.0 |
+| **`mtime`** | <code>number</code> | Time of last modification in milliseconds | 1.0.0 |
+| **`uri`**   | <code>string</code> | The uri of the file                       | 1.0.0 |
 
 
 #### StatOptions

--- a/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/FilesystemPlugin.java
+++ b/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/FilesystemPlugin.java
@@ -3,6 +3,7 @@ package com.capacitorjs.plugins.filesystem;
 import android.Manifest;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
+import android.os.Build;
 import com.capacitorjs.plugins.filesystem.exceptions.CopyFailedException;
 import com.capacitorjs.plugins.filesystem.exceptions.DirectoryExistsException;
 import com.capacitorjs.plugins.filesystem.exceptions.DirectoryNotFoundException;
@@ -18,6 +19,8 @@ import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributes;
 import org.json.JSONException;
 
 @CapacitorPlugin(
@@ -315,6 +318,14 @@ public class FilesystemPlugin extends Plugin {
             data.put("ctime", null);
             data.put("mtime", fileObject.lastModified());
             data.put("uri", Uri.fromFile(fileObject).toString());
+
+            if (Build.VERSION.SDK_INT >= 26) {
+                try {
+                    BasicFileAttributes attr = Files.readAttributes(fileObject.toPath(), BasicFileAttributes.class);
+                    long fileCreatedAt = attr.creationTime().toMillis();
+                    data.put("ctime", fileCreatedAt);
+                } catch (Exception ex) {}
+            }
             call.resolve(data);
         }
     }

--- a/filesystem/ios/Plugin/FilesystemPlugin.swift
+++ b/filesystem/ios/Plugin/FilesystemPlugin.swift
@@ -218,11 +218,11 @@ public class FilesystemPlugin: CAPPlugin {
             var mtime = ""
 
             if let ctimeSeconds = (attr[.creationDate] as? Date)?.timeIntervalSince1970 {
-                ctime = String(format: "%f", ctimeSeconds * 1000)
+                ctime = String(format: "%.0f", ctimeSeconds * 1000)
             }
 
             if let mtimeSeconds = (attr[.modificationDate] as? Date)?.timeIntervalSince1970 {
-                mtime = String(format: "%f", mtimeSeconds * 1000)
+                mtime = String(format: "%.0f", mtimeSeconds * 1000)
             }
 
             call.resolve([

--- a/filesystem/ios/Plugin/FilesystemPlugin.swift
+++ b/filesystem/ios/Plugin/FilesystemPlugin.swift
@@ -213,11 +213,23 @@ public class FilesystemPlugin: CAPPlugin {
 
         do {
             let attr = try implementation.stat(at: fileUrl)
+
+            var ctime = ""
+            var mtime = ""
+
+            if let ctimeSeconds = (attr[.creationDate] as? Date)?.timeIntervalSince1970 {
+                ctime = String(format: "%f", ctimeSeconds * 1000)
+            }
+
+            if let mtimeSeconds = (attr[.modificationDate] as? Date)?.timeIntervalSince1970 {
+                mtime = String(format: "%f", mtimeSeconds * 1000)
+            }
+
             call.resolve([
                 "type": attr[.type] as? String ?? "",
                 "size": attr[.size] as? UInt64 ?? "",
-                "ctime": (attr[.creationDate] as? Date)?.timeIntervalSince1970 ?? "",
-                "mtime": (attr[.modificationDate] as? Date)?.timeIntervalSince1970 ?? "",
+                "ctime": ctime,
+                "mtime": mtime,
                 "uri": fileUrl.absoluteString
             ])
         } catch {

--- a/filesystem/src/definitions.ts
+++ b/filesystem/src/definitions.ts
@@ -387,14 +387,14 @@ export interface StatResult {
   size: number;
 
   /**
-   * Time of creation
+   * Time of creation in milliseconds
    *
    * @since 1.0.0
    */
   ctime: number;
 
   /**
-   * Time of last modification
+   * Time of last modification in milliseconds
    *
    * @since 1.0.0
    */


### PR DESCRIPTION
This PR makes `Filesystem.stat` return `ctime` and `mtime` in milliseconds iOS, bringing it in line with Android.

closes: https://github.com/ionic-team/capacitor-plugins/issues/313