### PR TITLE
fix(local-notifications): extra not being returned on notification events

### DIFF
--- a/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
+++ b/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
@@ -160,7 +160,7 @@ public class LocalNotificationsPlugin: CAPPlugin {
             CAPLog.print(notifications)
 
             let ret = notifications.compactMap({ [weak self] (notification) -> JSObject? in
-                return self?.makePendingNotificationRequestJSObject(notification)
+                return self?.notificationDelegationHandler.makePendingNotificationRequestJSObject(notification)
             })
 
             call.resolve([
@@ -544,41 +544,6 @@ public class LocalNotificationsPlugin: CAPPlugin {
             opts[UNNotificationAttachmentOptionsThumbnailTimeKey] = iosUNNotificationAttachmentOptionsThumbnailTimeKey
         }
         return opts
-    }
-
-    func makePendingNotificationRequestJSObject(_ request: UNNotificationRequest) -> JSObject {
-        var notification: JSObject = [
-            "id": Int(request.identifier) ?? -1,
-            "title": request.content.title,
-            "body": request.content.body
-        ]
-
-        if let userInfo = JSTypes.coerceDictionaryToJSObject(request.content.userInfo) {
-            var extra = userInfo["cap_extra"] as? JSObject ?? userInfo
-
-            // check for any dates and convert them to strings
-            for(key, value) in extra {
-                if let date = value as? Date {
-                    let dateString = ISO8601DateFormatter().string(from: date)
-                    extra[key] = dateString
-                }
-            }
-
-            notification["extra"] = extra
-
-            if var schedule = userInfo["cap_schedule"] as? JSObject {
-                // convert schedule at date to string
-                if let date = schedule["at"] as? Date {
-                    let dateString = ISO8601DateFormatter().string(from: date)
-                    schedule["at"] = dateString
-                }
-
-                notification["schedule"] = schedule
-            }
-        }
-
-        return notification
-
     }
 
     @objc func createChannel(_ call: CAPPluginCall) {


### PR DESCRIPTION
extra was not being returned because it needed to be coerced, but also because userInfo was split into `cap_schedule` and `cap_extra`.

So reused `makePendingNotificationRequestJSObject` as it was already handling `cap_schedule` and `cap_extra` to generate the notification of `makeNotificationRequestJSObject`

closes https://github.com/ionic-team/capacitor-plugins/issues/337