### PR TITLE
feat(device): Add device hardware type recognition

### DIFF
--- a/device/README.md
+++ b/device/README.md
@@ -121,6 +121,7 @@ Get the device's current language locale code.
 | **`model`**           | <code>string</code>                                         | The device model. For example, "iPhone".                                                                                                                                                                                            | 1.0.0 |
 | **`platform`**        | <code>'ios' \| 'android' \| 'web'</code>                    | The device platform (lowercase).                                                                                                                                                                                                    | 1.0.0 |
 | **`operatingSystem`** | <code><a href="#operatingsystem">OperatingSystem</a></code> | The operating system of the device.                                                                                                                                                                                                 | 1.0.0 |
+| **`hardwareType`**    | <code><a href="#hardwaretype">HardwareType</a></code>       | The operating system of the device.                                                                                                                                                                                                 | 1.2.0 |
 | **`osVersion`**       | <code>string</code>                                         | The version of the device OS.                                                                                                                                                                                                       | 1.0.0 |
 | **`manufacturer`**    | <code>string</code>                                         | The manufacturer of the device.                                                                                                                                                                                                     | 1.0.0 |
 | **`isVirtual`**       | <code>boolean</code>                                        | Whether the app is running in a simulator/emulator.                                                                                                                                                                                 | 1.0.0 |
@@ -153,5 +154,10 @@ Get the device's current language locale code.
 #### OperatingSystem
 
 <code>'ios' | 'android' | 'windows' | 'mac' | 'unknown'</code>
+
+
+#### HardwareType
+
+<code>'smartphone' | 'tablet' | 'car' | 'tv' | 'desktop' | 'unknown'</code>
 
 </docgen-api>

--- a/device/android/src/main/java/com/capacitorjs/plugins/device/Device.java
+++ b/device/android/src/main/java/com/capacitorjs/plugins/device/Device.java
@@ -1,15 +1,18 @@
 package com.capacitorjs.plugins.device;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.os.BatteryManager;
 import android.os.Build;
 import android.os.Environment;
 import android.os.StatFs;
 import android.provider.Settings;
+import android.util.DisplayMetrics;
 import android.webkit.WebView;
 
 public class Device {
@@ -113,5 +116,21 @@ public class Device {
         }
 
         return android.os.Build.VERSION.RELEASE;
+    }
+
+    public String getHardwareType() {
+        int layout = this.context.getResources().getConfiguration().screenLayout;
+        boolean largeDevice
+        = ((layout & Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE);
+
+        if (largeDevice) {
+            DisplayMetrics metrics = new DisplayMetrics();
+            Activity activity = (Activity) this.context;
+            activity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+            if (metrics.densityDpi >= DisplayMetrics.DENSITY_DEFAULT) {
+                return "tablet";
+            }
+        }
+        return "smartphone";
     }
 }

--- a/device/android/src/main/java/com/capacitorjs/plugins/device/DevicePlugin.java
+++ b/device/android/src/main/java/com/capacitorjs/plugins/device/DevicePlugin.java
@@ -37,6 +37,7 @@ public class DevicePlugin extends Plugin {
         r.put("realDiskTotal", implementation.getRealDiskTotal());
         r.put("model", android.os.Build.MODEL);
         r.put("operatingSystem", "android");
+        r.put("hardwareType", implementation.getHardwareType());
         r.put("osVersion", android.os.Build.VERSION.RELEASE);
         r.put("platform", implementation.getPlatform());
         r.put("manufacturer", android.os.Build.MANUFACTURER);

--- a/device/ios/Plugin.xcodeproj/project.pbxproj
+++ b/device/ios/Plugin.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		50ADFFA42020D75100D50D53 /* Capacitor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50ADFFA52020D75100D50D53 /* Capacitor.framework */; };
 		50ADFFA82020EE4F00D50D53 /* DevicePlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = 50ADFFA72020EE4F00D50D53 /* DevicePlugin.m */; };
 		50E1A94820377CB70090CE1A /* DevicePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E1A94720377CB70090CE1A /* DevicePlugin.swift */; };
+		FBDFBA6F2798381900D3F4C9 /* UIUserInterfaceIdiom+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBDFBA6E2798381900D3F4C9 /* UIUserInterfaceIdiom+Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +46,7 @@
 		96ED1B6440D6672E406C8D19 /* Pods-PluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F65BB2953ECE002E1EF3E424 /* Pods-PluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PluginTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PluginTests/Pods-PluginTests.release.xcconfig"; sourceTree = "<group>"; };
 		F6753A823D3815DB436415E3 /* Pods_PluginTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PluginTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FBDFBA6E2798381900D3F4C9 /* UIUserInterfaceIdiom+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIUserInterfaceIdiom+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +99,7 @@
 				50ADFF8B201F53D600D50D53 /* DevicePlugin.h */,
 				50ADFFA72020EE4F00D50D53 /* DevicePlugin.m */,
 				50ADFF8C201F53D600D50D53 /* Info.plist */,
+				FBDFBA6E2798381900D3F4C9 /* UIUserInterfaceIdiom+Extensions.swift */,
 			);
 			path = Plugin;
 			sourceTree = "<group>";
@@ -309,6 +312,7 @@
 				50E1A94820377CB70090CE1A /* DevicePlugin.swift in Sources */,
 				2F98D68224C9AAE500613A4C /* Device.swift in Sources */,
 				50ADFFA82020EE4F00D50D53 /* DevicePlugin.m in Sources */,
+				FBDFBA6F2798381900D3F4C9 /* UIUserInterfaceIdiom+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/device/ios/Plugin/Device.swift
+++ b/device/ios/Plugin/Device.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 @objc public class Device: NSObject {
     /**
@@ -64,5 +65,9 @@ import Foundation
 
     public func getLanguageCode() -> String {
         return String(Locale.preferredLanguages[0].prefix(2))
+    }
+    
+    public func getHardwareType() -> String {
+        return UIDevice.current.userInterfaceIdiom.bridgeValue
     }
 }

--- a/device/ios/Plugin/DevicePlugin.swift
+++ b/device/ios/Plugin/DevicePlugin.swift
@@ -24,6 +24,7 @@ public class DevicePlugin: CAPPlugin {
         let diskFree = implementation.getFreeDiskSize() ?? 0
         let realDiskFree = implementation.getRealFreeDiskSize() ?? 0
         let diskTotal = implementation.getTotalDiskSize() ?? 0
+        let hardwareType = implementation.getHardwareType()
 
         call.resolve([
             "memUsed": memUsed,
@@ -34,6 +35,7 @@ public class DevicePlugin: CAPPlugin {
             "name": UIDevice.current.name,
             "model": UIDevice.current.model,
             "operatingSystem": "ios",
+            "hardwareType": hardwareType,
             "osVersion": UIDevice.current.systemVersion,
             "platform": "ios",
             "manufacturer": "Apple",

--- a/device/ios/Plugin/UIUserInterfaceIdiom+Extensions.swift
+++ b/device/ios/Plugin/UIUserInterfaceIdiom+Extensions.swift
@@ -1,0 +1,33 @@
+//
+//  UIUserInterfaceIdiom+Extensions.swift
+//  Plugin
+//
+//  Created by Kondrat Kielar on 19/01/2022.
+//  Copyright © 2022 Max Lynch. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UIUserInterfaceIdiom {
+    
+    var bridgeValue: String {
+        
+        switch self {
+        case .carPlay:
+            return "car"
+        case .mac:
+            return "desktop"
+        case .pad:
+            return "tablet"
+        case .phone:
+            return "smartphone"
+        case .tv:
+            return "tv"
+        case .unspecified:
+            return "unknown"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}

--- a/device/package.json
+++ b/device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/device",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "The Device API exposes internal information about the device, such as the model and operating system version, along with user information such as unique ids.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/device/src/definitions.ts
+++ b/device/src/definitions.ts
@@ -1,4 +1,5 @@
 export type OperatingSystem = 'ios' | 'android' | 'windows' | 'mac' | 'unknown';
+export type HardwareType = 'smartphone' | 'tablet' | 'car' | 'tv' | 'desktop' | 'unknown';
 
 export interface DeviceId {
   /**
@@ -42,6 +43,13 @@ export interface DeviceInfo {
    * @since 1.0.0
    */
   operatingSystem: OperatingSystem;
+
+  /**
+   * Type of the hardware that app runs at.
+   *
+   * @since 1.2.0
+   */
+  hardwareType: HardwareType;
 
   /**
    * The version of the device OS.

--- a/device/src/web.ts
+++ b/device/src/web.ts
@@ -5,6 +5,7 @@ import type {
   DeviceId,
   DeviceInfo,
   DevicePlugin,
+  HardwareType,
   GetLanguageCodeResult,
 } from './definitions';
 
@@ -40,6 +41,7 @@ export class DeviceWeb extends WebPlugin implements DevicePlugin {
       model: uaFields.model,
       platform: <const>'web',
       operatingSystem: uaFields.operatingSystem,
+      hardwareType: 'desktop' as HardwareType,
       osVersion: uaFields.osVersion,
       manufacturer: navigator.vendor,
       isVirtual: false,


### PR DESCRIPTION
Some apps require to determine if the hardware they run at is tablet, or a regular smartphone.
This improvement uses native APIs to forward such information to Capacitor app.

As a plus, thanks to Apple userInterFaceIdiom, additional types were exposes, like tv or car.