### PR TITLE
fix(camera): Reset exif orientation if corrected

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/ImageUtils.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/ImageUtils.java
@@ -78,7 +78,9 @@ public class ImageUtils {
             if (orientation != 0) {
                 Matrix matrix = new Matrix();
                 matrix.postRotate(orientation);
-
+                ExifInterface exif = new ExifInterface(imageUri.getPath());
+                exif.resetOrientation();
+                exif.saveAttributes();
                 return transform(bitmap, matrix);
             } else {
                 return bitmap;


### PR DESCRIPTION
If `getPhoto` is called with `correctOrientation: true` and the photo gets the orientation corrected, reset the exif orientation too.

closes https://github.com/ionic-team/capacitor-plugins/issues/503