### PR TITLE
Make camera prompt cancelable

### DIFF
--- a/camera/src/definitions.ts
+++ b/camera/src/definitions.ts
@@ -173,6 +173,14 @@ export interface ImageOptions {
    * @since 1.0.0
    */
   promptLabelPicture?: string;
+
+  /**
+   * Make prompt cancelable
+   * If true, prompt will dissmis when overlay is clicked
+   * 
+   * @default: false
+   */
+  promptCancelable?: boolean;
 }
 
 export interface Photo {

--- a/camera/src/web.ts
+++ b/camera/src/web.ts
@@ -23,7 +23,7 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
           document.body.appendChild(actionSheet);
         }
         actionSheet.header = options.promptLabelHeader || 'Photo';
-        actionSheet.cancelable = false;
+        actionSheet.cancelable = options.promptCancelable || false;
         actionSheet.options = [
           { title: options.promptLabelPhoto || 'From Photos' },
           { title: options.promptLabelPicture || 'Take Picture' },


### PR DESCRIPTION
Added ability to make camera prompt cancelable. When set to true, clicking on overlay will dismiss prompt.