### PR TITLE
refactor(haptics): replace deprecations

### DIFF
--- a/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/Haptics.java
+++ b/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/Haptics.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Build;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
+import android.os.VibratorManager;
 import com.capacitorjs.plugins.haptics.arguments.HapticsSelectionType;
 import com.capacitorjs.plugins.haptics.arguments.HapticsVibrationType;
 
@@ -15,11 +16,21 @@ public class Haptics {
 
     Haptics(Context context) {
         this.context = context;
-        this.vibrator = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            VibratorManager vibratorManager = (VibratorManager) context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
+            this.vibrator = vibratorManager.getDefaultVibrator();
+        } else {
+            this.vibrator = getDeprecatedVibrator(context);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private Vibrator getDeprecatedVibrator(Context context) {
+        return (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
     }
 
     public void vibrate(int duration) {
-        if (Build.VERSION.SDK_INT >= 26) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             vibrator.vibrate(VibrationEffect.createOneShot(duration, VibrationEffect.DEFAULT_AMPLITUDE));
         } else {
             vibratePre26(duration);
@@ -51,7 +62,7 @@ public class Haptics {
     }
 
     public void performHaptics(HapticsVibrationType type) {
-        if (Build.VERSION.SDK_INT >= 26) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             vibrator.vibrate(VibrationEffect.createWaveform(type.getTimings(), type.getAmplitudes(), -1));
         } else {
             vibratePre26(type.getOldSDKPattern(), -1);


### PR DESCRIPTION
Suppress deprecation warning on `Context.VIBRATOR_SERVICE`
Also, replace hardcoded 26 with `Build.VERSION_CODES.O`

closes https://github.com/ionic-team/capacitor-plugins/issues/842