### PR TITLE
fix(camera): Remove capture attribute from multiple photo picker

### DIFF
--- a/camera/src/web.ts
+++ b/camera/src/web.ts
@@ -201,7 +201,6 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
     }
 
     input.accept = 'image/*';
-    (input as any).capture = true;
 
     input.click();
   }


### PR DESCRIPTION
capture shouldn't be used in the multiple picker as it shows the camera UI instead of the image picker.

closes https://github.com/ionic-team/capacitor-plugins/issues/686