### PR TITLE
chore(local-notifications): Create ic_transparent drawable

### DIFF
--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
@@ -23,7 +23,6 @@ import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginConfig;
-import com.getcapacitor.android.R;
 import com.getcapacitor.plugin.util.AssetUtil;
 import java.text.SimpleDateFormat;
 import java.util.Date;

--- a/local-notifications/android/src/main/res/drawable/ic_transparent.xml
+++ b/local-notifications/android/src/main/res/drawable/ic_transparent.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportHeight="108"
+    android:viewportWidth="108">
+
+    <path
+        android:width="1dp"
+        android:color="@android:color/transparent" />
+
+</vector>


### PR DESCRIPTION
In https://github.com/ionic-team/capacitor/pull/5682 I removed unused Capacitor resources, but ic_transparent was being used in local-notifications plugin.
I've added the ic_transparent to the plugin as if the plugin is using it it should be created here instead of in Capacitor.
Removed the R import so it finds the drawable instead of searching inside Capacitor.