### PR TITLE
docs(toast): Fix typo in position description

### DIFF
--- a/toast/README.md
+++ b/toast/README.md
@@ -63,6 +63,6 @@ Shows a Toast on the screen
 | -------------- | ------------------------------------------ | ----------------------------------------------------------------- | --------------------- | ----- |
 | **`text`**     | <code>string</code>                        | Text to display on the Toast                                      |                       | 1.0.0 |
 | **`duration`** | <code>'short' \| 'long'</code>             | Duration of the Toast, either 'short' (2000ms) or 'long' (3500ms) | <code>'short'</code>  | 1.0.0 |
-| **`position`** | <code>'top' \| 'center' \| 'bottom'</code> | Postion of the Toast                                              | <code>'bottom'</code> | 1.0.0 |
+| **`position`** | <code>'top' \| 'center' \| 'bottom'</code> | Position of the Toast                                             | <code>'bottom'</code> | 1.0.0 |
 
 </docgen-api>

--- a/toast/src/definitions.ts
+++ b/toast/src/definitions.ts
@@ -24,7 +24,7 @@ export interface ShowOptions {
   duration?: 'short' | 'long';
 
   /**
-   * Postion of the Toast
+   * Position of the Toast
    *
    * @default 'bottom'
    * @since 1.0.0


### PR DESCRIPTION
closes https://github.com/ionic-team/capacitor-plugins/pull/781