### PR TITLE
fix(camera): return original image if editing is cancelled

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -76,6 +76,7 @@ public class CameraPlugin extends Plugin {
     private String imageFileSavePath;
     private String imageEditedFileSavePath;
     private Uri imageFileUri;
+    private Uri imagePickedContentUri;
     private boolean isEdited = false;
 
     private CameraSettings settings = new CameraSettings();
@@ -283,10 +284,16 @@ public class CameraPlugin extends Plugin {
 
         Uri u = data.getData();
 
+        imagePickedContentUri = u;
+
+        processPickedImage(u, call);
+    }
+
+    private void processPickedImage(Uri imageUri, PluginCall call) {
         InputStream imageStream = null;
 
         try {
-            imageStream = getContext().getContentResolver().openInputStream(u);
+            imageStream = getContext().getContentResolver().openInputStream(imageUri);
             Bitmap bitmap = BitmapFactory.decodeStream(imageStream);
 
             if (bitmap == null) {
@@ -294,7 +301,7 @@ public class CameraPlugin extends Plugin {
                 return;
             }
 
-            returnResult(call, bitmap, u);
+            returnResult(call, bitmap, imageUri);
         } catch (OutOfMemoryError err) {
             call.reject("Out of memory");
         } catch (FileNotFoundException ex) {
@@ -315,8 +322,13 @@ public class CameraPlugin extends Plugin {
         isEdited = true;
 
         if (result.getResultCode() == Activity.RESULT_CANCELED) {
-            // User cancelled the edit operation, return the original image
-            processCameraImage(call, result);
+            // User cancelled the edit operation, if this file was picked from photos,
+            // process the original picked image, otherwise process it as a camera photo
+            if (imagePickedContentUri != null) {
+                processPickedImage(imagePickedContentUri, call);
+            } else {
+                processCameraImage(call, result);
+            }
         } else {
             processPickedImage(call, result);
         }
@@ -401,6 +413,7 @@ public class CameraPlugin extends Plugin {
         }
         imageFileSavePath = null;
         imageFileUri = null;
+        imagePickedContentUri = null;
         imageEditedFileSavePath = null;
     }
 


### PR DESCRIPTION
There's a fairly popular issue on the old repo ([#2835](https://github.com/ionic-team/capacitor/issues/2835)) on what to do when `allowEdit: true` is set when calling `Camera.getPhoto()` and the user cancels the edit operation.

This change returns the original image if the editing activity result code comes back as canceled, and I think it makes sense if you consider the UX that Android uses for editing. If the user taps above the bottom sheet in the below screenshot, I think the intention is to keep the original image but skip editing. This also makes sense since `allowEdit` is a _hint_, not a requirement.

Without this change, the activity is treated as cancelled and no image is returned.

![OQuEbCWY jpg large](https://user-images.githubusercontent.com/11214/130864903-ad38865f-916a-42da-b2cf-0f69e6f0602a.jpg)