### PR TITLE
chore: Make update-all script to use latest

### DIFF
--- a/scripts/update-all.mjs
+++ b/scripts/update-all.mjs
@@ -11,11 +11,12 @@ execute(async () => {
     await Promise.all(
       PROJECTS.map(async project => [
         `@capacitor/${project}`,
-        `^${await getLatestVersion(`@capacitor/${project}`, 'next')}`,
+        `^${await getLatestVersion(`@capacitor/${project}`, 'latest')}`,
       ]),
     ),
   );
 
   await setLernaPackageDependencies(packages, 'devDependencies');
+  await setLernaPackageDependencies(packages, 'peerDependencies');
   await bootstrap();
 });


### PR DESCRIPTION
update-all script is updating to latest `@next` tag, but should use `@latest` now since capacitor 3 is final

also make it update devDependencies too