### PR TITLE
chore(local-notifications): use non deprecated type for createChannel

### DIFF
--- a/local-notifications/README.md
+++ b/local-notifications/README.md
@@ -188,7 +188,7 @@ Check if notifications are enabled or not.
 ### createChannel(...)
 
 ```typescript
-createChannel(channel: NotificationChannel) => Promise<void>
+createChannel(channel: Channel) => Promise<void>
 ```
 
 Create a notification channel.
@@ -600,11 +600,6 @@ An action that can be taken when a notification is displayed.
 <code>'year' | 'month' | 'two-weeks' | 'week' | 'day' | 'hour' | 'minute' | 'second'</code>
 
 
-#### NotificationChannel
-
-<code><a href="#channel">Channel</a></code>
-
-
 #### Importance
 
 The importance level. For more details, see the [Android Developer Docs](https://developer.android.com/reference/android/app/NotificationManager#IMPORTANCE_DEFAULT)
@@ -617,6 +612,11 @@ The importance level. For more details, see the [Android Developer Docs](https:/
 The notification visibility. For more details, see the [Android Developer Docs](https://developer.android.com/reference/androidx/core/app/NotificationCompat#VISIBILITY_PRIVATE)
 
 <code>-1 | 0 | 1</code>
+
+
+#### NotificationChannel
+
+<code><a href="#channel">Channel</a></code>
 
 
 #### PermissionState

--- a/local-notifications/src/definitions.ts
+++ b/local-notifications/src/definitions.ts
@@ -98,7 +98,7 @@ export interface LocalNotificationsPlugin {
    *
    * @since 1.0.0
    */
-  createChannel(channel: NotificationChannel): Promise<void>;
+  createChannel(channel: Channel): Promise<void>;
 
   /**
    * Delete a notification channel.


### PR DESCRIPTION
while working on https://github.com/ionic-team/capacitor-plugins/pull/1015 I noticed createChannel was using the deprecated NotificationChannel type instead of the non deprecated alternative (Channel), so I've changed it.

I've verified that all the other plugins are using non deprecated types