### PR TITLE
feat(browser): Add option to prevent urls being open as deeplink on android

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -144,6 +144,7 @@ Represents the options passed to `open`.
 | ----------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
 | **`url`**               | <code>string</code>                    | The URL to which the browser is opened.                                                                                                    | 1.0.0 |
 | **`windowName`**        | <code>string</code>                    | Web only: Optional target for browser open. Follows the `target` property for window.open. Defaults to _blank. Ignored on other platforms. | 1.0.0 |
+| **`preventDeeplink`**   | <code>boolean</code>                   | Android only: Prevent url being opend in installed app instead of default browser.                                                         | 1.0.1 |
 | **`toolbarColor`**      | <code>string</code>                    | A hex color to which the toolbar color is set.                                                                                             | 1.0.0 |
 | **`presentationStyle`** | <code>'fullscreen' \| 'popover'</code> | iOS only: The presentation style of the browser. Defaults to fullscreen. Ignored on other platforms.                                       | 1.0.0 |
 

--- a/browser/android/src/main/AndroidManifest.xml
+++ b/browser/android/src/main/AndroidManifest.xml
@@ -1,5 +1,12 @@
 
   <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="com.capacitorjs.plugins.browser">
+    <queries>
+      <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="http" />
+      </intent>
+    </queries>
   </manifest>
   

--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/Browser.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/Browser.java
@@ -3,6 +3,8 @@ package com.capacitorjs.plugins.browser;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
@@ -88,15 +90,16 @@ public class Browser {
      * @param url
      */
     public void open(Uri url) {
-        open(url, null);
+        open(url, null, null);
     }
 
     /**
      * Open the browser to the specified URL with the specified toolbar color.
      * @param url
      * @param toolbarColor
+     * @param preventDeeplink
      */
-    public void open(Uri url, @Nullable Integer toolbarColor) {
+    public void open(Uri url, @Nullable Integer toolbarColor, @Nullable Boolean preventDeeplink) {
         CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(getCustomTabsSession());
 
         builder.addDefaultShareMenuItem();
@@ -107,6 +110,20 @@ public class Browser {
 
         CustomTabsIntent tabsIntent = builder.build();
         tabsIntent.intent.putExtra(Intent.EXTRA_REFERRER, Uri.parse(Intent.URI_ANDROID_APP_SCHEME + "//" + context.getPackageName()));
+
+        if (preventDeeplink != null) {
+          String browserPackageName = "";
+          Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://"));
+          ResolveInfo resolveInfo = context.getPackageManager().resolveActivity(browserIntent, PackageManager.MATCH_DEFAULT_ONLY);
+
+          if (resolveInfo != null) {
+            browserPackageName = resolveInfo.activityInfo.packageName;
+
+            if (!browserPackageName.isEmpty()) {
+              tabsIntent.intent.setPackage(browserPackageName);
+            }
+          }
+        }
 
         isInitialLoad = true;
         group.reset();

--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
@@ -47,8 +47,11 @@ public class BrowserPlugin extends Plugin {
             Logger.error(getLogTag(), "Invalid color provided for toolbarColor. Using default", null);
         }
 
+        // get the deeplink prevention, if provided
+        Boolean preventDeeplink = call.getBoolean("preventDeeplink", null);
+
         // open the browser and finish
-        implementation.open(url, toolbarColor);
+        implementation.open(url, toolbarColor, preventDeeplink);
         call.resolve();
     }
 


### PR DESCRIPTION
When installed 3rdparty android apps register for deeplinks (url being opened in 3rdparty apps instead of installed / default browser; see reddit, booking.com ... ) the capacitor plugin currently has no control over this behavior. This can be problematic when using specific implementations / APIs and alike.

In order to enforce the default browser we introduced an additional optional parameter.