### PR TITLE
chore(google-maps): bump default androidxAppCompatVersion version

### DIFF
--- a/google-maps/android/build.gradle
+++ b/google-maps/android/build.gradle
@@ -1,6 +1,6 @@
 ext {
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
-    androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.2.0'
+    androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.4.0'
 }


### PR DESCRIPTION
we couldn't update before capacitor 4 was being used, now we can, so bump the androidxAppCompatVersion default value to latest available to match other plugins