### PR TITLE
fix(camera): Make allowEdit work on all devices

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -3,6 +3,7 @@ package com.capacitorjs.plugins.camera;
 import android.Manifest;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
@@ -516,16 +517,9 @@ public class CameraPlugin extends Plugin {
     }
 
     private void editImage(PluginCall call, Bitmap bitmap, Uri uri, ByteArrayOutputStream bitmapOutputStream) {
-        Uri origPhotoUri = uri;
-        if (imageFileUri != null) {
-            origPhotoUri = imageFileUri;
-        }
         try {
-            Intent editIntent = createEditIntent(origPhotoUri, false);
-            startActivityForResult(call, editIntent, "processEditedImage");
-        } catch (SecurityException ex) {
             Uri tempImage = getTempImage(bitmap, uri, bitmapOutputStream);
-            Intent editIntent = createEditIntent(tempImage, true);
+            Intent editIntent = createEditIntent(tempImage);
             if (editIntent != null) {
                 startActivityForResult(call, editIntent, "processEditedImage");
             } else {
@@ -536,25 +530,26 @@ public class CameraPlugin extends Plugin {
         }
     }
 
-    private Intent createEditIntent(Uri origPhotoUri, boolean expose) {
-        Uri editUri = origPhotoUri;
+    private Intent createEditIntent(Uri origPhotoUri) {
         try {
-            if (expose) {
-                editUri =
-                    FileProvider.getUriForFile(
-                        getActivity(),
-                        getContext().getPackageName() + ".fileprovider",
-                        new File(origPhotoUri.getPath())
-                    );
-            }
+            Uri editUri = FileProvider.getUriForFile(
+                getActivity(),
+                getContext().getPackageName() + ".fileprovider",
+                new File(origPhotoUri.getPath())
+            );
             Intent editIntent = new Intent(Intent.ACTION_EDIT);
             editIntent.setDataAndType(editUri, "image/*");
-            File editedFile = CameraUtils.createImageFile(getActivity());
-            imageEditedFileSavePath = editedFile.getAbsolutePath();
-            Uri editedUri = Uri.fromFile(editedFile);
-            editIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            editIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-            editIntent.putExtra(MediaStore.EXTRA_OUTPUT, editedUri);
+            imageEditedFileSavePath = editUri.toString();
+            int flags = Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION;
+            editIntent.addFlags(flags);
+            editIntent.putExtra(MediaStore.EXTRA_OUTPUT, editUri);
+            List<ResolveInfo> resInfoList = getContext()
+                .getPackageManager()
+                .queryIntentActivities(editIntent, PackageManager.MATCH_DEFAULT_ONLY);
+            for (ResolveInfo resolveInfo : resInfoList) {
+                String packageName = resolveInfo.activityInfo.packageName;
+                getContext().grantUriPermission(packageName, editUri, flags);
+            }
             return editIntent;
         } catch (Exception ex) {
             return null;


### PR DESCRIPTION
Hopefully on all devices, but maybe not all, I tested on android 5, 7, 9 and 11 without problems

With the move from request codes to activity launcher the code no longer catch the security exception, so now will always create a copy of the file and edit the copy instead of trying to edit the returned content urls, which could cause security exceptions in some devices.

Also calls `grantUriPermission` for the url passed to the edit intent, shouldn't be necessary, but on Android 11 it doesn't work without it.


closes https://github.com/ionic-team/capacitor-plugins/issues/306
closes https://github.com/ionic-team/capacitor-plugins/issues/307