### PR TITLE
feat(splash-screen): Add layoutName configuration option for Android

### DIFF
--- a/splash-screen/README.md
+++ b/splash-screen/README.md
@@ -84,6 +84,7 @@ These config values are available:
 | **`spinnerColor`**              | <code>string</code>                                                                                                           | Color of the spinner in hex format, #RRGGBB or #RRGGBBAA.                                                                                                               |                     | 1.0.0 |
 | **`splashFullScreen`**          | <code>boolean</code>                                                                                                          | Hide the status bar on the Splash Screen. Only available on Android.                                                                                                    |                     | 1.0.0 |
 | **`splashImmersive`**           | <code>boolean</code>                                                                                                          | Hide the status bar and the software navigation buttons on the Splash Screen. Only available on Android.                                                                |                     | 1.0.0 |
+| **`layoutName`**                | <code>string</code>                                                                                                           | Allows to specify a layout xml file that would be used as the splash layout instead of the default ImageView. Only available on Android.                                |                     | 1.1.0 |
 
 ### Examples
 
@@ -103,7 +104,8 @@ In `capacitor.config.json`:
       "iosSpinnerStyle": "small",
       "spinnerColor": "#999999",
       "splashFullScreen": true,
-      "splashImmersive": true
+      "splashImmersive": true,
+      "layoutName": "launch_screen"
     }
   }
 }
@@ -130,6 +132,7 @@ const config: CapacitorConfig = {
       spinnerColor: "#999999",
       splashFullScreen: true,
       splashImmersive: true,
+      layoutName: "launch_screen",
     },
   },
 };

--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenConfig.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenConfig.java
@@ -15,6 +15,7 @@ public class SplashScreenConfig {
     private boolean immersive = false;
     private boolean fullScreen = false;
     private ScaleType scaleType = ScaleType.FIT_XY;
+    private String layoutName;
 
     public Integer getBackgroundColor() {
         return backgroundColor;
@@ -98,5 +99,13 @@ public class SplashScreenConfig {
 
     public void setScaleType(ScaleType scaleType) {
         this.scaleType = scaleType;
+    }
+
+    public String getLayoutName() {
+        return layoutName;
+    }
+
+    public void setLayoutName(String layoutName) {
+        this.layoutName = layoutName;
     }
 }

--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
@@ -141,6 +141,9 @@ public class SplashScreenPlugin extends Plugin {
 
         Boolean showSpinner = getConfig().getBoolean("showSpinner", config.isShowSpinner());
         config.setShowSpinner(showSpinner);
+        if (getConfig().getString("layoutName") != null) {
+            config.setLayoutName(getConfig().getString("layoutName"));
+        }
 
         return config;
     }

--- a/splash-screen/src/definitions.ts
+++ b/splash-screen/src/definitions.ts
@@ -124,6 +124,17 @@ declare module '@capacitor/cli' {
        * @example true
        */
       splashImmersive?: boolean;
+
+      /**
+       * Allows to specify a layout xml file that would be used
+       * as the splash layout instead of the default ImageView.
+       *
+       * Only available on Android.
+       *
+       * @since 1.1.0
+       * @example "launch_screen"
+       */
+      layoutName?: string;
     };
   }
 }


### PR DESCRIPTION
alternative to https://github.com/ionic-team/capacitor-plugins/pull/519
it allows to use a layout without using Dialog and all options keep working