### PR TITLE
hotfix(maps): Cast item.bounds to compare as Double instead of CGFloat for XCode 12 support

### DIFF
--- a/google-maps/ios/Plugin/Map.swift
+++ b/google-maps/ios/Plugin/Map.swift
@@ -94,7 +94,11 @@ public class Map {
                     if let typeClass = NSClassFromString("WKChildScrollView"), item.isKind(of: typeClass) {
                         (item as? UIScrollView)?.isScrollEnabled = true
 
-                        if item.bounds.width == self.config.width && item.bounds.height == self.config.height && (item as? UIView)?.tag == 0 {
+                        let isWidthEqual = Double(item.bounds.width) == self.config.width
+                        let isHeightEqual = Double(item.bounds.height) == self.config.height
+
+                        if (isWidthEqual && isHeightEqual && (item as? UIView)?.tag == 0)
+                        {
                             self.targetViewController = item
                             break
                         }


### PR DESCRIPTION
In XCode 13 (Swift 5.5) this is not an issue. On XCode 12 (Swift 5.4), the ScrollView.bounds variables are `CGFloat` and not `Double` so the compiler gets mad at us