### PR TITLE
fix(local-notifications): Handle case of not allowed exact notifications

### DIFF
--- a/local-notifications/README.md
+++ b/local-notifications/README.md
@@ -9,6 +9,16 @@ npm install @capacitor/local-notifications
 npx cap sync
 ```
 
+## Android
+
+Starting on Android 12, scheduled notifications won't be exact unless this permission is added to your `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+```
+
+Note that even if the permission is present, users can still disable exact notifications from the app settings.
+
 ## Configuration
 
 <docgen-config>

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
@@ -377,7 +377,12 @@ public class LocalNotificationManager {
         }
     }
 
-    private void setExactIfPossible(AlarmManager alarmManager, LocalNotificationSchedule schedule, long trigger, PendingIntent pendingIntent) {
+    private void setExactIfPossible(
+        AlarmManager alarmManager,
+        LocalNotificationSchedule schedule,
+        long trigger,
+        PendingIntent pendingIntent
+    ) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms()) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && schedule.allowWhileIdle()) {
                 alarmManager.setAndAllowWhileIdle(AlarmManager.RTC, trigger, pendingIntent);

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
@@ -349,11 +349,7 @@ public class LocalNotificationManager {
                 long interval = at.getTime() - new Date().getTime();
                 alarmManager.setRepeating(AlarmManager.RTC, at.getTime(), interval, pendingIntent);
             } else {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && schedule.allowWhileIdle()) {
-                    alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC, at.getTime(), pendingIntent);
-                } else {
-                    alarmManager.setExact(AlarmManager.RTC, at.getTime(), pendingIntent);
-                }
+                setExactIfPossible(alarmManager, schedule, at.getTime(), pendingIntent);
             }
             return;
         }
@@ -375,14 +371,25 @@ public class LocalNotificationManager {
             long trigger = on.nextTrigger(new Date());
             notificationIntent.putExtra(TimedNotificationPublisher.CRON_KEY, on.toMatchString());
             pendingIntent = PendingIntent.getBroadcast(context, request.getId(), notificationIntent, flags);
+            setExactIfPossible(alarmManager, schedule, trigger, pendingIntent);
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+            Logger.debug(Logger.tags("LN"), "notification " + request.getId() + " will next fire at " + sdf.format(new Date(trigger)));
+        }
+    }
+
+    private void setExactIfPossible(AlarmManager alarmManager, LocalNotificationSchedule schedule, long trigger, PendingIntent pendingIntent) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms()) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && schedule.allowWhileIdle()) {
+                alarmManager.setAndAllowWhileIdle(AlarmManager.RTC, trigger, pendingIntent);
+            } else {
+                alarmManager.set(AlarmManager.RTC, trigger, pendingIntent);
+            }
+        } else {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && schedule.allowWhileIdle()) {
                 alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC, trigger, pendingIntent);
             } else {
                 alarmManager.setExact(AlarmManager.RTC, trigger, pendingIntent);
             }
-
-            SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-            Logger.debug(Logger.tags("LN"), "notification " + request.getId() + " will next fire at " + sdf.format(new Date(trigger)));
         }
     }
 

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
@@ -7,6 +7,8 @@ import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
+
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
 import java.text.SimpleDateFormat;
@@ -49,7 +51,11 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
             long trigger = date.nextTrigger(new Date());
             Intent clone = (Intent) intent.clone();
             PendingIntent pendingIntent = PendingIntent.getBroadcast(context, id, clone, PendingIntent.FLAG_CANCEL_CURRENT);
-            alarmManager.setExact(AlarmManager.RTC, trigger, pendingIntent);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms() ) {
+                alarmManager.set(AlarmManager.RTC, trigger, pendingIntent);
+            } else {
+                alarmManager.setExact(AlarmManager.RTC, trigger, pendingIntent);
+            }
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
             Logger.debug(Logger.tags("LN"), "notification " + id + " will next fire at " + sdf.format(new Date(trigger)));
             return true;

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
@@ -8,7 +8,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
 import java.text.SimpleDateFormat;
@@ -51,7 +50,7 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
             long trigger = date.nextTrigger(new Date());
             Intent clone = (Intent) intent.clone();
             PendingIntent pendingIntent = PendingIntent.getBroadcast(context, id, clone, PendingIntent.FLAG_CANCEL_CURRENT);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms() ) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms()) {
                 alarmManager.set(AlarmManager.RTC, trigger, pendingIntent);
             } else {
                 alarmManager.setExact(AlarmManager.RTC, trigger, pendingIntent);


### PR DESCRIPTION
Use set/setAndAllowWhileIdle when exact notifications are not allowed on SDK >= 31 