### PR TITLE
feat: Added Device Machine Model name for iOS devices

### DIFF
--- a/device/README.md
+++ b/device/README.md
@@ -119,6 +119,7 @@ Get the device's current language locale code.
 | --------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----- |
 | **`name`**            | <code>string</code>                                         | The name of the device. For example, "John's iPhone". This is only supported on iOS and Android 7.1 or above. | 1.0.0 |
 | **`model`**           | <code>string</code>                                         | The device model. For example, "iPhone".                                                                      | 1.0.0 |
+| **`modelName`**       | <code>string</code>                                         | The device machine model name. For example, "iPhone13,2".                                                                      | 1.0.3 |
 | **`platform`**        | <code>'ios' \| 'android' \| 'web'</code>                    | The device platform (lowercase).                                                                              | 1.0.0 |
 | **`operatingSystem`** | <code><a href="#operatingsystem">OperatingSystem</a></code> | The operating system of the device.                                                                           | 1.0.0 |
 | **`osVersion`**       | <code>string</code>                                         | The version of the device OS.                                                                                 | 1.0.0 |

--- a/device/ios/Plugin/DevicePlugin.swift
+++ b/device/ios/Plugin/DevicePlugin.swift
@@ -24,12 +24,19 @@ public class DevicePlugin: CAPPlugin {
         let diskFree = implementation.getFreeDiskSize() ?? 0
         let diskTotal = implementation.getTotalDiskSize() ?? 0
 
+        var size = 0
+        sysctlbyname("hw.machine", nil, &size, nil, 0)
+        var machine = [CChar](repeating: 0, count: size)
+        sysctlbyname("hw.machine", &machine, &size, nil, 0)
+        let modelName = String(cString: machine)
+
         call.resolve([
             "memUsed": memUsed,
             "diskFree": diskFree,
             "diskTotal": diskTotal,
             "name": UIDevice.current.name,
             "model": UIDevice.current.model,
+            "modelName": modelName,
             "operatingSystem": "ios",
             "osVersion": UIDevice.current.systemVersion,
             "platform": "ios",

--- a/device/src/definitions.ts
+++ b/device/src/definitions.ts
@@ -30,6 +30,15 @@ export interface DeviceInfo {
   model: string;
 
   /**
+   * The device machine model name. For example, "iPhone13,2".
+   *
+   * This is only supported on iOS
+   *
+   * @since 1.0.1
+   */
+  modelName?: string;
+
+  /**
    * The device platform (lowercase).
    *
    * @since 1.0.0

--- a/device/src/definitions.ts
+++ b/device/src/definitions.ts
@@ -34,7 +34,7 @@ export interface DeviceInfo {
    *
    * This is only supported on iOS
    *
-   * @since 1.0.1
+   * @since 1.0.3
    */
   modelName?: string;
 

--- a/device/src/web.ts
+++ b/device/src/web.ts
@@ -38,6 +38,7 @@ export class DeviceWeb extends WebPlugin implements DevicePlugin {
 
     return {
       model: uaFields.model,
+      modelName: uaFields.modelName,
       platform: <const>'web',
       operatingSystem: uaFields.operatingSystem,
       osVersion: uaFields.osVersion,


### PR DESCRIPTION
### iOS
This feature needs many developers on Capacitor. As i tested, all devices on ios prints device machine name as well

For example:
```
{
  ...
    model: "iPhone",
    modelName: "iPhone13,1"
  ...
}
```

### Android
In android devices `android.os.Build.MODEL` prints as well. So, no need to edit.