### PR TITLE
feat(geolocation): Throw error if location is disabled

### DIFF
--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
@@ -3,8 +3,8 @@ package com.capacitorjs.plugins.geolocation;
 import android.content.Context;
 import android.location.Location;
 import android.location.LocationManager;
+import androidx.core.location.LocationManagerCompat;
 import com.google.android.gms.location.FusedLocationProviderClient;
-import com.google.android.gms.location.LocationAvailability;
 import com.google.android.gms.location.LocationCallback;
 import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationResult;
@@ -41,45 +41,42 @@ public class Geolocation {
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(context);
 
         LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-        boolean networkEnabled = false;
+        if (LocationManagerCompat.isLocationEnabled(lm)) {
+            boolean networkEnabled = false;
 
-        try {
-            networkEnabled = lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
-        } catch (Exception ex) {}
+            try {
+                networkEnabled = lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+            } catch (Exception ex) {}
 
-        LocationRequest locationRequest = new LocationRequest();
-        locationRequest.setMaxWaitTime(timeout);
-        locationRequest.setInterval(10000);
-        locationRequest.setFastestInterval(5000);
-        int lowPriority = networkEnabled ? LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY : LocationRequest.PRIORITY_LOW_POWER;
-        int priority = enableHighAccuracy ? LocationRequest.PRIORITY_HIGH_ACCURACY : lowPriority;
-        locationRequest.setPriority(priority);
+            LocationRequest locationRequest = new LocationRequest();
+            locationRequest.setMaxWaitTime(timeout);
+            locationRequest.setInterval(10000);
+            locationRequest.setFastestInterval(5000);
+            int lowPriority = networkEnabled ? LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY : LocationRequest.PRIORITY_LOW_POWER;
+            int priority = enableHighAccuracy ? LocationRequest.PRIORITY_HIGH_ACCURACY : lowPriority;
+            locationRequest.setPriority(priority);
 
-        locationCallback =
-            new LocationCallback() {
-                @Override
-                public void onLocationResult(LocationResult locationResult) {
-                    if (getCurrentPosition) {
-                        clearLocationUpdates();
-                    }
-                    Location lastLocation = locationResult.getLastLocation();
-                    if (lastLocation == null) {
-                        resultCallback.error("location unavailable");
-                    } else {
-                        resultCallback.success(lastLocation);
-                    }
-                }
+            locationCallback =
+                    new LocationCallback() {
+                        @Override
+                        public void onLocationResult(LocationResult locationResult) {
+                            if (getCurrentPosition) {
+                                clearLocationUpdates();
+                            }
+                            Location lastLocation = locationResult.getLastLocation();
+                            if (lastLocation == null) {
+                                resultCallback.error("location unavailable");
+                            } else {
+                                resultCallback.success(lastLocation);
+                            }
+                        }
+                    };
 
-                @Override
-                public void onLocationAvailability(LocationAvailability availability) {
-                    if (!availability.isLocationAvailable()) {
-                        resultCallback.error("location unavailable");
-                        clearLocationUpdates();
-                    }
-                }
-            };
+            fusedLocationClient.requestLocationUpdates(locationRequest, locationCallback, null);
+        } else {
+            resultCallback.error("location disabled");
+        }
 
-        fusedLocationClient.requestLocationUpdates(locationRequest, locationCallback, null);
     }
 
     public void clearLocationUpdates() {

--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
@@ -57,26 +57,25 @@ public class Geolocation {
             locationRequest.setPriority(priority);
 
             locationCallback =
-                    new LocationCallback() {
-                        @Override
-                        public void onLocationResult(LocationResult locationResult) {
-                            if (getCurrentPosition) {
-                                clearLocationUpdates();
-                            }
-                            Location lastLocation = locationResult.getLastLocation();
-                            if (lastLocation == null) {
-                                resultCallback.error("location unavailable");
-                            } else {
-                                resultCallback.success(lastLocation);
-                            }
+                new LocationCallback() {
+                    @Override
+                    public void onLocationResult(LocationResult locationResult) {
+                        if (getCurrentPosition) {
+                            clearLocationUpdates();
                         }
-                    };
+                        Location lastLocation = locationResult.getLastLocation();
+                        if (lastLocation == null) {
+                            resultCallback.error("location unavailable");
+                        } else {
+                            resultCallback.success(lastLocation);
+                        }
+                    }
+                };
 
             fusedLocationClient.requestLocationUpdates(locationRequest, locationCallback, null);
         } else {
             resultCallback.error("location disabled");
         }
-
     }
 
     public void clearLocationUpdates() {


### PR DESCRIPTION
By checking `isLocationEnabled` instead of relying on `isLocationAvailable`, we can throw an error if the location is disabled by the user, and not having the `onLocationAvailability` callback workarounds the google play services bug that makes `isLocationAvailable()` to be always false.