### PR TITLE
chore(browser): remove supportsPopover() usage

### DIFF
--- a/browser/ios/Plugin/BrowserPlugin.swift
+++ b/browser/ios/Plugin/BrowserPlugin.swift
@@ -50,7 +50,7 @@ public class CAPBrowserPlugin: CAPPlugin {
     }
 
     private func presentationStyle(for style: String?) -> UIModalPresentationStyle {
-        if let style = style, style == "popover", supportsPopover() {
+        if let style = style, style == "popover" {
             return .popover
         }
         return .fullScreen


### PR DESCRIPTION
It's deprecated and no longer needed as on iOS 13+ it's always supported