### PR TITLE
fix(ios): reset web view height and origin after share is closed #831

### DIFF
--- a/share/ios/Plugin/SharePlugin.swift
+++ b/share/ios/Plugin/SharePlugin.swift
@@ -36,6 +36,10 @@ public class SharePlugin: CAPPlugin {
             }
 
             actionController.completionWithItemsHandler = { (activityType, completed, _ returnedItems, activityError) in
+
+                self?.bridge?.webView?.frame.size.height = UIScreen.main.bounds.size.height;
+                self?.bridge?.webView?.frame.origin.y = 0;
+                
                 if activityError != nil {
                     call.reject("Error sharing item", nil, activityError)
                     return


### PR DESCRIPTION
By no means a swift developer, but this change does address the issue we are having trouble with on share not properly resizing the app/web view after closing.

https://github.com/ionic-team/capacitor-plugins/issues/831