### PR TITLE
feat(camera): Support for 1 Gallery app

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -494,7 +494,6 @@ public class CameraPlugin extends Plugin {
         File outFile = null;
         if (uri.getScheme().equals("content")) {
             outFile = getTempFile(uri);
-            writePhoto(outFile, is);
         } else {
             outFile = new File(uri.getPath());
         }

--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -493,15 +493,22 @@ public class CameraPlugin extends Plugin {
     private Uri saveImage(Uri uri, InputStream is) throws IOException {
         File outFile = null;
         if (uri.getScheme().equals("content")) {
-            String filename = Uri.parse(Uri.decode(uri.toString())).getLastPathSegment();
-            if (!filename.contains(".jpg") && !filename.contains(".jpeg")) {
-                filename += "." + (new java.util.Date()).getTime() + ".jpeg";
-            }
-            File cacheDir = getContext().getCacheDir();
-            outFile = new File(cacheDir, filename);
+            outFile = getTempFile(uri);
+            writePhoto(outFile, is);
         } else {
             outFile = new File(uri.getPath());
         }
+        try {
+            writePhoto(outFile, is);
+        } catch (FileNotFoundException ex) {
+            // Some gallery apps return read only file url, create a temporary file for modifications
+            outFile = getTempFile(uri);
+            writePhoto(outFile, is);
+        }
+        return Uri.fromFile(outFile);
+    }
+
+    private void writePhoto(File outFile, InputStream is) throws IOException {
         FileOutputStream fos = new FileOutputStream(outFile);
         byte[] buffer = new byte[1024];
         int len;
@@ -509,7 +516,15 @@ public class CameraPlugin extends Plugin {
             fos.write(buffer, 0, len);
         }
         fos.close();
-        return Uri.fromFile(outFile);
+    }
+
+    private File getTempFile(Uri uri) {
+        String filename = Uri.parse(Uri.decode(uri.toString())).getLastPathSegment();
+        if (!filename.contains(".jpg") && !filename.contains(".jpeg")) {
+            filename += "." + (new java.util.Date()).getTime() + ".jpeg";
+        }
+        File cacheDir = getContext().getCacheDir();
+        return new File(cacheDir, filename);
     }
 
     /**


### PR DESCRIPTION
Add support for 1 Gallery and other gallery apps that return a file url instead of a content url.
Since the urls are read only when we try to save it throws an error, in that case we need to create a temporary file as we do for content urls 

closes https://github.com/ionic-team/capacitor-plugins/issues/722