### PR TITLE
chore(splash-screen): use getConfig instead of getConfigValue

### DIFF
--- a/splash-screen/ios/Plugin/SplashScreenPlugin.swift
+++ b/splash-screen/ios/Plugin/SplashScreenPlugin.swift
@@ -58,10 +58,10 @@ public class SplashScreenPlugin: CAPPlugin {
     private func splashScreenConfig() -> SplashScreenConfig {
         var config = SplashScreenConfig()
 
-        if let backgroundColor = getConfigValue("backgroundColor") as? String {
+        if let backgroundColor = getConfig().getString(configKey: "backgroundColor") {
             config.backgroundColor = UIColor.capacitor.color(fromHex: backgroundColor)
         }
-        if let spinnerStyle = getConfigValue("iosSpinnerStyle") as? String {
+        if let spinnerStyle = getConfig().getString(configKey: "iosSpinnerStyle") {
             switch spinnerStyle.lowercased() {
             case "small":
                 config.spinnerStyle = .white
@@ -69,19 +69,13 @@ public class SplashScreenPlugin: CAPPlugin {
                 config.spinnerStyle = .whiteLarge
             }
         }
-        if let spinnerColor = getConfigValue("spinnerColor") as? String {
+        if let spinnerColor = getConfig().getString(configKey: "spinnerColor") {
             config.spinnerColor = UIColor.capacitor.color(fromHex: spinnerColor)
         }
-        if let showSpinner = getConfigValue("showSpinner") as? Bool {
-            config.showSpinner = showSpinner
-        }
+        config.showSpinner = getConfig().getBoolean(configKey: "showSpinner", defaultValue: config.showSpinner)
 
-        if let launchShowDuration = getConfigValue("launchShowDuration") as? Int {
-            config.launchShowDuration = launchShowDuration
-        }
-        if let launchAutoHide = getConfigValue("launchAutoHide") as? Bool {
-            config.launchAutoHide = launchAutoHide
-        }
+        config.launchShowDuration = getConfig().getInt(configKey: "launchShowDuration", defaultValue: config.launchShowDuration)
+        config.launchAutoHide = getConfig().getBoolean(configKey: "launchAutoHide", defaultValue: config.launchAutoHide)
         return config
     }
 


### PR DESCRIPTION
Just wondering, should we change the @capacitor/ios implementation to not use labels?

i.e. so we can do
```
getConfig().getString("backgroundColor")
getConfig().getBoolean("launchAutoHide", config.launchAutoHide)
```
instead of
```
getConfig().getString(configKey: "backgroundColor")
getConfig().getBoolean(configKey: "launchAutoHide", defaultValue: config.launchAutoHide)
```