### PR TITLE
fix(app): use alternative to deprecated versionCode

### DIFF
--- a/app/android/src/main/java/com/capacitorjs/plugins/app/AppPlugin.java
+++ b/app/android/src/main/java/com/capacitorjs/plugins/app/AppPlugin.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.net.Uri;
+import android.os.Build;
 import androidx.activity.OnBackPressedCallback;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
@@ -80,7 +81,11 @@ public class AppPlugin extends Plugin {
             String appName = stringId == 0 ? applicationInfo.nonLocalizedLabel.toString() : getContext().getString(stringId);
             data.put("name", appName);
             data.put("id", pinfo.packageName);
-            data.put("build", Integer.toString(pinfo.versionCode));
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                data.put("build", Long.toString(pinfo.getLongVersionCode()));
+            } else {
+                data.put("build", Integer.toString(pinfo.versionCode));
+            }
             data.put("version", pinfo.versionName);
             call.resolve(data);
         } catch (Exception ex) {


### PR DESCRIPTION
where available, use getLongVersionCode as versionCode is deprecated

closes https://github.com/ionic-team/capacitor-plugins/issues/363