### PR TITLE
fix(camera): Hide the temporary file input for web

### DIFF
--- a/camera/src/web.ts
+++ b/camera/src/web.ts
@@ -62,6 +62,7 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
       input = document.createElement('input') as HTMLInputElement;
       input.id = '_capacitor-camera-input';
       input.type = 'file';
+      input.style.visibility = 'hidden';
       document.body.appendChild(input);
     }
 


### PR DESCRIPTION
Otherwise it shows up while the file prompt is open