### PR TITLE
fix(camera): Remove unused saveCall

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -80,11 +80,7 @@ public class CameraPlugin extends Plugin {
     @PluginMethod
     public void getPhoto(PluginCall call) {
         isEdited = false;
-
-        saveCall(call);
-
         settings = getSettings(call);
-
         doShow(call);
     }
 


### PR DESCRIPTION
the call is never retrieved but passed to the methods that need it, so it shouldn't be saved and also saveCall is deprecated