### PR TITLE
fix(filesystem): Prevent android crash on invalid base64 write

### DIFF
--- a/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/FilesystemPlugin.java
+++ b/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/FilesystemPlugin.java
@@ -169,6 +169,8 @@ public class FilesystemPlugin extends Plugin {
                 ex
             );
             call.reject("FILE_NOTCREATED");
+        } catch (IllegalArgumentException ex) {
+            call.reject("The supplied data is not valid base64 content.");
         }
     }
 


### PR DESCRIPTION
closes https://github.com/ionic-team/capacitor-plugins/issues/901