### PR TITLE
docs: replace alert with console.log in example section

### DIFF
--- a/app-launcher/README.md
+++ b/app-launcher/README.md
@@ -30,7 +30,7 @@ import { AppLauncher } from '@capacitor/app-launcher';
 const checkCanOpenUrl = async () => {
   const { value } = await AppLauncher.canOpenUrl({ url: 'com.getcapacitor.myapp' });
 
-  alert('Can open url: ', value);
+  console.log('Can open url: ', value);
 };
 
 const openPortfolioPage = async () => {

--- a/app/README.md
+++ b/app/README.md
@@ -63,7 +63,7 @@ App.addListener('appRestoredResult', data => {
 const checkAppLaunchUrl = async () => {
   const { url } = await App.getLaunchUrl();
 
-  alert('App opened with URL: ' + url);
+  console.log('App opened with URL: ' + url);
 };
 ```
 

--- a/clipboard/README.md
+++ b/clipboard/README.md
@@ -23,7 +23,7 @@ const writeToClipboard = async () => {
 const checkClipboard = async () => {
   const { type, value } = await Clipboard.read();
 
-  alert(`Got ${type} from clipboard: ${value}`);
+  console.log(`Got ${type} from clipboard: ${value}`);
 };
 ```
 

--- a/screen-reader/README.md
+++ b/screen-reader/README.md
@@ -21,7 +21,7 @@ ScreenReader.addListener('screenReaderStateChange', ({ value }) => {
 const checkScreenReaderEnabled = async () => {
   const { value } = await ScreenReader.isEnabled();
 
-  alert('Voice over enabled? ' + value);
+  console.log('Voice over enabled? ' + value);
 };
 
 const sayHello = async () => {

--- a/storage/README.md
+++ b/storage/README.md
@@ -38,7 +38,7 @@ const setName = async () => {
 const checkName = async () => {
   const { value } = await Storage.get({ key: 'name' });
 
-  alert(`Hello ${value}!`);
+  console.log(`Hello ${value}!`);
 };
 
 const removeName = async () => {


### PR DESCRIPTION
Because `alert()` only accept one argument, the second argument `value` will be ignored, and thus the `value` will not be shown on screen in the original example.