### PR TITLE
fix(camera): fix photo resizing on iOS

### DIFF
--- a/camera/ios/Plugin/CameraExtensions.swift
+++ b/camera/ios/Plugin/CameraExtensions.swift
@@ -88,9 +88,9 @@ internal extension UIImage {
         }
         // adjust to preserve aspect ratio
         var targetWidth = min(imageWidth, maxWidth)
-        var targetHeight = (imageHeight * targetWidth) / imageWidth
+        var targetHeight = (imageHeight * maxWidth) / imageWidth
         if targetHeight > maxHeight {
-            targetWidth = (imageWidth * targetHeight) / imageHeight
+            targetWidth = (imageWidth * maxHeight) / imageHeight
             targetHeight = maxHeight
         }
         // generate the new image and return


### PR DESCRIPTION
Hi again 🤓 

My [earlier PR](https://github.com/ionic-team/capacitor-plugins/pull/448) was made because resizing images on iOS by specifying `width` and `height` doesn't work, so I thought the logic was missing, but it turns out it just doesn't work.

To test the bug, just add `width` and `height` options to the TestApp Camera page. Notice it does not preserve the aspect ratio. This PR fixes that.