### PR TITLE
feat(storage): Add removeOld function

### DIFF
--- a/storage/README.md
+++ b/storage/README.md
@@ -63,6 +63,7 @@ This method can also be used to store non-string values, such as numbers and boo
 * [`clear()`](#clear)
 * [`keys()`](#keys)
 * [`migrate()`](#migrate)
+* [`removeOld()`](#removeold)
 * [Interfaces](#interfaces)
 
 </docgen-index>
@@ -180,10 +181,24 @@ Migrate data from the Capacitor 2 Storage plugin.
 
 This action is non-destructive. It will not remove old data and will only
 write new data if they key was not already set.
+To remove the old data after being migrated, call removeOld().
 
 **Returns:** <code>Promise&lt;<a href="#migrateresult">MigrateResult</a>&gt;</code>
 
 **Since:** 1.0.0
+
+--------------------
+
+
+### removeOld()
+
+```typescript
+removeOld() => Promise<void>
+```
+
+Removes old data with `_cap_` prefix from the Capacitor 2 Storage plugin.
+
+**Since:** 1.1.0
 
 --------------------
 

--- a/storage/android/src/main/java/com/capacitorjs/plugins/storage/StoragePlugin.java
+++ b/storage/android/src/main/java/com/capacitorjs/plugins/storage/StoragePlugin.java
@@ -121,4 +121,9 @@ public class StoragePlugin extends Plugin {
         ret.put("existing", new JSArray(existing));
         call.resolve(ret);
     }
+
+    @PluginMethod
+    public void removeOld(PluginCall call) {
+        call.resolve();
+    }
 }

--- a/storage/ios/Plugin/StoragePlugin.m
+++ b/storage/ios/Plugin/StoragePlugin.m
@@ -11,4 +11,5 @@ CAP_PLUGIN(StoragePlugin, "Storage",
            CAP_PLUGIN_METHOD(keys, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(clear, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(migrate, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(removeOld, CAPPluginReturnPromise);
 )

--- a/storage/ios/Plugin/StoragePlugin.swift
+++ b/storage/ios/Plugin/StoragePlugin.swift
@@ -94,4 +94,13 @@ public class StoragePlugin: CAPPlugin {
             "existing": existing
         ])
     }
+
+    @objc func removeOld(_ call: CAPPluginCall) {
+        let oldPrefix = "_cap_"
+        let oldKeys = UserDefaults.standard.dictionaryRepresentation().keys.filter { $0.hasPrefix(oldPrefix) }
+        for oldKey in oldKeys {
+            UserDefaults.standard.removeObject(forKey: oldKey)
+        }
+        call.resolve()
+    }
 }

--- a/storage/src/definitions.ts
+++ b/storage/src/definitions.ts
@@ -136,8 +136,16 @@ export interface StoragePlugin {
    *
    * This action is non-destructive. It will not remove old data and will only
    * write new data if they key was not already set.
+   * To remove the old data after being migrated, call removeOld().
    *
    * @since 1.0.0
    */
   migrate(): Promise<MigrateResult>;
+
+  /**
+   * Removes old data with `_cap_` prefix from the Capacitor 2 Storage plugin.
+   *
+   * @since 1.1.0
+   */
+  removeOld(): Promise<void>;
 }

--- a/storage/src/web.ts
+++ b/storage/src/web.ts
@@ -68,6 +68,14 @@ export class StorageWeb extends WebPlugin implements StoragePlugin {
     return { migrated, existing };
   }
 
+  public async removeOld(): Promise<void> {
+    const oldprefix = '_cap_';
+    const keys = Object.keys(this.impl).filter(k => k.indexOf(oldprefix) === 0);
+    for (const oldkey of keys) {
+      this.impl.removeItem(oldkey);
+    }
+  }
+
   private get impl(): Storage {
     return window.localStorage;
   }


### PR DESCRIPTION
to remove data prefixed with `_cap_` that can't be removed otherwise after being migrated

android didn't use the prefix, so the code does nothing there

closes https://github.com/ionic-team/capacitor-plugins/issues/541