### PR TITLE
fix(push-notifications): proper return of push notification object properties

### DIFF
--- a/push-notifications/ios/Plugin/PushNotificationsHandler.swift
+++ b/push-notifications/ios/Plugin/PushNotificationsHandler.swift
@@ -83,7 +83,7 @@ public class PushNotificationsHandler: NSObject, NotificationHandlerProtocol {
             "title": request.content.title,
             "sound": notificationRequest["sound"]  ?? "",
             "body": request.content.body,
-            "extra": JSTypes.coerceDictionaryToJSObject(request.content.userInfo) ?? [:],
+            "data": JSTypes.coerceDictionaryToJSObject(request.content.userInfo) ?? [:],
             "actionTypeId": request.content.categoryIdentifier,
             "attachments": notificationRequest["attachments"]  ?? []
         ]

--- a/push-notifications/ios/Plugin/PushNotificationsHandler.swift
+++ b/push-notifications/ios/Plugin/PushNotificationsHandler.swift
@@ -81,8 +81,7 @@ public class PushNotificationsHandler: NSObject, NotificationHandlerProtocol {
         return [
             "id": request.identifier,
             "title": request.content.title,
-            "subtitle": request.content.subtitle,
-            "sound": notificationRequest["sound"]  ?? "",
+            "subtitle": request.content.subtitle,            
             "badge" : request.content.badge ?? 1,
             "body": request.content.body,
             "data": JSTypes.coerceDictionaryToJSObject(request.content.userInfo) ?? [:],            

--- a/push-notifications/ios/Plugin/PushNotificationsHandler.swift
+++ b/push-notifications/ios/Plugin/PushNotificationsHandler.swift
@@ -81,11 +81,11 @@ public class PushNotificationsHandler: NSObject, NotificationHandlerProtocol {
         return [
             "id": request.identifier,
             "title": request.content.title,
+            "subtitle": request.content.subtitle,
             "sound": notificationRequest["sound"]  ?? "",
+            "badge" : request.content.badge ?? 1,
             "body": request.content.body,
-            "data": JSTypes.coerceDictionaryToJSObject(request.content.userInfo) ?? [:],
-            "actionTypeId": request.content.categoryIdentifier,
-            "attachments": notificationRequest["attachments"]  ?? []
+            "data": JSTypes.coerceDictionaryToJSObject(request.content.userInfo) ?? [:],            
         ]
     }
 }

--- a/push-notifications/ios/Plugin/PushNotificationsHandler.swift
+++ b/push-notifications/ios/Plugin/PushNotificationsHandler.swift
@@ -76,8 +76,7 @@ public class PushNotificationsHandler: NSObject, NotificationHandlerProtocol {
 
     }
 
-    func makeNotificationRequestJSObject(_ request: UNNotificationRequest) -> JSObject {
-        let notificationRequest = notificationRequestLookup[request.identifier] ?? [:]
+    func makeNotificationRequestJSObject(_ request: UNNotificationRequest) -> JSObject {        
         return [
             "id": request.identifier,
             "title": request.content.title,


### PR DESCRIPTION
- Renames `extra` back to `data`
- Remove `actionTypeId` and `attachments`
- Adds back `subtitle` and `badge`

closes: https://github.com/ionic-team/capacitor-plugins/issues/332