### PR TITLE
docs(push-notifications): Update iOS code & add link to setup guide

### DIFF
--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -2,6 +2,8 @@
 
 The Push Notifications API provides access to native push notifications.
 
+For a detailed setup guide, see [Push Notifications - Firebase](https://capacitorjs.com/docs/guides/push-notifications-firebase).
+
 ## Install
 
 ```bash
@@ -17,9 +19,15 @@ After enabling the Push Notifications capability, add the following to your app'
 
 ```swift
 func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-  NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
+  Messaging.messaging().apnsToken = deviceToken
+  Messaging.messaging().token(completion: { (token, error) in
+    if let error = error {
+        NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+    } else if let token = token {
+        NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: token)
+    }
+  })
 }
-
 func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
   NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
 }


### PR DESCRIPTION
The code in the [Push Notification guide](https://capacitorjs.com/docs/guides/push-notifications-firebase) was recently updated in this [commit](https://github.com/ionic-team/capacitor-site/commit/f46f05d0f5aa5da39f8545364de8addf23f36eb3) clarifying the FCM token is needed in Firebase for sending push notifications to iOS and not the APN token. To reduce confusion, I've updated the code here as well.

I've also added a link to the more detailed guide of setting up push notifications. There seems to be quite a few questions on the Ionic Forum about setup. The most recent is [here](https://forum.ionicframework.com/t/ios-push-notifications-not-being-received-after-capacitor-2-3-and-ionic-5-6-migration/222497) which prompted this PR.