### PR TITLE
fix(camera): Return the image on dismiss completion

### DIFF
--- a/camera/ios/Plugin/CameraPlugin.swift
+++ b/camera/ios/Plugin/CameraPlugin.swift
@@ -158,11 +158,12 @@ extension CameraPlugin: UIImagePickerControllerDelegate, UINavigationControllerD
     }
 
     public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-        picker.dismiss(animated: true, completion: nil)
-        if let processedImage = processImage(from: info) {
-            returnProcessedImage(processedImage)
-        } else {
-            self.call?.reject("Error processing image")
+        picker.dismiss(animated: true) {
+            if let processedImage = self.processImage(from: info) {
+                self.returnProcessedImage(processedImage)
+            } else {
+                self.call?.reject("Error processing image")
+            }
         }
     }
 }


### PR DESCRIPTION
At the moment we are returning the image at the same time that we call dismiss, that causes problems if the user tries to present another native modal with the result (i.e. share plugin).

This PR changes the code to return the image once dismiss is completed, so it's safe to present other modals.
