### PR TITLE
fix(device): isVirtual is false on M1 simulators

### DIFF
--- a/device/ios/Plugin/DevicePlugin.swift
+++ b/device/ios/Plugin/DevicePlugin.swift
@@ -16,7 +16,7 @@ public class DevicePlugin: CAPPlugin {
     }
     @objc func getInfo(_ call: CAPPluginCall) {
         var isSimulator = false
-        #if arch(i386) || arch(x86_64)
+        #if targetEnvironment(simulator)
         isSimulator = true
         #endif
 


### PR DESCRIPTION
isVirtual is false on simulators run on M1 macs because it's none of those architectures, use `targetEnvironment(simulator)`  instead

closes https://github.com/ionic-team/capacitor-plugins/issues/720