### PR TITLE
fix(camera): set settings again on callbacks

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -256,6 +256,7 @@ public class CameraPlugin extends Plugin {
 
     @ActivityCallback
     public void processCameraImage(PluginCall call, ActivityResult result) {
+        settings = getSettings(call);
         if (imageFileSavePath == null) {
             call.reject(IMAGE_PROCESS_NO_FILE_ERROR);
             return;
@@ -276,6 +277,7 @@ public class CameraPlugin extends Plugin {
 
     @ActivityCallback
     public void processPickedImage(PluginCall call, ActivityResult result) {
+        settings = getSettings(call);
         Intent data = result.getData();
         if (data == null) {
             call.reject("No image picked");
@@ -320,7 +322,7 @@ public class CameraPlugin extends Plugin {
     @ActivityCallback
     private void processEditedImage(PluginCall call, ActivityResult result) {
         isEdited = true;
-
+        settings = getSettings(call);
         if (result.getResultCode() == Activity.RESULT_CANCELED) {
             // User cancelled the edit operation, if this file was picked from photos,
             // process the original picked image, otherwise process it as a camera photo


### PR DESCRIPTION
If the app gets killed when the camera intent is launched, the settings go back to the default values.
This PR sets the settings again from the restored plugin call.

