### PR TITLE
fix(camera): Use Locale.ROOT on toUpperCase

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -232,7 +233,7 @@ public class CameraPlugin extends Plugin {
             return null;
         }
         try {
-            return CameraResultType.valueOf(resultType.toUpperCase());
+            return CameraResultType.valueOf(resultType.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException ex) {
             Logger.debug(getLogTag(), "Invalid result type \"" + resultType + "\", defaulting to base64");
             return CameraResultType.BASE64;


### PR DESCRIPTION
by default `toUpperCase` uses the device locale, which can cause undesired values in certain languages, pass `Locale.ROOT` to get the expected value

closes https://github.com/ionic-team/capacitor-plugins/issues/811