### PR TITLE
fix(status-bar): not working on older android devices

### DIFF
--- a/status-bar/android/src/main/java/com/capacitorjs/plugins/statusbar/StatusBar.java
+++ b/status-bar/android/src/main/java/com/capacitorjs/plugins/statusbar/StatusBar.java
@@ -6,21 +6,20 @@ import android.view.Window;
 import android.view.WindowManager;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
-import com.getcapacitor.Logger;
 
 public class StatusBar {
 
-    private final String logTag = "Capacitor-StatusBar";
-    private int currentStatusbarColor;
-    private AppCompatActivity activity;
-    private String defaultStyle;
+    private int currentStatusBarColor;
+    private final AppCompatActivity activity;
+    private final String defaultStyle;
 
     public StatusBar(AppCompatActivity activity) {
         // save initial color of the status bar
         this.activity = activity;
-        this.currentStatusbarColor = activity.getWindow().getStatusBarColor();
+        this.currentStatusBarColor = activity.getWindow().getStatusBarColor();
         this.defaultStyle = getStyle();
     }
 
@@ -32,12 +31,8 @@ public class StatusBar {
             style = this.defaultStyle;
         }
 
-        WindowInsetsControllerCompat windowInsetsControllerCompat = ViewCompat.getWindowInsetsController(decorView);
-        if (windowInsetsControllerCompat != null) {
-            windowInsetsControllerCompat.setAppearanceLightStatusBars(!style.equals("DARK"));
-        } else {
-            Logger.warn(logTag, "Could not get a WindowInsetsControllerCompat instance. Can not set status bar style.");
-        }
+        WindowInsetsControllerCompat windowInsetsControllerCompat = WindowCompat.getInsetsController(window, decorView);
+        windowInsetsControllerCompat.setAppearanceLightStatusBars(!style.equals("DARK"));
     }
 
     @SuppressWarnings("deprecation")
@@ -47,27 +42,19 @@ public class StatusBar {
         window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
         window.setStatusBarColor(color);
         // update the local color field as well
-        currentStatusbarColor = color;
+        currentStatusBarColor = color;
     }
 
     public void hide() {
         View decorView = activity.getWindow().getDecorView();
-        WindowInsetsControllerCompat windowInsetsControllerCompat = ViewCompat.getWindowInsetsController(decorView);
-        if (windowInsetsControllerCompat != null) {
-            windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.statusBars());
-        } else {
-            Logger.warn(logTag, "Could not get a WindowInsetsControllerCompat instance. Can not hide the status bar.");
-        }
+        WindowInsetsControllerCompat windowInsetsControllerCompat = WindowCompat.getInsetsController(activity.getWindow(), decorView);
+        windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.statusBars());
     }
 
     public void show() {
         View decorView = activity.getWindow().getDecorView();
-        WindowInsetsControllerCompat windowInsetsControllerCompat = ViewCompat.getWindowInsetsController(decorView);
-        if (windowInsetsControllerCompat != null) {
-            windowInsetsControllerCompat.show(WindowInsetsCompat.Type.statusBars());
-        } else {
-            Logger.warn(logTag, "Could not get a WindowInsetsControllerCompat instance. Can not show the status bar.");
-        }
+        WindowInsetsControllerCompat windowInsetsControllerCompat = WindowCompat.getInsetsController(activity.getWindow(), decorView);
+        windowInsetsControllerCompat.show(WindowInsetsCompat.Type.statusBars());
     }
 
     @SuppressWarnings("deprecation")
@@ -75,22 +62,22 @@ public class StatusBar {
         View decorView = activity.getWindow().getDecorView();
         int uiOptions = decorView.getSystemUiVisibility();
         if (overlays) {
-            // Sets the layout to a fullscreen one that does not hide the actual status bar, so the webview is displayed behind it.
+            // Sets the layout to a fullscreen one that does not hide the actual status bar, so the WebView is displayed behind it.
             uiOptions = uiOptions | View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
             decorView.setSystemUiVisibility(uiOptions);
-            currentStatusbarColor = activity.getWindow().getStatusBarColor();
+            currentStatusBarColor = activity.getWindow().getStatusBarColor();
             activity.getWindow().setStatusBarColor(Color.TRANSPARENT);
         } else {
-            // Sets the layout to a normal one that displays the webview below the status bar.
+            // Sets the layout to a normal one that displays the WebView below the status bar.
             uiOptions = uiOptions & ~View.SYSTEM_UI_FLAG_LAYOUT_STABLE & ~View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
             decorView.setSystemUiVisibility(uiOptions);
             // recover the previous color of the status bar
-            activity.getWindow().setStatusBarColor(currentStatusbarColor);
+            activity.getWindow().setStatusBarColor(currentStatusBarColor);
         }
     }
 
     @SuppressWarnings("deprecation")
-    private boolean getIsOverlayed() {
+    private boolean getIsOverlaid() {
         return (
             (activity.getWindow().getDecorView().getSystemUiVisibility() & View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN) ==
             View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
@@ -103,7 +90,7 @@ public class StatusBar {
         boolean isVisible = windowInsetsCompat != null && windowInsetsCompat.isVisible(WindowInsetsCompat.Type.statusBars());
         StatusBarInfo info = new StatusBarInfo();
         info.setStyle(getStyle());
-        info.setOverlays(getIsOverlayed());
+        info.setOverlays(getIsOverlaid());
         info.setVisible(isVisible);
         info.setColor(String.format("#%06X", (0xFFFFFF & window.getStatusBarColor())));
         return info;
@@ -112,15 +99,9 @@ public class StatusBar {
     private String getStyle() {
         View decorView = activity.getWindow().getDecorView();
         String style = "DARK";
-        WindowInsetsControllerCompat windowInsetsControllerCompat = ViewCompat.getWindowInsetsController(decorView);
-        if (windowInsetsControllerCompat != null) {
-            if (windowInsetsControllerCompat.isAppearanceLightStatusBars()) {
-                style = "LIGHT";
-            } else {
-                style = "DARK";
-            }
-        } else {
-            Logger.warn(logTag, "Could not get a WindowInsetsControllerCompat instance. Can not get the status bar appearance.");
+        WindowInsetsControllerCompat windowInsetsControllerCompat = WindowCompat.getInsetsController(activity.getWindow(), decorView);
+        if (windowInsetsControllerCompat.isAppearanceLightStatusBars()) {
+            style = "LIGHT";
         }
         return style;
     }


### PR DESCRIPTION
I was replacing deprecation warnings and noticed the old deprecated code was not even working, so this change removes the deprecation warnings and also makes hide/show/setStyle work on Android again.
Also removes some other code warnings Android Studio was reporting about typos in words or functions and null checks are no longer needed since the new method returns non null.