### PR TITLE
fix(network): Don't add window event listeners if there is no window

### DIFF
--- a/network/src/web.ts
+++ b/network/src/web.ts
@@ -59,8 +59,10 @@ function translatedConnection(): ConnectionType {
 export class NetworkWeb extends WebPlugin implements NetworkPlugin {
   constructor() {
     super();
-    window.addEventListener('online', this.handleOnline);
-    window.addEventListener('offline', this.handleOffline);
+    if (typeof window !== 'undefined') {
+      window.addEventListener('online', this.handleOnline);
+      window.addEventListener('offline', this.handleOffline);
+    }
   }
 
   async getStatus(): Promise<ConnectionStatus> {


### PR DESCRIPTION
If network plugin is imported in SSR context, it fails to compile because window is not available on SSR, so add a window check before adding the event listeners

closes https://github.com/ionic-team/capacitor-plugins/issues/669