### PR TITLE
Text-Zoom base fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ See [`CONTRIBUTING.md`](https://github.com/ionic-team/capacitor/blob/HEAD/CONTRI
     brew install swiftlint
     ```
 
-Sometimes, it may be necessary to work on Capacitor in parellel with the plugin(s). In this case, a few extra steps are necessary:
+Sometimes, it may be necessary to work on Capacitor in parallel with the plugin(s). In this case, a few extra steps are necessary:
 
 4. Follow the Capacitor repo's [local setup instructions](https://github.com/ionic-team/capacitor/blob/HEAD/CONTRIBUTING.md#local-setup).
 5. Toggle each plugin to use your local copy of Capacitor.

--- a/dialog/android/src/main/java/com/capacitorjs/plugins/dialog/Dialog.java
+++ b/dialog/android/src/main/java/com/capacitorjs/plugins/dialog/Dialog.java
@@ -44,7 +44,7 @@ public class Dialog {
         final String alertOkButtonTitle = okButtonTitle == null ? "OK" : okButtonTitle;
 
         new Handler(Looper.getMainLooper())
-        .post(
+            .post(
                 () -> {
                     AlertDialog.Builder builder = new AlertDialog.Builder(context);
 
@@ -89,7 +89,7 @@ public class Dialog {
         final String confirmCancelButtonTitle = cancelButtonTitle == null ? "Cancel" : cancelButtonTitle;
 
         new Handler(Looper.getMainLooper())
-        .post(
+            .post(
                 () -> {
                     final AlertDialog.Builder builder = new AlertDialog.Builder(context);
 
@@ -145,7 +145,7 @@ public class Dialog {
         final String promptInputText = inputText == null ? "" : inputText;
 
         new Handler(Looper.getMainLooper())
-        .post(
+            .post(
                 () -> {
                     final AlertDialog.Builder builder = new AlertDialog.Builder(context);
                     final EditText input = new EditText(context);

--- a/keyboard/android/src/main/java/com/capacitorjs/plugins/keyboard/KeyboardPlugin.java
+++ b/keyboard/android/src/main/java/com/capacitorjs/plugins/keyboard/KeyboardPlugin.java
@@ -27,7 +27,7 @@ public class KeyboardPlugin extends Plugin {
         execute(
             () ->
                 new Handler()
-                .postDelayed(
+                    .postDelayed(
                         () -> {
                             implementation.show();
                             call.resolve();

--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
@@ -188,7 +188,7 @@ public class SplashScreen {
 
                 if (settings.isAutoHide()) {
                     new Handler()
-                    .postDelayed(
+                        .postDelayed(
                             () -> {
                                 hide(settings.getFadeOutDuration(), isLaunchSplash);
 

--- a/text-zoom/ios/Plugin/TextZoomPlugin.swift
+++ b/text-zoom/ios/Plugin/TextZoomPlugin.swift
@@ -10,4 +10,12 @@ public class TextZoomPlugin: CAPPlugin {
             "value": textZoom.preferredFontSize()
         ])
     }
+
+    @objc func get(_ call: CAPPluginCall) {
+        call.unimplemented("Not available on iOS")
+    }
+
+    @objc func set(_ call: CAPPluginCall) {
+        call.unimplemented("Not available on iOS")
+    }
 }

--- a/text-zoom/src/index.ts
+++ b/text-zoom/src/index.ts
@@ -3,7 +3,7 @@ import { registerPlugin } from '@capacitor/core';
 import type { TextZoomPlugin } from './definitions';
 
 const TextZoom = registerPlugin<TextZoomPlugin>('TextZoom', {
-  ios: import('./ios').then(m => new m.TextZoomIOS()),
+  web: () => import('./web').then(m => new m.TextZoomWeb()),
 });
 
 export * from './definitions';

--- a/text-zoom/src/web.ts
+++ b/text-zoom/src/web.ts
@@ -1,4 +1,4 @@
-import { Plugins } from '@capacitor/core';
+import { WebPlugin } from '@capacitor/core';
 
 import type {
   GetPreferredResult,
@@ -7,7 +7,7 @@ import type {
   TextZoomPlugin,
 } from './definitions';
 
-export class TextZoomIOS implements TextZoomPlugin {
+export class TextZoomWeb extends WebPlugin implements TextZoomPlugin {
   static readonly TEXT_SIZE_REGEX = /(\d+)%/;
 
   async get(): Promise<GetResult> {
@@ -18,7 +18,7 @@ export class TextZoomIOS implements TextZoomPlugin {
   }
 
   async getPreferred(): Promise<GetPreferredResult> {
-    return Plugins.TextZoom.getPreferred();
+    return this.get();
   }
 
   async set(options: SetOptions): Promise<void> {
@@ -40,7 +40,7 @@ export class TextZoomIOS implements TextZoomPlugin {
   }
 
   textSizePercentageToNumber(percentage: string): number {
-    const m = TextZoomIOS.TEXT_SIZE_REGEX.exec(percentage);
+    const m = TextZoomWeb.TEXT_SIZE_REGEX.exec(percentage);
 
     if (!m) {
       return 1;

--- a/toast/android/src/main/java/com/capacitorjs/plugins/toast/Toast.java
+++ b/toast/android/src/main/java/com/capacitorjs/plugins/toast/Toast.java
@@ -20,7 +20,7 @@ public class Toast {
 
     public static void show(final Context c, final String text, final int duration, final String position) {
         new Handler(Looper.getMainLooper())
-        .post(
+            .post(
                 () -> {
                     android.widget.Toast toast = android.widget.Toast.makeText(c, text, duration);
                     if ("top".equals(position)) {


### PR DESCRIPTION
This appears to correct the major problems encountered in #322 , but someone iOS savvy will have to complete the implementations of `get` and `set`. This at least stubs the methods to complete the interface of the plugin.

**Fixes**

1. Renames ios typescript impl to `web.ts`
2. Updates web plugin registration to function loader
3. Updates web plugin to extend base class
4. Updates web plugin to avoid self-reference causing infinite loop
5. Stubs missing iOS plugin methods