### PR TITLE
fix(geolocation): return cached location if newer than maximumAge

### DIFF
--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
@@ -3,12 +3,14 @@ package com.capacitorjs.plugins.geolocation;
 import android.content.Context;
 import android.location.Location;
 import android.location.LocationManager;
+import android.os.SystemClock;
 import androidx.core.location.LocationManagerCompat;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationCallback;
 import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationResult;
 import com.google.android.gms.location.LocationServices;
+import java.util.List;
 
 public class Geolocation {
 
@@ -83,5 +85,26 @@ public class Geolocation {
             fusedLocationClient.removeLocationUpdates(locationCallback);
             locationCallback = null;
         }
+    }
+
+    @SuppressWarnings("MissingPermission")
+    public Location getLastLocation(int maximumAge) {
+        Location lastLoc = null;
+        LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+        List<String> providers = lm.getAllProviders();
+        for (String provider : providers) {
+            Location tmpLoc = lm.getLastKnownLocation(provider);
+            if (tmpLoc != null) {
+                long locationAge = SystemClock.elapsedRealtimeNanos() - tmpLoc.getElapsedRealtimeNanos();
+                long maximumAgeNanoSec = maximumAge * 1000000L;
+                if (
+                    locationAge <= maximumAgeNanoSec &&
+                    (lastLoc == null || lastLoc.getElapsedRealtimeNanos() > tmpLoc.getElapsedRealtimeNanos())
+                ) {
+                    lastLoc = lm.getLastKnownLocation(provider);
+                }
+            }
+        }
+        return lastLoc;
     }
 }

--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
@@ -10,7 +10,6 @@ import com.google.android.gms.location.LocationCallback;
 import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationResult;
 import com.google.android.gms.location.LocationServices;
-import java.util.List;
 
 public class Geolocation {
 
@@ -91,8 +90,7 @@ public class Geolocation {
     public Location getLastLocation(int maximumAge) {
         Location lastLoc = null;
         LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-        List<String> providers = lm.getAllProviders();
-        for (String provider : providers) {
+        for (String provider : lm.getAllProviders()) {
             Location tmpLoc = lm.getLastKnownLocation(provider);
             if (tmpLoc != null) {
                 long locationAge = SystemClock.elapsedRealtimeNanos() - tmpLoc.getElapsedRealtimeNanos();

--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
@@ -99,7 +99,7 @@ public class Geolocation {
                     locationAge <= maximumAgeNanoSec &&
                     (lastLoc == null || lastLoc.getElapsedRealtimeNanos() > tmpLoc.getElapsedRealtimeNanos())
                 ) {
-                    lastLoc = lm.getLastKnownLocation(provider);
+                    lastLoc = tmpLoc;
                 }
             }
         }

--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/GeolocationPlugin.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/GeolocationPlugin.java
@@ -111,23 +111,28 @@ public class GeolocationPlugin extends Plugin {
     private void getPosition(PluginCall call) {
         boolean enableHighAccuracy = call.getBoolean("enableHighAccuracy", false);
         int timeout = call.getInt("timeout", 10000);
+        int maximumAge = call.getInt("maximumAge", 0);
+        Location location = implementation.getLastLocation(maximumAge);
+        if (location != null) {
+            call.resolve(getJSObjectForLocation(location));
+        } else {
+            implementation.sendLocation(
+                enableHighAccuracy,
+                timeout,
+                true,
+                new LocationResultCallback() {
+                    @Override
+                    public void success(Location location) {
+                        call.resolve(getJSObjectForLocation(location));
+                    }
 
-        implementation.sendLocation(
-            enableHighAccuracy,
-            timeout,
-            true,
-            new LocationResultCallback() {
-                @Override
-                public void success(Location location) {
-                    call.resolve(getJSObjectForLocation(location));
+                    @Override
+                    public void error(String message) {
+                        call.reject(message);
+                    }
                 }
-
-                @Override
-                public void error(String message) {
-                    call.reject(message);
-                }
-            }
-        );
+            );
+        }
     }
 
     @SuppressWarnings("MissingPermission")


### PR DESCRIPTION
At the moment we are always getting a new location instead of checking if the latest cached location is newer than maximumAge.
This PR reads maximumAge and check the cached locations (for all providers) and returns a cached value if newer than maximumAge, otherwise it gets current location as usual.

closes https://github.com/ionic-team/capacitor-plugins/issues/609