### PR TITLE
fix(filesystem): Make ctime optional

### DIFF
--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -420,13 +420,13 @@ Required on Android, only when using <a href="#directory">`Directory.Documents`<
 
 #### StatResult
 
-| Prop        | Type                | Description                               | Since |
-| ----------- | ------------------- | ----------------------------------------- | ----- |
-| **`type`**  | <code>string</code> | Type of the file                          | 1.0.0 |
-| **`size`**  | <code>number</code> | Size of the file                          | 1.0.0 |
-| **`ctime`** | <code>number</code> | Time of creation in milliseconds          | 1.0.0 |
-| **`mtime`** | <code>number</code> | Time of last modification in milliseconds | 1.0.0 |
-| **`uri`**   | <code>string</code> | The uri of the file                       | 1.0.0 |
+| Prop        | Type                | Description                                                                          | Since |
+| ----------- | ------------------- | ------------------------------------------------------------------------------------ | ----- |
+| **`type`**  | <code>string</code> | Type of the file                                                                     | 1.0.0 |
+| **`size`**  | <code>number</code> | Size of the file                                                                     | 1.0.0 |
+| **`ctime`** | <code>number</code> | Time of creation in milliseconds. It's not available on Android 7 and older devices. | 1.0.0 |
+| **`mtime`** | <code>number</code> | Time of last modification in milliseconds.                                           | 1.0.0 |
+| **`uri`**   | <code>string</code> | The uri of the file                                                                  | 1.0.0 |
 
 
 #### StatOptions

--- a/filesystem/src/definitions.ts
+++ b/filesystem/src/definitions.ts
@@ -387,14 +387,16 @@ export interface StatResult {
   size: number;
 
   /**
-   * Time of creation in milliseconds
+   * Time of creation in milliseconds.
+   *
+   * It's not available on Android 7 and older devices.
    *
    * @since 1.0.0
    */
-  ctime: number;
+  ctime?: number;
 
   /**
-   * Time of last modification in milliseconds
+   * Time of last modification in milliseconds.
    *
    * @since 1.0.0
    */

--- a/filesystem/src/web.ts
+++ b/filesystem/src/web.ts
@@ -481,6 +481,8 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
       await this.dbRequest('put', [entry]);
     };
 
+    const ctime = fromObj.ctime ? fromObj.ctime : Date.now();
+
     switch (fromObj.type) {
       // The "from" object is a file
       case 'file': {
@@ -507,7 +509,7 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
 
         // Copy the mtime/ctime of a renamed file
         if (doRename) {
-          await updateTime(to, fromObj.ctime, fromObj.mtime);
+          await updateTime(to, ctime, fromObj.mtime);
         }
 
         // Resolve promise
@@ -528,7 +530,7 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
 
           // Copy the mtime/ctime of a renamed directory
           if (doRename) {
-            await updateTime(to, fromObj.ctime, fromObj.mtime);
+            await updateTime(to, ctime, fromObj.mtime);
           }
         } catch (e) {
           // ignore


### PR DESCRIPTION
As it's not available con Android versions lower than `O`

closes https://github.com/ionic-team/capacitor-plugins/issues/355