### PR TITLE
feat(share): Add canShare method to check availability

### DIFF
--- a/share/README.md
+++ b/share/README.md
@@ -31,6 +31,7 @@ Each platform uses a different set of fields, but you should supply them all.
 
 <docgen-index>
 
+* [`canShare()`](#canshare)
 * [`share(...)`](#share)
 * [Interfaces](#interfaces)
 
@@ -38,6 +39,21 @@ Each platform uses a different set of fields, but you should supply them all.
 
 <docgen-api>
 <!--Update the source file JSDoc comments and rerun docgen to update the docs below-->
+
+### canShare()
+
+```typescript
+canShare() => Promise<CanShareResult>
+```
+
+Check if sharing is supported.
+
+**Returns:** <code>Promise&lt;<a href="#canshareresult">CanShareResult</a>&gt;</code>
+
+**Since:** 1.1.0
+
+--------------------
+
 
 ### share(...)
 
@@ -59,6 +75,13 @@ Show a Share modal for sharing content with other apps
 
 
 ### Interfaces
+
+
+#### CanShareResult
+
+| Prop        | Type                 | Description                          | Since |
+| ----------- | -------------------- | ------------------------------------ | ----- |
+| **`value`** | <code>boolean</code> | Whether sharing is supported or not. | 1.1.0 |
 
 
 #### ShareResult

--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -51,6 +51,13 @@ public class SharePlugin extends Plugin {
     }
 
     @PluginMethod
+    public void canShare(PluginCall call) {
+        JSObject callResult = new JSObject();
+        callResult.put("value", true);
+        call.resolve(callResult);
+    }
+
+    @PluginMethod
     public void share(PluginCall call) {
         if (!isPresenting) {
             String title = call.getString("title", "");

--- a/share/ios/Plugin/SharePlugin.m
+++ b/share/ios/Plugin/SharePlugin.m
@@ -4,5 +4,6 @@
 // Define the plugin using the CAP_PLUGIN Macro, and
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
 CAP_PLUGIN(SharePlugin, "Share",
+           CAP_PLUGIN_METHOD(canShare, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(share, CAPPluginReturnPromise);
 )

--- a/share/ios/Plugin/SharePlugin.swift
+++ b/share/ios/Plugin/SharePlugin.swift
@@ -4,6 +4,12 @@ import Capacitor
 @objc(SharePlugin)
 public class SharePlugin: CAPPlugin {
 
+    @objc func canShare(_ call: CAPPluginCall) {
+        call.resolve([
+            "value": true
+        ])
+    }
+
     @objc func share(_ call: CAPPluginCall) {
         var items = [Any]()
 

--- a/share/src/definitions.ts
+++ b/share/src/definitions.ts
@@ -42,7 +42,23 @@ export interface ShareResult {
   activityType?: string;
 }
 
+export interface CanShareResult {
+  /**
+   * Whether sharing is supported or not.
+   *
+   * @since 1.1.0
+   */
+  value: boolean;
+}
+
 export interface SharePlugin {
+  /**
+   * Check if sharing is supported.
+   *
+   * @since 1.1.0
+   */
+  canShare(): Promise<CanShareResult>;
+
   /**
    * Show a Share modal for sharing content with other apps
    *

--- a/share/src/web.ts
+++ b/share/src/web.ts
@@ -1,8 +1,20 @@
 import { WebPlugin } from '@capacitor/core';
 
-import type { ShareOptions, SharePlugin, ShareResult } from './definitions';
+import type {
+  CanShareResult,
+  ShareOptions,
+  SharePlugin,
+  ShareResult,
+} from './definitions';
 
 export class ShareWeb extends WebPlugin implements SharePlugin {
+  async canShare(): Promise<CanShareResult> {
+    if (typeof navigator === 'undefined' || !navigator.share) {
+      return { value: false };
+    } else {
+      return { value: true };
+    }
+  }
   async share(options: ShareOptions): Promise<ShareResult> {
     if (typeof navigator === 'undefined' || !navigator.share) {
       throw this.unavailable('Share API not available in this browser');


### PR DESCRIPTION
At the moment we reject if share is not available and an user tries to share, but it would be more useful if they can check if sharing is available in the browser/device beforehand to show or hide sharing buttons accordingly.
iOS and Android just return true.


closes https://github.com/ionic-team/capacitor-plugins/issues/747