### PR TITLE
fix(splash-screen): Use Locale.ROOT on toLowerCase

### DIFF
--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
@@ -7,6 +7,7 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.util.WebColor;
+import java.util.Locale;
 
 @CapacitorPlugin(name = "SplashScreen")
 public class SplashScreenPlugin extends Plugin {
@@ -103,7 +104,7 @@ public class SplashScreenPlugin extends Plugin {
         if (spinnerStyle != null) {
             int spinnerBarStyle = android.R.attr.progressBarStyleLarge;
 
-            switch (spinnerStyle.toLowerCase()) {
+            switch (spinnerStyle.toLowerCase(Locale.ROOT)) {
                 case "horizontal":
                     spinnerBarStyle = android.R.attr.progressBarStyleHorizontal;
                     break;


### PR DESCRIPTION
some spinner styles don't work when the device is using certain locales, use Locale.ROOT in toLowerCase to fix it