### PR TITLE
feat(camera): Return if image was saved to gallery

### DIFF
--- a/camera/README.md
+++ b/camera/README.md
@@ -143,14 +143,15 @@ Request camera and photo album permissions
 
 #### Photo
 
-| Prop               | Type                | Description                                                                                                                                                                   | Since |
-| ------------------ | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| **`base64String`** | <code>string</code> | The base64 encoded string representation of the image, if using <a href="#cameraresulttype">CameraResultType.Base64</a>.                                                      | 1.0.0 |
-| **`dataUrl`**      | <code>string</code> | The url starting with 'data:image/jpeg;base64,' and the base64 encoded string representation of the image, if using <a href="#cameraresulttype">CameraResultType.DataUrl</a>. | 1.0.0 |
-| **`path`**         | <code>string</code> | If using <a href="#cameraresulttype">CameraResultType.Uri</a>, the path will contain a full, platform-specific file URL that can be read later using the Filsystem API.       | 1.0.0 |
-| **`webPath`**      | <code>string</code> | webPath returns a path that can be used to set the src attribute of an image for efficient loading and rendering.                                                             | 1.0.0 |
-| **`exif`**         | <code>any</code>    | Exif data, if any, retrieved from the image                                                                                                                                   | 1.0.0 |
-| **`format`**       | <code>string</code> | The format of the image, ex: jpeg, png, gif. iOS and Android only support jpeg. Web supports jpeg and png. gif is only supported if using file input.                         | 1.0.0 |
+| Prop               | Type                 | Description                                                                                                                                                                                                      | Since |
+| ------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`base64String`** | <code>string</code>  | The base64 encoded string representation of the image, if using <a href="#cameraresulttype">CameraResultType.Base64</a>.                                                                                         | 1.0.0 |
+| **`dataUrl`**      | <code>string</code>  | The url starting with 'data:image/jpeg;base64,' and the base64 encoded string representation of the image, if using <a href="#cameraresulttype">CameraResultType.DataUrl</a>.                                    | 1.0.0 |
+| **`path`**         | <code>string</code>  | If using <a href="#cameraresulttype">CameraResultType.Uri</a>, the path will contain a full, platform-specific file URL that can be read later using the Filsystem API.                                          | 1.0.0 |
+| **`webPath`**      | <code>string</code>  | webPath returns a path that can be used to set the src attribute of an image for efficient loading and rendering.                                                                                                | 1.0.0 |
+| **`exif`**         | <code>any</code>     | Exif data, if any, retrieved from the image                                                                                                                                                                      | 1.0.0 |
+| **`format`**       | <code>string</code>  | The format of the image, ex: jpeg, png, gif. iOS and Android only support jpeg. Web supports jpeg and png. gif is only supported if using file input.                                                            | 1.0.0 |
+| **`saved`**        | <code>boolean</code> | Whether if the image was saved to the gallery or not. On Android and iOS, saving to the gallery can fail if the user didn't grant the required permissions. On Web there is no gallery, so always returns false. | 1.1.0 |
 
 
 #### ImageOptions

--- a/camera/ios/Plugin.xcodeproj/project.pbxproj
+++ b/camera/ios/Plugin.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		03FC29A292ACC40490383A1F /* Pods_Plugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B2A61DA5A1F2DD4F959604D /* Pods_Plugin.framework */; };
 		20C0B05DCFC8E3958A738AF2 /* Pods_PluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6753A823D3815DB436415E3 /* Pods_PluginTests.framework */; };
+		2FA5008E26E9143C00127B0B /* ImageSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5008D26E9143C00127B0B /* ImageSaver.swift */; };
 		50ADFF92201F53D600D50D53 /* Plugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50ADFF88201F53D600D50D53 /* Plugin.framework */; };
 		50ADFF97201F53D600D50D53 /* CameraPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50ADFF96201F53D600D50D53 /* CameraPluginTests.swift */; };
 		50ADFF99201F53D600D50D53 /* CameraPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 50ADFF8B201F53D600D50D53 /* CameraPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -30,6 +31,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2FA5008D26E9143C00127B0B /* ImageSaver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageSaver.swift; sourceTree = "<group>"; };
 		3B2A61DA5A1F2DD4F959604D /* Pods_Plugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Plugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		50ADFF88201F53D600D50D53 /* Plugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Plugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		50ADFF8B201F53D600D50D53 /* CameraPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CameraPlugin.h; sourceTree = "<group>"; };
@@ -94,6 +96,7 @@
 		50ADFF8A201F53D600D50D53 /* Plugin */ = {
 			isa = PBXGroup;
 			children = (
+				2FA5008D26E9143C00127B0B /* ImageSaver.swift */,
 				50ADFF8B201F53D600D50D53 /* CameraPlugin.h */,
 				50ADFFA72020EE4F00D50D53 /* CameraPlugin.m */,
 				50E1A94720377CB70090CE1A /* CameraPlugin.swift */,
@@ -311,6 +314,7 @@
 			files = (
 				50E1A94820377CB70090CE1A /* CameraPlugin.swift in Sources */,
 				50ADFFA82020EE4F00D50D53 /* CameraPlugin.m in Sources */,
+				2FA5008E26E9143C00127B0B /* ImageSaver.swift in Sources */,
 				6276AAD7255B3E1400097815 /* CameraTypes.swift in Sources */,
 				6276AAD3255B3E0E00097815 /* CameraExtensions.swift in Sources */,
 			);

--- a/camera/ios/Plugin/CameraTypes.swift
+++ b/camera/ios/Plugin/CameraTypes.swift
@@ -94,6 +94,7 @@ internal struct PhotoFlags: OptionSet {
 internal struct ProcessedImage {
     var image: UIImage
     var metadata: [String: Any]
+    var flags: PhotoFlags = []
 
     var exifData: [String: Any] {
         var exifData = metadata["{Exif}"] as? [String: Any]

--- a/camera/ios/Plugin/ImageSaver.swift
+++ b/camera/ios/Plugin/ImageSaver.swift
@@ -1,0 +1,18 @@
+class ImageSaver: NSObject {
+
+    var onResult: ((Error?)->Void) = {_ in }
+
+    init(image: UIImage, onResult:@escaping ((Error?)->Void)) {
+        self.onResult = onResult
+        super.init()
+        UIImageWriteToSavedPhotosAlbum(image, self, #selector(saveResult), nil)
+    }
+
+    @objc func saveResult(_ image: UIImage, didFinishSavingWithError error: Error?, contextInfo: UnsafeRawPointer) {
+        if let error = error {
+            onResult(error)
+        } else {
+            onResult(nil)
+        }
+    }
+}

--- a/camera/ios/Plugin/ImageSaver.swift
+++ b/camera/ios/Plugin/ImageSaver.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 class ImageSaver: NSObject {
 
     var onResult: ((Error?)->Void) = {_ in }

--- a/camera/src/definitions.ts
+++ b/camera/src/definitions.ts
@@ -208,6 +208,16 @@ export interface Photo {
    * @since 1.0.0
    */
   format: string;
+  /**
+   * Whether if the image was saved to the gallery or not.
+   *
+   * On Android and iOS, saving to the gallery can fail if the user didn't
+   * grant the required permissions.
+   * On Web there is no gallery, so always returns false.
+   *
+   * @since 1.1.0
+   */
+  saved: boolean;
 }
 
 export enum CameraSource {

--- a/camera/src/web.ts
+++ b/camera/src/web.ts
@@ -161,6 +161,7 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
         resolve({
           webPath: URL.createObjectURL(photo),
           format: format,
+          saved: false,
         });
       } else {
         reader.readAsDataURL(photo);
@@ -170,11 +171,13 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
             resolve({
               dataUrl: r,
               format: format,
+              saved: false,
             });
           } else {
             resolve({
               base64String: r.split(',')[1],
               format: format,
+              saved: false,
             });
           }
         };


### PR DESCRIPTION
At the moment on iOS, if the user doesn't grant the gallery permission, we return the image even if it fails to save it to the gallery.
On Android, if the user doesn't grant the gallery permission in enters in an infinite loop of requesting the permission.

This PR unify the behaviour so on Android it returns the image even if it failed to save to to the gallery and prevents the infinite loop.

Additionally, on the returned object, it adds a saved property that will tell the user if the image was saved to the gallery or not.

closes https://github.com/ionic-team/capacitor-plugins/issues/593