### PR TITLE
fix(app): get correct build value

### DIFF
--- a/app/android/src/main/java/com/capacitorjs/plugins/app/AppPlugin.java
+++ b/app/android/src/main/java/com/capacitorjs/plugins/app/AppPlugin.java
@@ -6,6 +6,7 @@ import android.content.pm.PackageInfo;
 import android.net.Uri;
 import android.os.Build;
 import androidx.activity.OnBackPressedCallback;
+import androidx.core.content.pm.PackageInfoCompat;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
@@ -75,11 +76,7 @@ public class AppPlugin extends Plugin {
             String appName = stringId == 0 ? applicationInfo.nonLocalizedLabel.toString() : getContext().getString(stringId);
             data.put("name", appName);
             data.put("id", pinfo.packageName);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                data.put("build", Long.toString(pinfo.getLongVersionCode()));
-            } else {
-                data.put("build", Integer.toString(pinfo.versionCode));
-            }
+            data.put("build", Integer.toString((int)PackageInfoCompat.getLongVersionCode(pinfo)));
             data.put("version", pinfo.versionName);
             call.resolve(data);
         } catch (Exception ex) {

--- a/app/android/src/main/java/com/capacitorjs/plugins/app/AppPlugin.java
+++ b/app/android/src/main/java/com/capacitorjs/plugins/app/AppPlugin.java
@@ -76,7 +76,7 @@ public class AppPlugin extends Plugin {
             String appName = stringId == 0 ? applicationInfo.nonLocalizedLabel.toString() : getContext().getString(stringId);
             data.put("name", appName);
             data.put("id", pinfo.packageName);
-            data.put("build", Integer.toString((int)PackageInfoCompat.getLongVersionCode(pinfo)));
+            data.put("build", Integer.toString((int) PackageInfoCompat.getLongVersionCode(pinfo)));
             data.put("version", pinfo.versionName);
             call.resolve(data);
         } catch (Exception ex) {


### PR DESCRIPTION
build value was incorrect for Android >= P devices if `versionCodeMajor` was specified in the AndroidManifest.xml, this PR resolves that problem by getting only the int part of `getLongVersionCode`, which corresponds to the deprecated `versionCode`.
Also uses `PackageInfoCompat` class to avoid the deprecation warning on `versionCode` usage.

closes https://github.com/ionic-team/capacitor-plugins/issues/838