### PR TITLE
fix(geolocation): reject checkPermissions / requestPermissions if location services are disabled

### DIFF
--- a/geolocation/README.md
+++ b/geolocation/README.md
@@ -131,7 +131,7 @@ Clear a given watch
 checkPermissions() => Promise<PermissionStatus>
 ```
 
-Check location permissions
+Check location permissions.  Will throw if system location services are disabled.
 
 **Returns:** <code>Promise&lt;<a href="#permissionstatus">PermissionStatus</a>&gt;</code>
 
@@ -146,7 +146,7 @@ Check location permissions
 requestPermissions(permissions?: GeolocationPluginPermissions | undefined) => Promise<PermissionStatus>
 ```
 
-Request location permissions
+Request location permissions.  Will throw if system location services are disabled.
 
 | Param             | Type                                                                                  |
 | ----------------- | ------------------------------------------------------------------------------------- |

--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
@@ -24,6 +24,11 @@ public class Geolocation {
         this.context = context;
     }
 
+    public Boolean isLocationServicesEnabled() {
+        LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+        return LocationManagerCompat.isLocationEnabled(lm);
+    }
+
     @SuppressWarnings("MissingPermission")
     public void sendLocation(boolean enableHighAccuracy, final LocationResultCallback resultCallback) {
         int resultCode = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context);

--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
@@ -35,7 +35,7 @@ public class Geolocation {
         if (resultCode == ConnectionResult.SUCCESS) {
             LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
 
-            if (LocationManagerCompat.isLocationEnabled(lm)) {
+            if (this.isLocationServicesEnabled()) {
                 boolean networkEnabled = false;
 
                 try {
@@ -74,7 +74,7 @@ public class Geolocation {
             fusedLocationClient = LocationServices.getFusedLocationProviderClient(context);
 
             LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-            if (LocationManagerCompat.isLocationEnabled(lm)) {
+            if (this.isLocationServicesEnabled()) {
                 boolean networkEnabled = false;
 
                 try {

--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/GeolocationPlugin.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/GeolocationPlugin.java
@@ -5,9 +5,7 @@ import android.content.Context;
 import android.location.Location;
 import android.location.LocationManager;
 import android.os.Build;
-
 import androidx.core.location.LocationManagerCompat;
-
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;

--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/GeolocationPlugin.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/GeolocationPlugin.java
@@ -57,7 +57,7 @@ public class GeolocationPlugin extends Plugin {
         if (implementation.isLocationServicesEnabled()) {
             super.checkPermissions(call);
         } else {
-            call.reject("System location services are not enabled");
+            call.reject("Location services are not enabled");
         }
     }
 
@@ -67,7 +67,7 @@ public class GeolocationPlugin extends Plugin {
         if (implementation.isLocationServicesEnabled()) {
             super.requestPermissions(call);
         } else {
-            call.reject("System location services are not enabled");
+            call.reject("Location services are not enabled");
         }
     }
 

--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/GeolocationPlugin.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/GeolocationPlugin.java
@@ -1,11 +1,8 @@
 package com.capacitorjs.plugins.geolocation;
 
 import android.Manifest;
-import android.content.Context;
 import android.location.Location;
-import android.location.LocationManager;
 import android.os.Build;
-import androidx.core.location.LocationManagerCompat;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;
@@ -57,8 +54,7 @@ public class GeolocationPlugin extends Plugin {
     @Override
     @PluginMethod
     public void checkPermissions(PluginCall call) {
-        LocationManager lm = (LocationManager) this.getContext().getSystemService(Context.LOCATION_SERVICE);
-        if (LocationManagerCompat.isLocationEnabled(lm)) {
+        if (implementation.isLocationServicesEnabled()) {
             super.checkPermissions(call);
         } else {
             call.reject("System location services are not enabled");
@@ -68,8 +64,7 @@ public class GeolocationPlugin extends Plugin {
     @Override
     @PluginMethod
     public void requestPermissions(PluginCall call) {
-        LocationManager lm = (LocationManager) this.getContext().getSystemService(Context.LOCATION_SERVICE);
-        if (LocationManagerCompat.isLocationEnabled(lm)) {
+        if (implementation.isLocationServicesEnabled()) {
             super.requestPermissions(call);
         } else {
             call.reject("System location services are not enabled");

--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/GeolocationPlugin.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/GeolocationPlugin.java
@@ -1,8 +1,13 @@
 package com.capacitorjs.plugins.geolocation;
 
 import android.Manifest;
+import android.content.Context;
 import android.location.Location;
+import android.location.LocationManager;
 import android.os.Build;
+
+import androidx.core.location.LocationManagerCompat;
+
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;
@@ -48,6 +53,28 @@ public class GeolocationPlugin extends Plugin {
         super.handleOnResume();
         for (PluginCall call : watchingCalls.values()) {
             startWatch(call);
+        }
+    }
+
+    @Override
+    @PluginMethod
+    public void checkPermissions(PluginCall call) {
+        LocationManager lm = (LocationManager) this.getContext().getSystemService(Context.LOCATION_SERVICE);
+        if (LocationManagerCompat.isLocationEnabled(lm)) {
+            super.checkPermissions(call);
+        } else {
+            call.reject("System location services are not enabled");
+        }
+    }
+
+    @Override
+    @PluginMethod
+    public void requestPermissions(PluginCall call) {
+        LocationManager lm = (LocationManager) this.getContext().getSystemService(Context.LOCATION_SERVICE);
+        if (LocationManagerCompat.isLocationEnabled(lm)) {
+            super.requestPermissions(call);
+        } else {
+            call.reject("System location services are not enabled");
         }
     }
 

--- a/geolocation/src/definitions.ts
+++ b/geolocation/src/definitions.ts
@@ -64,14 +64,14 @@ export interface GeolocationPlugin {
   clearWatch(options: ClearWatchOptions): Promise<void>;
 
   /**
-   * Check location permissions
+   * Check location permissions.  Will throw if system location services are disabled.
    *
    * @since 1.0.0
    */
   checkPermissions(): Promise<PermissionStatus>;
 
   /**
-   * Request location permissions
+   * Request location permissions.  Will throw if system location services are disabled.
    *
    * @since 1.0.0
    */


### PR DESCRIPTION
This PR will check the Android location services and will throw an error in `checkPermissions` and `requestPermissions` if it's disabled, bringing the behavior inline with iOS.

closes: https://github.com/ionic-team/capacitor-plugins/issues/1035

