### PR TITLE
fix(camera): fix `preserveAspectRatio` option on iOS

### DIFF
--- a/camera/ios/Plugin/CameraTypes.swift
+++ b/camera/ios/Plugin/CameraTypes.swift
@@ -44,6 +44,7 @@ public struct CameraSettings {
     var allowEditing = false
     var shouldResize = false
     var shouldCorrectOrientation = true
+    var preserveAspectRatio = false
     var saveToGallery = false
     var presentationStyle = UIModalPresentationStyle.fullScreen
 }


### PR DESCRIPTION
Hi. 🤓

It looks like the resize functionality from Capacitor 2 never made it into the rewrite for the iOS Camera plugin. The [`width` and `height` options](https://capacitorjs.com/docs/apis/camera#imageoptions) are always used literally. But the `preserveAspectRatio` option is supposed to make `width` and `height` act as boundaries and maintain the aspect ratio when resizing.

For functionality reference, look at the behavior on Android.
See the original PR: https://github.com/ionic-team/capacitor/pull/3309