### PR TITLE
fix(splash-screen): pick first window when there is no key window

### DIFF
--- a/splash-screen/ios/Plugin/SplashScreen.swift
+++ b/splash-screen/ios/Plugin/SplashScreen.swift
@@ -120,7 +120,11 @@ import Capacitor
         var window: UIWindow? = UIApplication.shared.delegate?.window as? UIWindow
 
         if #available(iOS 13, *), window == nil {
-            window = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.filter({$0.isKeyWindow}).first
+            let scene: UIWindowScene? = (UIApplication.shared.connectedScenes.first as? UIWindowScene)
+            window = scene?.windows.filter({$0.isKeyWindow}).first
+            if window == nil {
+                window = scene?.windows.first
+            }
         }
 
         if let unwrappedWindow = window {

--- a/splash-screen/ios/Plugin/SplashScreen.swift
+++ b/splash-screen/ios/Plugin/SplashScreen.swift
@@ -120,7 +120,7 @@ import Capacitor
         var window: UIWindow? = UIApplication.shared.delegate?.window as? UIWindow
 
         if #available(iOS 13, *), window == nil {
-            let scene: UIWindowScene? = (UIApplication.shared.connectedScenes.first as? UIWindowScene)
+            let scene: UIWindowScene? = UIApplication.shared.connectedScenes.first as? UIWindowScene
             window = scene?.windows.filter({$0.isKeyWindow}).first
             if window == nil {
                 window = scene?.windows.first


### PR DESCRIPTION
updateSplashImageBounds is called multiple times and the first two are before the app window is set as key window, so the first check returns a nil, in that case just pick the first window.