### PR TITLE
fix(push-notifications): use id and tag for canceling active notification

### DIFF
--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -452,7 +452,7 @@ Remove all native listeners for this plugin.
 | **`subtitle`**     | <code>string</code>  | The notification subtitle.                                                                                           | 1.0.0 |
 | **`body`**         | <code>string</code>  | The main text payload for the notification.                                                                          | 1.0.0 |
 | **`id`**           | <code>string</code>  | The notification identifier.                                                                                         | 1.0.0 |
-| **`tag`**          | <code>string</code>  | The notification tag. Only available on Android (from push notifications).                                           | 1.0.9 |
+| **`tag`**          | <code>string</code>  | The notification tag. Only available on Android (from push notifications).                                           | 4.0.0 |
 | **`badge`**        | <code>number</code>  | The number to display for the app icon badge.                                                                        | 1.0.0 |
 | **`notification`** | <code>any</code>     | It's not being returned.                                                                                             | 1.0.0 |
 | **`data`**         | <code>any</code>     | Any additional data that was included in the push notification payload.                                              | 1.0.0 |

--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -452,6 +452,7 @@ Remove all native listeners for this plugin.
 | **`subtitle`**     | <code>string</code>  | The notification subtitle.                                                                                           | 1.0.0 |
 | **`body`**         | <code>string</code>  | The main text payload for the notification.                                                                          | 1.0.0 |
 | **`id`**           | <code>string</code>  | The notification identifier.                                                                                         | 1.0.0 |
+| **`tag`**          | <code>string</code>  | The notification tag. Only available on Android (from push notifications).                                           | 1.0.9 |
 | **`badge`**        | <code>number</code>  | The number to display for the app icon badge.                                                                        | 1.0.0 |
 | **`notification`** | <code>any</code>     | It's not being returned.                                                                                             | 1.0.0 |
 | **`data`**         | <code>any</code>     | Any additional data that was included in the push notification payload.                                              | 1.0.0 |

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -134,7 +134,7 @@ public class PushNotificationsPlugin extends Plugin {
                 if (o instanceof JSONObject) {
                     JSObject notif = JSObject.fromJSONObject((JSONObject) o);
                     String tag = notif.getString("tag");
-                    Integer id = notif.getInteger("id", 0);
+                    Integer id = notif.getInteger("id");
 
                     if (tag == null) {
                         notificationManager.cancel(id);

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -98,6 +98,7 @@ public class PushNotificationsPlugin extends Plugin {
                 JSObject jsNotif = new JSObject();
 
                 jsNotif.put("id", notif.getId());
+                jsNotif.put("tag", notif.getTag());
 
                 Notification notification = notif.getNotification();
                 if (notification != null) {
@@ -105,7 +106,6 @@ public class PushNotificationsPlugin extends Plugin {
                     jsNotif.put("body", notification.extras.getCharSequence(Notification.EXTRA_TEXT));
                     jsNotif.put("group", notification.getGroup());
                     jsNotif.put("groupSummary", 0 != (notification.flags & Notification.FLAG_GROUP_SUMMARY));
-                    jsNotif.put("tag", notification.extras.getCharSequence(Notification.EXTRA_NOTIFICATION_TAG));
 
                     JSObject extras = new JSObject();
 

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -134,7 +134,7 @@ public class PushNotificationsPlugin extends Plugin {
                 if (o instanceof JSONObject) {
                     JSObject notif = JSObject.fromJSONObject((JSONObject) o);
                     String tag = notif.getString("tag");
-                    Integer id = notif.getInteger("id");
+                    Integer id = notif.getInteger("id", 0);
                     
                     if (tag == null) {
                         notificationManager.cancel(id);

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -135,7 +135,7 @@ public class PushNotificationsPlugin extends Plugin {
                     JSObject notif = JSObject.fromJSONObject((JSONObject) o);
                     String tag = notif.getString("tag");
                     Integer id = notif.getInteger("id", 0);
-                    
+
                     if (tag == null) {
                         notificationManager.cancel(id);
                     } else {

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -129,13 +129,13 @@ public class PushNotificationsPlugin extends Plugin {
     public void removeDeliveredNotifications(PluginCall call) {
         JSArray notifications = call.getArray("notifications");
 
-        List<Integer> ids = new ArrayList<>();
+        List<String> tags = new ArrayList<>();
         try {
             for (Object o : notifications.toList()) {
                 if (o instanceof JSONObject) {
                     JSObject notif = JSObject.fromJSONObject((JSONObject) o);
-                    Integer id = notif.getInteger("id");
-                    ids.add(id);
+                    String tag = notif.getString("tag");
+                    tags.add(tag);
                 } else {
                     call.reject("Expected notifications to be a list of notification objects");
                 }
@@ -144,8 +144,8 @@ public class PushNotificationsPlugin extends Plugin {
             call.reject(e.getMessage());
         }
 
-        for (int id : ids) {
-            notificationManager.cancel(id);
+        for (String tag : tags) {
+            notificationManager.cancel(tag, 0);
         }
 
         call.resolve();

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -105,6 +105,7 @@ public class PushNotificationsPlugin extends Plugin {
                     jsNotif.put("body", notification.extras.getCharSequence(Notification.EXTRA_TEXT));
                     jsNotif.put("group", notification.getGroup());
                     jsNotif.put("groupSummary", 0 != (notification.flags & Notification.FLAG_GROUP_SUMMARY));
+                    jsNotif.put("tag", notification.extras.getCharSequence(Notification.EXTRA_NOTIFICATION_TAG));
 
                     JSObject extras = new JSObject();
 

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -129,23 +129,24 @@ public class PushNotificationsPlugin extends Plugin {
     public void removeDeliveredNotifications(PluginCall call) {
         JSArray notifications = call.getArray("notifications");
 
-        List<String> tags = new ArrayList<>();
         try {
             for (Object o : notifications.toList()) {
                 if (o instanceof JSONObject) {
                     JSObject notif = JSObject.fromJSONObject((JSONObject) o);
                     String tag = notif.getString("tag");
-                    tags.add(tag);
+                    Integer id = notif.getInteger("id");
+                    
+                    if (tag == null) {
+                        notificationManager.cancel(id);
+                    } else {
+                        notificationManager.cancel(tag, id);
+                    }
                 } else {
                     call.reject("Expected notifications to be a list of notification objects");
                 }
             }
         } catch (JSONException e) {
             call.reject(e.getMessage());
-        }
-
-        for (String tag : tags) {
-            notificationManager.cancel(tag, 0);
         }
 
         call.resolve();

--- a/push-notifications/src/definitions.ts
+++ b/push-notifications/src/definitions.ts
@@ -199,9 +199,9 @@ export interface PushNotificationSchema {
 
   /**
    * The notification tag.
-   * 
+   *
    * Only available on Android (from push notifications).
-   * 
+   *
    * @since 4.0.0
    */
   tag?: string;

--- a/push-notifications/src/definitions.ts
+++ b/push-notifications/src/definitions.ts
@@ -202,7 +202,7 @@ export interface PushNotificationSchema {
    * 
    * Only available on Android (from push notifications).
    * 
-   * @since 1.0.9
+   * @since 4.0.0
    */
   tag?: string;
 

--- a/push-notifications/src/definitions.ts
+++ b/push-notifications/src/definitions.ts
@@ -198,6 +198,15 @@ export interface PushNotificationSchema {
   id: string;
 
   /**
+   * The notification tag.
+   * 
+   * Only available on Android (from push notifications).
+   * 
+   * @since 1.0.9
+   */
+  tag?: string;
+
+  /**
    * The number to display for the app icon badge.
    *
    * @since 1.0.0


### PR DESCRIPTION
Fixes an issue where it was not possible to delete individual notifications on Android.

closes: https://github.com/ionic-team/capacitor-plugins/issues/740