### PR TITLE
feat(haptics): Implement duration for vibration on iOS 13+

### DIFF
--- a/haptics/README.md
+++ b/haptics/README.md
@@ -169,9 +169,9 @@ For example, call this when a user has lifted their finger from a control
 
 #### VibrateOptions
 
-| Prop           | Type                | Description                                                      | Default          | Since |
-| -------------- | ------------------- | ---------------------------------------------------------------- | ---------------- | ----- |
-| **`duration`** | <code>number</code> | Duration of the vibration in milliseconds. Not supported in iOS. | <code>300</code> | 1.0.0 |
+| Prop           | Type                | Description                                                                   | Default          | Since |
+| -------------- | ------------------- | ----------------------------------------------------------------------------- | ---------------- | ----- |
+| **`duration`** | <code>number</code> | Duration of the vibration in milliseconds. Not supported in iOS 12 and older. | <code>300</code> | 1.0.0 |
 
 
 ### Enums

--- a/haptics/ios/Plugin/Haptics.swift
+++ b/haptics/ios/Plugin/Haptics.swift
@@ -1,5 +1,6 @@
 import AudioToolbox
 import UIKit
+import CoreHaptics
 
 @objc public class Haptics: NSObject {
 
@@ -33,5 +34,40 @@ import UIKit
 
     @objc public func vibrate() {
         AudioServicesPlayAlertSound(kSystemSoundID_Vibrate)
+    }
+
+    @objc public func vibrate(_ duration: Double) {
+        if #available(iOS 13, *) {
+            if CHHapticEngine.capabilitiesForHardware().supportsHaptics {
+                do {
+                    let engine = try CHHapticEngine()
+                    try engine.start()
+                    engine.resetHandler = { [] in
+                        do {
+                            try engine.start()
+                        } catch {
+                            self.vibrate()
+                        }
+                    }
+                    let intensity = CHHapticEventParameter(parameterID: .hapticIntensity, value: 1.0)
+                    let sharpness = CHHapticEventParameter(parameterID: .hapticSharpness, value: 1.0)
+
+                    let continuousEvent = CHHapticEvent(eventType: .hapticContinuous,
+                                                        parameters: [intensity, sharpness],
+                                                        relativeTime: 0.0,
+                                                        duration: duration)
+                    let pattern = try CHHapticPattern(events: [continuousEvent], parameters: [])
+                    let player = try engine.makePlayer(with: pattern)
+
+                    try player.start(atTime: 0)
+                } catch {
+                    vibrate()
+                }
+            } else {
+                vibrate()
+            }
+        } else {
+            vibrate()
+        }
     }
 }

--- a/haptics/ios/Plugin/HapticsPlugin.swift
+++ b/haptics/ios/Plugin/HapticsPlugin.swift
@@ -56,8 +56,9 @@ public class HapticsPlugin: CAPPlugin {
     }
 
     @objc public func vibrate(_ call: CAPPluginCall) {
+        let duration = call.getDouble("duration", 300)/1000
         DispatchQueue.main.async {
-            self.implementation.vibrate()
+            self.implementation.vibrate(duration)
         }
         call.resolve()
     }

--- a/haptics/src/definitions.ts
+++ b/haptics/src/definitions.ts
@@ -119,7 +119,7 @@ export interface VibrateOptions {
   /**
    * Duration of the vibration in milliseconds.
    *
-   * Not supported in iOS.
+   * Not supported in iOS 12 and older.
    *
    * @default 300
    * @since 1.0.0


### PR DESCRIPTION
Making it a feature despite it's technically a fix since the duration works in other platforms.

Implements duration for iOS 13+, where available, rely on the old vibration without duration where not available.

closes https://github.com/ionic-team/capacitor-plugins/issues/316