### PR TITLE
fix(ios): Check if UIApplicationDelegate responds to window selector before calling it.

### DIFF
--- a/keyboard/ios/Plugin/Keyboard.m
+++ b/keyboard/ios/Plugin/Keyboard.m
@@ -200,7 +200,12 @@ NSString* UITraitsClassString;
     _paddingBottom = _paddingBottom + 20;
   }
   CGRect f, wf = CGRectZero;
-  UIWindow * window = [[[UIApplication sharedApplication] delegate] window];
+  UIWindow * window = nil;
+    
+  if ([[[UIApplication sharedApplication] delegate] respondsToSelector:@selector(window)]) {
+    window = [[[UIApplication sharedApplication] delegate] window];
+  }
+  
   if (!window) {
     if (@available(iOS 13.0, *)) {
       UIScene *scene = [UIApplication sharedApplication].connectedScenes.allObjects.firstObject;


### PR DESCRIPTION
When using the Keyboard plugin, a crash is occurring on iOS 15 when attempting to access a window property that doesn't exist:
![Screen Shot 2022-06-10 at 12 01 41 AM](https://user-images.githubusercontent.com/24440751/172993721-66e1afc1-ceea-4941-884e-22b4fe477cbc.png)

This PR adds a check make sure `UIApplicationDelegate` responds to the window selector before attempting to access it.
