### PR TITLE
fix(camera): Properly reset orientation exif if corrected

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -347,14 +347,15 @@ public class CameraPlugin extends Plugin {
      * @param u
      */
     private void returnResult(PluginCall call, Bitmap bitmap, Uri u) {
+        ExifWrapper exif = ImageUtils.getExifData(getContext(), bitmap, u);
+
         try {
-            bitmap = prepareBitmap(bitmap, u);
+            bitmap = prepareBitmap(bitmap, u, exif);
         } catch (IOException e) {
             call.reject(UNABLE_TO_PROCESS_IMAGE);
             return;
         }
 
-        ExifWrapper exif = ImageUtils.getExifData(getContext(), bitmap, u);
 
         // Compress the final image and prepare for output to client
         ByteArrayOutputStream bitmapOutputStream = new ByteArrayOutputStream();
@@ -432,9 +433,9 @@ public class CameraPlugin extends Plugin {
      * @param imageUri
      * @return
      */
-    private Bitmap prepareBitmap(Bitmap bitmap, Uri imageUri) throws IOException {
+    private Bitmap prepareBitmap(Bitmap bitmap, Uri imageUri, ExifWrapper exif) throws IOException {
         if (settings.isShouldCorrectOrientation()) {
-            final Bitmap newBitmap = ImageUtils.correctOrientation(getContext(), bitmap, imageUri);
+            final Bitmap newBitmap = ImageUtils.correctOrientation(getContext(), bitmap, imageUri, exif);
             bitmap = replaceBitmap(bitmap, newBitmap);
         }
 

--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -348,14 +348,12 @@ public class CameraPlugin extends Plugin {
      */
     private void returnResult(PluginCall call, Bitmap bitmap, Uri u) {
         ExifWrapper exif = ImageUtils.getExifData(getContext(), bitmap, u);
-
         try {
             bitmap = prepareBitmap(bitmap, u, exif);
         } catch (IOException e) {
             call.reject(UNABLE_TO_PROCESS_IMAGE);
             return;
         }
-
         // Compress the final image and prepare for output to client
         ByteArrayOutputStream bitmapOutputStream = new ByteArrayOutputStream();
         bitmap.compress(Bitmap.CompressFormat.JPEG, settings.getQuality(), bitmapOutputStream);
@@ -430,6 +428,7 @@ public class CameraPlugin extends Plugin {
      * recycling the old one in the process
      * @param bitmap
      * @param imageUri
+     * @param exif
      * @return
      */
     private Bitmap prepareBitmap(Bitmap bitmap, Uri imageUri, ExifWrapper exif) throws IOException {

--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -356,7 +356,6 @@ public class CameraPlugin extends Plugin {
             return;
         }
 
-
         // Compress the final image and prepare for output to client
         ByteArrayOutputStream bitmapOutputStream = new ByteArrayOutputStream();
         bitmap.compress(Bitmap.CompressFormat.JPEG, settings.getQuality(), bitmapOutputStream);

--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/ExifWrapper.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/ExifWrapper.java
@@ -198,4 +198,11 @@ public class ExifWrapper {
             destExif.saveAttributes();
         } catch (Exception ex) {}
     }
+
+    public void resetOrientation() {
+        try {
+            exif.resetOrientation();
+            exif.saveAttributes();
+        } catch (Exception ex) {}
+    }
 }

--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/ExifWrapper.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/ExifWrapper.java
@@ -200,9 +200,6 @@ public class ExifWrapper {
     }
 
     public void resetOrientation() {
-        try {
-            exif.resetOrientation();
-            exif.saveAttributes();
-        } catch (Exception ex) {}
+        exif.resetOrientation();
     }
 }

--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/ImageUtils.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/ImageUtils.java
@@ -69,7 +69,7 @@ public class ImageUtils {
      * @param imageUri
      * @return
      */
-    public static Bitmap correctOrientation(final Context c, final Bitmap bitmap, final Uri imageUri) throws IOException {
+    public static Bitmap correctOrientation(final Context c, final Bitmap bitmap, final Uri imageUri, ExifWrapper exif) throws IOException {
         if (Build.VERSION.SDK_INT < 24) {
             return correctOrientationOlder(c, bitmap, imageUri);
         } else {
@@ -78,9 +78,7 @@ public class ImageUtils {
             if (orientation != 0) {
                 Matrix matrix = new Matrix();
                 matrix.postRotate(orientation);
-                ExifInterface exif = new ExifInterface(imageUri.getPath());
                 exif.resetOrientation();
-                exif.saveAttributes();
                 return transform(bitmap, matrix);
             } else {
                 return bitmap;

--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/ImageUtils.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/ImageUtils.java
@@ -67,6 +67,7 @@ public class ImageUtils {
      * the appropriate amount for portrait mode
      * @param bitmap
      * @param imageUri
+     * @param exif
      * @return
      */
     public static Bitmap correctOrientation(final Context c, final Bitmap bitmap, final Uri imageUri, ExifWrapper exif) throws IOException {


### PR DESCRIPTION
Pass the exif object to ImageUtils and correct the orientation in it instead of in the file path to prevent problems with content urls.

closes https://github.com/ionic-team/capacitor-plugins/issues/524
