### PR TITLE
feat(storage): make StorageConfiguration init public

### DIFF
--- a/storage/ios/Plugin/Storage.swift
+++ b/storage/ios/Plugin/Storage.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 public struct StorageConfiguration {
-    enum Group {
+    public enum Group {
         case named(String), cordovaNativeStorage
     }
 
     let group: Group
 
-    init(for group: Group = .named("CapacitorStorage")) {
+    public init(for group: Group = .named("CapacitorStorage")) {
         self.group = group
     }
 }


### PR DESCRIPTION
In order to use StoragePlugin in the native context the StorageConfiguration inits needs to be public