### PR TITLE
fix(text-zoom): Lazy load iOS implementation

### DIFF
--- a/text-zoom/src/index.ts
+++ b/text-zoom/src/index.ts
@@ -3,7 +3,7 @@ import { registerPlugin } from '@capacitor/core';
 import type { TextZoomPlugin } from './definitions';
 
 const TextZoom = registerPlugin<TextZoomPlugin>('TextZoom', {
-  ios: import('./ios').then(m => new m.TextZoomIOS()),
+  ios: () => import('./ios').then(m => new m.TextZoomIOS()),
 });
 
 export * from './definitions';


### PR DESCRIPTION
we are declaring the implementations like this on all plugins except this one, so I think it was a mistake and it makes web to import iOS code despite it's not being used
I've tested on iOS and the plugin keeps working after the change, so I think it can be lazy loaded like the others.


closes https://github.com/ionic-team/capacitor-plugins/issues/717