### PR TITLE
fix(local-notifications): Fixed wrong rollup config

### DIFF
--- a/local-notifications/rollup.config.js
+++ b/local-notifications/rollup.config.js
@@ -4,9 +4,9 @@ export default {
     {
       file: 'dist/plugin.js',
       format: 'iife',
-      name: 'capacitorHaptics',
+      name: 'capacitorLocalNotifications',
       globals: {
-        '@capacitor/core': 'capacitorLocalNotifications',
+        '@capacitor/core': 'capacitorExports',
       },
       sourcemap: true,
       inlineDynamicImports: true,


### PR DESCRIPTION
I tried to use the latest version of the Local Notifications plugin by linking the `dist/plugin.js` and it turns out the configuration of this plugin is wrong. Instead of using `capacitorLocalNotifications` it was set to `capacitorHaptics` and instead of using the globals `capacitorExports` it was using `capacitorLocalNotifications`.

Console output:
```
capacitor-local-notifications.js:150 Uncaught ReferenceError: capacitorLocalNotifications is not defined
    at capacitor-local-notifications.js:150
(anonymous) @ capacitor-local-notifications.js:150
```
