### PR TITLE
fix(local-notifications): return schedule on as object

### DIFF
--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotification.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotification.java
@@ -312,7 +312,7 @@ public class LocalNotification {
                 jsSchedule.put("at", schedule.getAt());
                 jsSchedule.put("every", schedule.getEvery());
                 jsSchedule.put("count", schedule.getCount());
-                jsSchedule.put("on", schedule.getOn());
+                jsSchedule.put("on", schedule.getOnObj());
                 jsSchedule.put("repeats", schedule.isRepeating());
                 jsNotification.put("schedule", jsSchedule);
             }

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationSchedule.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationSchedule.java
@@ -20,7 +20,10 @@ public class LocalNotificationSchedule {
 
     private Boolean whileIdle;
 
+    private JSObject scheduleObj;
+
     public LocalNotificationSchedule(JSObject schedule) throws ParseException {
+        this.scheduleObj = schedule;
         // Every specific unit of time (always constant)
         buildEveryElement(schedule);
         // Count of units of time from every to repeat on
@@ -70,6 +73,10 @@ public class LocalNotificationSchedule {
 
     public DateMatch getOn() {
         return on;
+    }
+
+    public JSObject getOnObj() {
+        return this.scheduleObj.getJSObject("on");
     }
 
     public void setOn(DateMatch on) {


### PR DESCRIPTION
return the original js object instead of the native object string representation

closes https://github.com/ionic-team/capacitor-plugins/issues/406