### PR TITLE
fix(app): Don't unset App Listeners on removeAllListeners

### DIFF
--- a/app/android/src/main/java/com/capacitorjs/plugins/app/AppPlugin.java
+++ b/app/android/src/main/java/com/capacitorjs/plugins/app/AppPlugin.java
@@ -58,13 +58,6 @@ public class AppPlugin extends Plugin {
         getActivity().getOnBackPressedDispatcher().addCallback(getActivity(), callback);
     }
 
-    @Override
-    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
-    public void removeAllListeners(PluginCall call) {
-        super.removeAllListeners(call);
-        unsetAppListeners();
-    }
-
     @PluginMethod
     public void exitApp(PluginCall call) {
         unsetAppListeners();


### PR DESCRIPTION
Calling `unsetAppListeners` on `removeAllListeners` was needed for back button as the app logic was different if there were back button listeners or not, but back button logic was moved into the plugin without relying in App class, so it's no longer needed to call it. We were also unsetting `statusChangeListener` and `appRestoredListener`, with this change they won't be unset and they will be still fired inside App class, but there won't be plugin listeners to listen, so it won't be a problem.

The alternative is to override addListener to set the App listeners again, but I think this is simpler.


closes https://github.com/ionic-team/capacitor-plugins/issues/703