### PR TITLE
fix(splash-screen): Use configured storyboard instead of hardcoded value

### DIFF
--- a/splash-screen/ios/Plugin/SplashScreen.swift
+++ b/splash-screen/ios/Plugin/SplashScreen.swift
@@ -88,7 +88,8 @@ import Capacitor
     }
 
     private func buildViews() {
-        if let vc = UIStoryboard(name: "LaunchScreen", bundle: nil).instantiateInitialViewController() {
+        let storyboardName = Bundle.main.infoDictionary?["UILaunchStoryboardName"] as? String ?? "LaunchScreen"
+        if let vc = UIStoryboard(name: storyboardName, bundle: nil).instantiateInitialViewController() {
             viewController = vc
         }
 


### PR DESCRIPTION
We are using the hardcoded `LaunchScreen` value for the splash screen plugins, but users can change the launch storyboard by changing the value of `UILaunchStoryboardName` entry in the info.plist, so we should read the value, and if present use it instead of the hardcoded `LaunchScreen`

closes https://github.com/ionic-team/capacitor-plugins/issues/534
