### PR TITLE
fix(status-bar): Use Locale.ROOT on toUpperCase

### DIFF
--- a/status-bar/android/src/main/java/com/capacitorjs/plugins/statusbar/StatusBarPlugin.java
+++ b/status-bar/android/src/main/java/com/capacitorjs/plugins/statusbar/StatusBarPlugin.java
@@ -6,6 +6,7 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.util.WebColor;
+import java.util.Locale;
 
 @CapacitorPlugin(name = "StatusBar")
 public class StatusBarPlugin extends Plugin {
@@ -46,7 +47,7 @@ public class StatusBarPlugin extends Plugin {
             .executeOnMainThread(
                 () -> {
                     try {
-                        final int parsedColor = WebColor.parseColor(color.toUpperCase());
+                        final int parsedColor = WebColor.parseColor(color.toUpperCase(Locale.ROOT));
                         implementation.setBackgroundColor(parsedColor);
                         call.resolve();
                     } catch (IllegalArgumentException ex) {


### PR DESCRIPTION
I have not noticed any issues on status-bar since hex colors have a limited set of characters, but for consistency with camera and splash-screen I'm adding the `Locale.ROOT` in `toUpperCase`