### PR TITLE
feat: Disable analytics

### DIFF
--- a/action-sheet/android/build.gradle
+++ b/action-sheet/android/build.gradle
@@ -26,6 +26,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/action-sheet/ios/Podfile
+++ b/action-sheet/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/app-launcher/android/build.gradle
+++ b/app-launcher/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/app-launcher/ios/Podfile
+++ b/app-launcher/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/browser/android/build.gradle
+++ b/browser/android/build.gradle
@@ -26,6 +26,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/browser/ios/Podfile
+++ b/browser/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/camera/android/build.gradle
+++ b/camera/android/build.gradle
@@ -27,6 +27,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/camera/ios/Podfile
+++ b/camera/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/clipboard/android/build.gradle
+++ b/clipboard/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/clipboard/ios/Podfile
+++ b/clipboard/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/device/android/build.gradle
+++ b/device/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/device/ios/Podfile
+++ b/device/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/dialog/android/build.gradle
+++ b/dialog/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/dialog/ios/Podfile
+++ b/dialog/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/filesystem/android/build.gradle
+++ b/filesystem/android/build.gradle
@@ -24,6 +24,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/filesystem/ios/Podfile
+++ b/filesystem/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/geolocation/android/build.gradle
+++ b/geolocation/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/geolocation/ios/Podfile
+++ b/geolocation/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/haptics/android/build.gradle
+++ b/haptics/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/haptics/ios/Podfile
+++ b/haptics/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/keyboard/android/build.gradle
+++ b/keyboard/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/keyboard/ios/Podfile
+++ b/keyboard/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/local-notifications/android/build.gradle
+++ b/local-notifications/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/local-notifications/ios/Podfile
+++ b/local-notifications/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/network/android/build.gradle
+++ b/network/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/network/ios/Podfile
+++ b/network/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
   pod 'ReachabilitySwift', '~> 5.0'

--- a/push-notifications/android/build.gradle
+++ b/push-notifications/android/build.gradle
@@ -26,6 +26,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/push-notifications/ios/Podfile
+++ b/push-notifications/ios/Podfile
@@ -1,10 +1,11 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
-  pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'  
+  pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end
 
 target 'Plugin' do

--- a/screen-reader/android/build.gradle
+++ b/screen-reader/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/screen-reader/ios/Podfile
+++ b/screen-reader/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/share/android/build.gradle
+++ b/share/android/build.gradle
@@ -26,6 +26,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/share/ios/Podfile
+++ b/share/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/splash-screen/android/build.gradle
+++ b/splash-screen/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/splash-screen/ios/Podfile
+++ b/splash-screen/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/status-bar/android/build.gradle
+++ b/status-bar/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/status-bar/ios/Podfile
+++ b/status-bar/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/storage/android/build.gradle
+++ b/storage/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/storage/ios/Podfile
+++ b/storage/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/text-zoom/android/build.gradle
+++ b/text-zoom/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/text-zoom/ios/Podfile
+++ b/text-zoom/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end

--- a/toast/android/build.gradle
+++ b/toast/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments disableAnalytics: "true"
     }
     buildTypes {
         release {

--- a/toast/ios/Podfile
+++ b/toast/ios/Podfile
@@ -1,8 +1,9 @@
 platform :ios, '12.0'
+use_frameworks!
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 def capacitor_pods
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 end


### PR DESCRIPTION
Avoid metrics collection by default as this lacks consent required by
the GDPR in Europe. It most likely violates Californian privacy laws as
well. Additionally, metrics collection on dependencies might expose
sensitive information in proprietary projects. Finally, those additional
network requests have an impact on overall build-time, especially for
CocoaPods.

Relates-To: https://github.com/ionic-team/capacitor/issues/5191