### PR TITLE
Add missing `await` statement

### DIFF
--- a/splash-screen/README.md
+++ b/splash-screen/README.md
@@ -15,15 +15,15 @@ npx cap sync
 import { SplashScreen } from '@capacitor/splash-screen';
 
 // Hide the splash (you should do this on app launch)
-SplashScreen.hide();
+await SplashScreen.hide();
 
 // Show the splash for an indefinite amount of time:
-SplashScreen.show({
+await SplashScreen.show({
   autoHide: false
 });
 
 // Show the splash for two seconds and then automatically hide it:
-SplashScreen.show({
+await SplashScreen.show({
   showDuration: 2000,
   autoHide: true
 });


### PR DESCRIPTION
The JS code examples are missing `await` statements for functions that return promises.