### PR TITLE
fix: inline source code in esm map files

### DIFF
--- a/action-sheet/tsconfig.json
+++ b/action-sheet/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/app-launcher/tsconfig.json
+++ b/app-launcher/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/browser/tsconfig.json
+++ b/browser/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/camera/tsconfig.json
+++ b/camera/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/clipboard/tsconfig.json
+++ b/clipboard/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/device/tsconfig.json
+++ b/device/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/dialog/tsconfig.json
+++ b/dialog/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/filesystem/tsconfig.json
+++ b/filesystem/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/geolocation/tsconfig.json
+++ b/geolocation/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/haptics/tsconfig.json
+++ b/haptics/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/keyboard/tsconfig.json
+++ b/keyboard/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/local-notifications/tsconfig.json
+++ b/local-notifications/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/motion/tsconfig.json
+++ b/motion/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/network/tsconfig.json
+++ b/network/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/push-notifications/tsconfig.json
+++ b/push-notifications/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/screen-reader/tsconfig.json
+++ b/screen-reader/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/share/tsconfig.json
+++ b/share/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/splash-screen/tsconfig.json
+++ b/splash-screen/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/status-bar/tsconfig.json
+++ b/status-bar/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/storage/tsconfig.json
+++ b/storage/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/text-zoom/tsconfig.json
+++ b/text-zoom/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/toast/tsconfig.json
+++ b/toast/tsconfig.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
     "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
esm source maps point to the .ts files, but we don't distribute them

This PR makes typescript compiler to inline the plugins code into the source maps as rollup is doing for cjs and iife 

closes https://github.com/ionic-team/capacitor-plugins/issues/755