### PR TITLE
chore(push-notifications): Correct plugin version

### DIFF
--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -508,7 +508,7 @@ Remove all native listeners for this plugin.
 
 | Prop        | Type                | Description                                        | Since |
 | ----------- | ------------------- | -------------------------------------------------- | ----- |
-| **`error`** | <code>string</code> | Error message describing the registration failure. | 2.0.0 |
+| **`error`** | <code>string</code> | Error message describing the registration failure. | 4.0.0 |
 
 
 #### ActionPerformed

--- a/push-notifications/src/definitions.ts
+++ b/push-notifications/src/definitions.ts
@@ -296,7 +296,7 @@ export interface RegistrationError {
   /**
    * Error message describing the registration failure.
    *
-   * @since 2.0.0
+   * @since 4.0.0
    */
   error: string;
 }


### PR DESCRIPTION
This was documented as available on version 2.0.0 before it was decided to use version 4.0.0 as next major version instead of 2.0.0