### PR TITLE
fix(camera): avoid error if image has no orientation

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/ImageUtils.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/ImageUtils.java
@@ -71,38 +71,15 @@ public class ImageUtils {
      * @return
      */
     public static Bitmap correctOrientation(final Context c, final Bitmap bitmap, final Uri imageUri, ExifWrapper exif) throws IOException {
-        if (Build.VERSION.SDK_INT < 24) {
-            return correctOrientationOlder(c, bitmap, imageUri);
-        } else {
-            final int orientation = getOrientation(c, imageUri);
-
-            if (orientation != 0) {
-                Matrix matrix = new Matrix();
-                matrix.postRotate(orientation);
-                exif.resetOrientation();
-                return transform(bitmap, matrix);
-            } else {
-                return bitmap;
-            }
-        }
-    }
-
-    private static Bitmap correctOrientationOlder(final Context c, final Bitmap bitmap, final Uri imageUri) {
-        // TODO: To be tested on older phone using Android API < 24
-
-        String[] orientationColumn = { MediaStore.Images.Media.DATA, MediaStore.Images.Media.ORIENTATION };
-        Cursor cur = c.getContentResolver().query(imageUri, orientationColumn, null, null, null);
-        int orientation = -1;
-        if (cur != null && cur.moveToFirst()) {
-            orientation = cur.getInt(cur.getColumnIndex(orientationColumn[0]));
-        }
-        Matrix matrix = new Matrix();
-
-        if (orientation != -1) {
+        final int orientation = getOrientation(c, imageUri);
+        if (orientation != 0) {
+            Matrix matrix = new Matrix();
             matrix.postRotate(orientation);
+            exif.resetOrientation();
+            return transform(bitmap, matrix);
+        } else {
+            return bitmap;
         }
-
-        return transform(bitmap, matrix);
     }
 
     private static int getOrientation(final Context c, final Uri imageUri) throws IOException {


### PR DESCRIPTION
On Android <24 an error is thrown on the correctOrientationOlder method if the image has no orientation information. 

Since we are using AndroidX's ExifInterface we no longer need the correctOrientationOlder because AndroidX is supposed to be backward compatible, so should be handling this already.

I've verified that the error is no longer shown on my android 5 device.
