### PR TITLE
fix(camera): Return the full webPath

### DIFF
--- a/camera/ios/Plugin/CameraPlugin.swift
+++ b/camera/ios/Plugin/CameraPlugin.swift
@@ -213,7 +213,7 @@ private extension CameraPlugin {
             call?.resolve([
                 "path": fileURL.absoluteString,
                 "exif": processedImage.exifData,
-                "webPath": webURL.path,
+                "webPath": webURL.absoluteString,
                 "format": "jpeg"
             ])
         }


### PR DESCRIPTION
.path removes the scheme and hostname from the url, use absoluteString instead

closes https://github.com/ionic-team/capacitor-plugins/issues/501