### PR TITLE
chore: Run CI on push to main or pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: CI
 on:
   push:
     branches:
-      - '**'
-  pull_request_target:
+      - main
+  pull_request:
     branches:
       - '**'
 


### PR DESCRIPTION
`push` event only contains last commit changes, so making it run on all branches is self-defeating as on every commit will run tests on the packages that changed on that commit and not on the whole PR, which might make us miss commits that broke the CI if last executed commit didn't break it but a previous one did.
But keep it for main branch as we sometimes push things directly.

Change `pull_request_target` to `pull_request` as we want to test the changes on the PR commit, not on the target commit.