### PR TITLE
chore(ios): Remove code that checks status bar height

### DIFF
--- a/keyboard/ios/Plugin/Keyboard.m
+++ b/keyboard/ios/Plugin/Keyboard.m
@@ -23,22 +23,6 @@
 #import <Capacitor/CAPBridgedPlugin.h>
 #import <Capacitor/CAPBridgedJSTypes.h>
 
-
-@interface CAPBridgeViewController (viewTransition)
-- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator;
-@end
-
-
-@implementation CAPBridgeViewController (viewTransition)
--(void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
-    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-    
-    [nc postNotificationName:@"CAPKeyboardViewWillTransitionSize" object:nil];
-    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-}
-
-@end
-
 typedef enum : NSUInteger {
   ResizeNone,
   ResizeNative,
@@ -76,8 +60,6 @@ NSString* UITraitsClassString;
   UIClassString = [@[@"UI", @"Web", @"Browser", @"View"] componentsJoinedByString:@""];
   WKClassString = [@[@"WK", @"Content", @"View"] componentsJoinedByString:@""];
   UITraitsClassString = [@[@"UI", @"Text", @"Input", @"Traits"] componentsJoinedByString:@""];
-    
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(statusBarDidChangeFrame:) name:@"CAPKeyboardViewWillTransitionSize" object: nil];
 
   PluginConfig * config = [self getConfig];
   NSString * style = [config getString:@"style": nil];
@@ -118,10 +100,6 @@ NSString* UITraitsClassString;
 
 
 #pragma mark Keyboard events
-
--(void)statusBarDidChangeFrame:(NSNotification *)notification {
-  [self _updateFrame];
-}
 
 - (void)resetScrollView
 {
@@ -217,13 +195,6 @@ NSString* UITraitsClassString;
   }
   if (window) {
     f = [window bounds];
-      CGSize statusBarSize = [[[window windowScene] statusBarManager] statusBarFrame].size;
-      int statusBarHeight = MIN(statusBarSize.width, statusBarSize.height);
-      
-      int _paddingBottom = (int)self.paddingBottom;
-      if (statusBarHeight == 40) {
-          _paddingBottom = _paddingBottom + 20;
-      }
   }
   if (self.webView != nil) {
     wf = self.webView.frame;


### PR DESCRIPTION
The status bar size change listener was added to resize in case the status bar changed to the in-call status bar, which used to be 40 points of height, but since iOS 13 the status bar size doesn't change anymore, so this code is no longer relevant.
