### PR TITLE
refactor(filesystem): unify StatResult

### DIFF
--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -435,13 +435,13 @@ Required on Android, only when using <a href="#directory">`Directory.Documents`<
 
 #### StatResult
 
-| Prop        | Type                | Description                                                                          | Since |
-| ----------- | ------------------- | ------------------------------------------------------------------------------------ | ----- |
-| **`type`**  | <code>string</code> | Type of the file                                                                     | 1.0.0 |
-| **`size`**  | <code>number</code> | Size of the file                                                                     | 1.0.0 |
-| **`ctime`** | <code>number</code> | Time of creation in milliseconds. It's not available on Android 7 and older devices. | 1.0.0 |
-| **`mtime`** | <code>number</code> | Time of last modification in milliseconds.                                           | 1.0.0 |
-| **`uri`**   | <code>string</code> | The uri of the file                                                                  | 1.0.0 |
+| Prop        | Type                               | Description                                                                          | Since |
+| ----------- | ---------------------------------- | ------------------------------------------------------------------------------------ | ----- |
+| **`type`**  | <code>'directory' \| 'file'</code> | Type of the file.                                                                    | 1.0.0 |
+| **`size`**  | <code>number</code>                | Size of the file in bytes.                                                           | 1.0.0 |
+| **`ctime`** | <code>number</code>                | Time of creation in milliseconds. It's not available on Android 7 and older devices. | 1.0.0 |
+| **`mtime`** | <code>number</code>                | Time of last modification in milliseconds.                                           | 1.0.0 |
+| **`uri`**   | <code>string</code>                | The uri of the file                                                                  | 1.0.0 |
 
 
 #### StatOptions

--- a/filesystem/ios/Plugin/Filesystem.swift
+++ b/filesystem/ios/Plugin/Filesystem.swift
@@ -103,6 +103,15 @@ import Foundation
         return try FileManager.default.attributesOfItem(atPath: fileUrl.path)
     }
 
+    func getType(from attr: [FileAttributeKey: Any]) -> String {
+        let fileType = attr[.type] as? String ?? ""
+        if fileType == "NSFileTypeDirectory" {
+            return "directory"
+        } else {
+            return "file"
+        }
+    }
+
     @objc public func rename(at srcURL: URL, to dstURL: URL) throws {
         try _copy(at: srcURL, to: dstURL, doRename: true)
     }

--- a/filesystem/ios/Plugin/FilesystemPlugin.swift
+++ b/filesystem/ios/Plugin/FilesystemPlugin.swift
@@ -226,8 +226,8 @@ public class FilesystemPlugin: CAPPlugin {
             }
 
             call.resolve([
-                "type": attr[.type] as? String ?? "",
-                "size": attr[.size] as? UInt64 ?? "",
+                "type": implementation.getType(from: attr),
+                "size": attr[.size] as? UInt64 ?? 0,
                 "ctime": ctime,
                 "mtime": mtime,
                 "uri": fileUrl.absoluteString

--- a/filesystem/src/definitions.ts
+++ b/filesystem/src/definitions.ts
@@ -385,14 +385,14 @@ export interface GetUriResult {
 
 export interface StatResult {
   /**
-   * Type of the file
+   * Type of the file.
    *
    * @since 1.0.0
    */
-  type: string;
+  type: 'directory' | 'file';
 
   /**
-   * Size of the file
+   * Size of the file in bytes.
    *
    * @since 1.0.0
    */

--- a/filesystem/src/web.ts
+++ b/filesystem/src/web.ts
@@ -602,7 +602,7 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
 interface EntryObj {
   path: string;
   folder: string;
-  type: string;
+  type: 'directory' | 'file';
   size: number;
   ctime: number;
   mtime: number;


### PR DESCRIPTION
Improved documentation around StatResult

Make iOS return "file" or "directory" for type as web and Android do.

closes https://github.com/ionic-team/capacitor-plugins/issues/380