### PR TITLE
Animate splash screen using multiple images

### DIFF
--- a/splash-screen/README.md
+++ b/splash-screen/README.md
@@ -64,6 +64,39 @@ For iOS, `iosSpinnerStyle` has the following options:
 
 To set the color of the spinner use `spinnerColor`, values are either `#RRGGBB` or `#RRGGBBAA`.
 
+## Animated Splash Screen
+### iOS
+If you want to have an animated splash screen on iOS, set `animated` to `true`, and `launchAnimationDuration` to the desired animation length in milliseconds in your [Capacitor configuration file] (https://capacitorjs.com/docs/config).
+
+Once done, you can add the splash screen assets into your app's `Assets.xcassets` file inside a folder called `Splash`. Each frame should be placed in order, with `Splash_xx` (where xx is the number it belongs to in sequence, e.g. splash_1.png, splash_2.png, ...).
+
+## Android
+If you want to have an animated splash screen on Android, create a `splash.xml` in your app's `res/drawable` folder with an animation list showing the location and duration of each frame.
+
+For example:
+
+```
+<?xml version="1.0" encoding="utf-8"?>
+<animation-list xmlns:android="http://schemas.android.com/apk/res/android" android:oneshot="false">
+	<item android:duration="22" android:drawable="@drawable/splash_1">
+	</item>
+	<item android:duration="22" android:drawable="@drawable/splash_2">
+	</item>
+	<item android:duration="22" android:drawable="@drawable/splash_3">
+	</item>
+	<item android:duration="22" android:drawable="@drawable/splash_4">
+	</item>
+	<item android:duration="22" android:drawable="@drawable/splash_5">
+	</item>
+	<item android:duration="22" android:drawable="@drawable/splash_6">
+	</item>
+	<item android:duration="22" android:drawable="@drawable/splash_7">
+	</item>
+</animation-list>
+```
+
+Be sure to correctly scale your images as well, as not scaling them may cause significant performance degradation when loading your app.
+
 ## Configuration
 
 <docgen-config>
@@ -86,6 +119,8 @@ These config values are available:
 | **`splashImmersive`**           | <code>boolean</code>                                                                                                          | Hide the status bar and the software navigation buttons on the Splash Screen. Only available on Android.                                                                                                     |                     | 1.0.0 |
 | **`layoutName`**                | <code>string</code>                                                                                                           | If `useDialog` is set to true, configure the Dialog layout. If `useDialog` is not set or false, use a layout instead of the ImageView. Only available on Android.                                            |                     | 1.1.0 |
 | **`useDialog`**                 | <code>boolean</code>                                                                                                          | Use a Dialog instead of an ImageView. If `layoutName` is not configured, it will use a layout that uses the splash image as background. Only available on Android.                                           |                     | 1.1.0 |
+| **`animated`**                  | <code>boolean</code>                                                                                                          | Animate the splash screen using a series of image files.                                                                                                                                                     |                     | 1.2.3 |
+| **`launchAnimationDuration`**   | <code>number</code>                                                                                                           | Play the multiple frames across the amount of milliseconds specified.                                                                                                                                        |                     | 1.2.3 |
 
 ### Examples
 
@@ -107,7 +142,9 @@ In `capacitor.config.json`:
       "splashFullScreen": true,
       "splashImmersive": true,
       "layoutName": "launch_screen",
-      "useDialog": true
+      "useDialog": true,
+      "animated": true,
+      "launchAnimationDuration": 3000
     }
   }
 }
@@ -136,6 +173,8 @@ const config: CapacitorConfig = {
       splashImmersive: true,
       layoutName: "launch_screen",
       useDialog: true,
+      animated: true,
+      launchAnimationDuration: 3000,
     },
   },
 };

--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
@@ -10,6 +10,7 @@ import android.graphics.PixelFormat;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
+import android.os.Build;
 import android.os.Handler;
 import android.view.*;
 import android.view.animation.LinearInterpolator;
@@ -266,7 +267,17 @@ public class SplashScreen {
     }
 
     private Drawable getSplashDrawable() {
-        int splashId = context.getResources().getIdentifier(config.getResourceName(), "drawable", context.getPackageName());
+        int splashId;
+        // Disables animations on older versions of Android as it may cause OOM issues.
+        if (config.getAnimated() == true && Build.VERSION.SDK_INT <= Build.VERSION_CODES.N) {
+            // Uses the first image in the animation sequence in the aforementioned case.
+            splashId = context.getResources().getIdentifier(config.getResourceName() + "_0", "drawable", context.getPackageName());
+        } else {
+            // In all other cases, use the splash resource.
+            // In the case it is an animation, it would be an Animation List XML which would play in sequence.
+            // Otherwise, it should be just a standard image file.
+            splashId = context.getResources().getIdentifier(config.getResourceName(), "drawable", context.getPackageName());
+        }
         try {
             Drawable drawable = context.getResources().getDrawable(splashId, context.getTheme());
             return drawable;

--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenConfig.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenConfig.java
@@ -17,6 +17,8 @@ public class SplashScreenConfig {
     private ScaleType scaleType = ScaleType.FIT_XY;
     private boolean usingDialog = false;
     private String layoutName;
+    // This is used to determine whether a series of images should be used to animate the splash screen.
+    private boolean animated = false;
 
     public Integer getBackgroundColor() {
         return backgroundColor;
@@ -116,5 +118,15 @@ public class SplashScreenConfig {
 
     public void setLayoutName(String layoutName) {
         this.layoutName = layoutName;
+    }
+
+    // This is used to read the config for whether the splash screen should be animated.
+    public boolean getAnimated() {
+        return animated;
+    }
+
+    // This is used to set the config for whether the splash screen should be animated.
+    public void setAnimated(Boolean animated) {
+        this.animated = animated;
     }
 }

--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
@@ -40,6 +40,13 @@ public class SplashScreenPlugin extends Plugin {
         );
     }
 
+    // Show and update progress of progress bar.
+    @PluginMethod
+    public void updateProgress(final PluginCall call) {
+        splashScreen.updateProgress(getActivity(), call.getFloat("progress", (float) 0));
+        call.resolve();
+    }
+
     @PluginMethod
     public void hide(PluginCall call) {
         if (config.isUsingDialog()) {

--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
@@ -155,6 +155,12 @@ public class SplashScreenPlugin extends Plugin {
             config.setLayoutName(getConfig().getString("layoutName"));
         }
 
+        // This reads the Capacitor config for whether the splash screen should be animated.
+        // Defaults to false.
+        Boolean animated = getConfig().getBoolean("animated", false);
+        // Set the config that the splash screen should/should not be animated.
+        config.setAnimated(animated);
+
         return config;
     }
 }

--- a/splash-screen/ios/Plugin/SplashScreenConfig.swift
+++ b/splash-screen/ios/Plugin/SplashScreenConfig.swift
@@ -8,4 +8,8 @@ public struct SplashScreenConfig {
     var launchShowDuration = 500
     var launchAutoHide = true
     let launchFadeInDuration = 0
+    // How long it should take to flick through all the images for an animation.
+    var launchAnimationDuration = 3000
+    // Whether a splash screen should be animated.
+    var animated = false
 }

--- a/splash-screen/ios/Plugin/SplashScreenPlugin.m
+++ b/splash-screen/ios/Plugin/SplashScreenPlugin.m
@@ -5,5 +5,7 @@
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
 CAP_PLUGIN(SplashScreenPlugin, "SplashScreen",
            CAP_PLUGIN_METHOD(show, CAPPluginReturnPromise);
+           // Show and update progress of progress bar.
+           CAP_PLUGIN_METHOD(updateProgress, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(hide, CAPPluginReturnPromise);
 )

--- a/splash-screen/ios/Plugin/SplashScreenPlugin.swift
+++ b/splash-screen/ios/Plugin/SplashScreenPlugin.swift
@@ -82,6 +82,14 @@ public class SplashScreenPlugin: CAPPlugin {
         if let launchAutoHide = getConfigValue("launchAutoHide") as? Bool {
             config.launchAutoHide = launchAutoHide
         }
+        // Animate the splash screen using multiple image files.
+        if let animated = getConfigValue("animated") as? Bool {
+            config.animated = animated
+        }
+        // Play the multiple image frames across the amount of milliseconds specified.
+        if let launchAnimationDuration = getConfigValue("launchAnimationDuration") as? Int {
+            config.launchAnimationDuration = launchAnimationDuration
+        }
         return config
     }
 

--- a/splash-screen/ios/Plugin/SplashScreenPlugin.swift
+++ b/splash-screen/ios/Plugin/SplashScreenPlugin.swift
@@ -26,6 +26,16 @@ public class SplashScreenPlugin: CAPPlugin {
 
     }
 
+    // Show and update progress of progress bar.
+    @objc public func updateProgress(_ call: CAPPluginCall) {
+        if let splash = splashScreen {
+            splash.updateProgress(percentage: call.getFloat("progress", 0))
+            call.resolve()
+        } else {
+            call.reject("Unable to hide Splash Screen")
+        }
+    }
+
     // Hide the splash screen
     @objc public func hide(_ call: CAPPluginCall) {
         if let splash = splashScreen {

--- a/splash-screen/src/definitions.ts
+++ b/splash-screen/src/definitions.ts
@@ -153,6 +153,22 @@ declare module '@capacitor/cli' {
        * @example true
        */
       useDialog?: boolean;
+
+      /**
+       * Animate the splash screen using a series of image files.
+       *
+       * @since 1.2.3
+       * @example true
+       */
+      animated?: boolean;
+
+       /**
+       * Play the multiple frames across the amount of milliseconds specified.
+       *
+       * @since 1.2.3
+       * @example 3000
+       */
+      launchAnimationDuration?: number;
     };
   }
 }

--- a/splash-screen/src/definitions.ts
+++ b/splash-screen/src/definitions.ts
@@ -203,6 +203,15 @@ export interface ShowOptions {
   showDuration?: number;
 }
 
+export interface UpdateProgressOptions {
+  /**
+   * Set percentage of progress bar.
+   *
+   * @since 1.2.3
+   */
+  progress: number;
+}
+
 export interface HideOptions {
   /**
    * How long (in ms) to fade out.
@@ -220,6 +229,12 @@ export interface SplashScreenPlugin {
    * @since 1.0.0
    */
   show(options?: ShowOptions): Promise<void>;
+  /**
+   * Update progress of splash screen
+   *
+   * @since 1.2.3
+   */
+  updateProgress(options: UpdateProgressOptions): Promise<void>;
   /**
    * Hide the splash screen
    *

--- a/splash-screen/src/web.ts
+++ b/splash-screen/src/web.ts
@@ -4,10 +4,16 @@ import type {
   HideOptions,
   ShowOptions,
   SplashScreenPlugin,
+  UpdateProgressOptions,
 } from './definitions';
 
 export class SplashScreenWeb extends WebPlugin implements SplashScreenPlugin {
   async show(_options?: ShowOptions): Promise<void> {
+    return undefined;
+  }
+
+  // Show and update progress of progress bar.
+  async updateProgress(_options?: UpdateProgressOptions): Promise<void> {
     return undefined;
   }
 


### PR DESCRIPTION
This PR enables users to animate their splash screen using multiple PNGs on iOS (and Android, with some instructions), and adds instructions on how to use it in the README.md.

closes  #935