### PR TITLE
fix(camera): Return proper exif when picking multiple images

### DIFF
--- a/camera/ios/Plugin/CameraPlugin.swift
+++ b/camera/ios/Plugin/CameraPlugin.swift
@@ -187,7 +187,7 @@ extension CameraPlugin: PHPickerViewControllerDelegate {
                 img.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] (reading, _) in
                     if let image = reading as? UIImage {
                         var asset: PHAsset?
-                        if let assetId = result.assetIdentifier {
+                        if let assetId = img.assetIdentifier {
                             asset = PHAsset.fetchAssets(withLocalIdentifiers: [assetId], options: nil).firstObject
                         }
                         if let processedImage = self?.processedImage(from: image, with: asset?.imageData) {


### PR DESCRIPTION
The plugin is returning the exif of the first picture for all, make it return the real image exif.


closes https://github.com/ionic-team/capacitor-plugins/issues/707