### PR TITLE
 fix(camera): throw error if no activity to pick images is found

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -2,10 +2,10 @@ package com.capacitorjs.plugins.camera;
 
 import android.Manifest;
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
-import android.content.ActivityNotFoundException;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;


### PR DESCRIPTION
if Activity is not found, do not call com.getcapacitor.Plugin.startActivityForResult at CameraPlugin openPhotos and reject.

closes https://github.com/ionic-team/capacitor-plugins/issues/667