### PR TITLE
docs(local-notifications): Remove NotificationChannel docs

### DIFF
--- a/local-notifications/README.md
+++ b/local-notifications/README.md
@@ -614,11 +614,6 @@ The notification visibility. For more details, see the [Android Developer Docs](
 <code>-1 | 0 | 1</code>
 
 
-#### NotificationChannel
-
-<code><a href="#channel">Channel</a></code>
-
-
 #### PermissionState
 
 <code>'prompt' | 'prompt-with-rationale' | 'granted' | 'denied'</code>


### PR DESCRIPTION
NotificationChannel was removed from the types because it was deprecated, but wasn't removed from the readme