### PR TITLE
docs(haptics): iOS devices older than iPhone 7 only support vibrate(...)

### DIFF
--- a/haptics/README.md
+++ b/haptics/README.md
@@ -2,6 +2,8 @@
 
 The Haptics API provides physical feedback to the user through touch or vibration.
 
+**Note:** On iOS, devices older than iPhone 7 only support `vibrate(…)` as haptic feedback.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
See comment by C6Silver below this answer: https://stackoverflow.com/a/39957091
I tested this on an iPhone 6s running iOS 14.8 and I can confirm that `impact(...)` and `notification(...)` are not working.