### PR TITLE
fix(camera): saveToGallery for edited images

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -583,14 +583,15 @@ public class CameraPlugin extends Plugin {
 
     private Intent createEditIntent(Uri origPhotoUri) {
         try {
+            File editFile = new File(origPhotoUri.getPath());
             Uri editUri = FileProvider.getUriForFile(
                 getActivity(),
                 getContext().getPackageName() + ".fileprovider",
-                new File(origPhotoUri.getPath())
+                editFile
             );
             Intent editIntent = new Intent(Intent.ACTION_EDIT);
             editIntent.setDataAndType(editUri, "image/*");
-            imageEditedFileSavePath = editUri.toString();
+            imageEditedFileSavePath = editFile.getAbsolutePath();
             int flags = Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION;
             editIntent.addFlags(flags);
             editIntent.putExtra(MediaStore.EXTRA_OUTPUT, editUri);

--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -584,11 +584,7 @@ public class CameraPlugin extends Plugin {
     private Intent createEditIntent(Uri origPhotoUri) {
         try {
             File editFile = new File(origPhotoUri.getPath());
-            Uri editUri = FileProvider.getUriForFile(
-                getActivity(),
-                getContext().getPackageName() + ".fileprovider",
-                editFile
-            );
+            Uri editUri = FileProvider.getUriForFile(getActivity(), getContext().getPackageName() + ".fileprovider", editFile);
             Intent editIntent = new Intent(Intent.ACTION_EDIT);
             editIntent.setDataAndType(editUri, "image/*");
             imageEditedFileSavePath = editFile.getAbsolutePath();


### PR DESCRIPTION
If saveToGallery is set but you edit the image it's not being able to save it because imageEditedFileSavePath is being set to a content url, this PR changes it to use the original absolute path.

