### PR TITLE
Fixing null intent type

### DIFF
--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -100,7 +100,7 @@ public class SharePlugin extends Plugin {
                 );
                 intent.putExtra(Intent.EXTRA_STREAM, fileUrl);
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    intent.setData(fileUrl);
+                    intent.setDataAndType(fileUrl, type);
                 }
                 intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             }


### PR DESCRIPTION
Calling setDataAndType, as setData nulls the type (and setType nulls the data!)
This resolves issues sharing files to external apps. Specifically sending images to WhatsApp (https://github.com/ionic-team/capacitor-plugins/issues/196)