### PR TITLE
fix(camera): process picked image only once

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -334,7 +334,7 @@ public class CameraPlugin extends Plugin {
                             call.reject(processResult.getString("error"));
                             return;
                         } else {
-                            photos.put(processPickedImages(imageUri));
+                            photos.put(processResult);
                         }
                     }
                     ret.put("photos", photos);


### PR DESCRIPTION
we are calling processPickedImages(imageUri) twice, there is no need

this should decrease memory usage and increase speed when selecting multiple pictures
