### PR TITLE
fix(clipboard): prevent NotAllowedError on first method invocation

### DIFF
--- a/clipboard/src/index.ts
+++ b/clipboard/src/index.ts
@@ -1,9 +1,10 @@
 import { registerPlugin } from '@capacitor/core';
 
 import type { ClipboardPlugin } from './definitions';
+import { ClipboardWeb } from './web';
 
 const Clipboard = registerPlugin<ClipboardPlugin>('Clipboard', {
-  web: () => import('./web').then(m => new m.ClipboardWeb()),
+  web: () => new ClipboardWeb(),
 });
 
 export * from './definitions';

--- a/clipboard/src/web.ts
+++ b/clipboard/src/web.ts
@@ -107,7 +107,3 @@ export class ClipboardWeb extends WebPlugin implements ClipboardPlugin {
     });
   }
 }
-
-const Clipboard = new ClipboardWeb();
-
-export { Clipboard };


### PR DESCRIPTION
On iOS the the Clipboard API requires user interaction, the way the plugin is initialized makes the first method invocation to lose the user gesture and throw `NotAllowedError`.
By not using the promise on `registerPlugin`, the gesture is properly forwarded in first invocation

reference
https://forum.ionicframework.com/t/capacitor-3-clipboard-error/207576/5