### PR TITLE
fix(geolocation): Make getCurrentPosition return only once

### DIFF
--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/GeolocationPlugin.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/GeolocationPlugin.java
@@ -115,7 +115,7 @@ public class GeolocationPlugin extends Plugin {
         implementation.sendLocation(
             enableHighAccuracy,
             timeout,
-            false,
+            true,
             new LocationResultCallback() {
                 @Override
                 public void success(Location location) {


### PR DESCRIPTION
closes https://github.com/ionic-team/capacitor-plugins/issues/376