### PR TITLE
docs(keyboard): update TS config example w/ enum

### DIFF
--- a/keyboard/README.md
+++ b/keyboard/README.md
@@ -66,11 +66,12 @@ In `capacitor.config.ts`:
 /// <reference types="@capacitor/keyboard" />
 
 import { CapacitorConfig } from '@capacitor/cli';
+import { KeyboardResize } from '@capacitor/keyboard';
 
 const config: CapacitorConfig = {
   plugins: {
     Keyboard: {
-      resize: "body",
+      resize: KeyboardResize.Body,
       style: "dark",
       resizeOnFullScreen: true,
     },


### PR DESCRIPTION
Update the Keyboard plugin documentation to use the `KeyboardResize` enumeration for the TypeScript Capacitor configuration example.