### PR TITLE
chore(filesystem): silence deprecation warnings

### DIFF
--- a/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/Filesystem.java
+++ b/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/Filesystem.java
@@ -180,6 +180,7 @@ public class Filesystem {
         return Base64.encodeToString(byteStream.toByteArray(), Base64.NO_WRAP);
     }
 
+    @SuppressWarnings("deprecation")
     public File getDirectory(String directory) {
         Context c = this.context;
         switch (directory) {


### PR DESCRIPTION
There are no alternatives for those folders, they are just not accessible anymore on Android 10+.
It's already documented on the plugin directory options, so this PR just silence the warnings.

closes https://github.com/ionic-team/capacitor-plugins/issues/841