### PR TITLE
doc(storage): add async to setName example function

### DIFF
--- a/storage/README.md
+++ b/storage/README.md
@@ -29,7 +29,7 @@ npx cap sync
 ```typescript
 import { Storage } from '@capacitor/storage';
 
-const setName = () => {
+const setName = async () => {
   await Storage.set({
     key: 'name',
     value: 'Max',


### PR DESCRIPTION
Add `async` to `setName` example.