### PR TITLE
fix(camera): Remove deprecated method saveCall(call)

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -81,7 +81,7 @@ public class CameraPlugin extends Plugin {
     public void getPhoto(PluginCall call) {
         isEdited = false;
 
-        saveCall(call);
+        bridge.saveCall(call);
 
         settings = getSettings(call);
 


### PR DESCRIPTION
Replace deprecated method `saveCall(call)` with suggested method `bridge.saveCall(call)`