### PR TITLE
feat(keyboard): add getResizeMode function

### DIFF
--- a/keyboard/README.md
+++ b/keyboard/README.md
@@ -224,7 +224,7 @@ This method is only supported on iOS.
 getResizeMode() => Promise<KeyboardResizeOptions>
 ```
 
-Get the currently set keyboard style.
+Get the currently set resize mode.
 
 This method is only supported on iOS.
 

--- a/keyboard/README.md
+++ b/keyboard/README.md
@@ -99,6 +99,7 @@ the following events also work with `window.addEventListener`:
 * [`setScroll(...)`](#setscroll)
 * [`setStyle(...)`](#setstyle)
 * [`setResizeMode(...)`](#setresizemode)
+* [`getResizeMode()`](#getresizemode)
 * [`addListener('keyboardWillShow', ...)`](#addlistenerkeyboardwillshow)
 * [`addListener('keyboardDidShow', ...)`](#addlistenerkeyboarddidshow)
 * [`addListener('keyboardWillHide', ...)`](#addlistenerkeyboardwillhide)
@@ -213,6 +214,23 @@ This method is only supported on iOS.
 | **`options`** | <code><a href="#keyboardresizeoptions">KeyboardResizeOptions</a></code> |
 
 **Since:** 1.0.0
+
+--------------------
+
+
+### getResizeMode()
+
+```typescript
+getResizeMode() => Promise<KeyboardResizeOptions>
+```
+
+Get the currently set keyboard style.
+
+This method is only supported on iOS.
+
+**Returns:** <code>Promise&lt;<a href="#keyboardresizeoptions">KeyboardResizeOptions</a>&gt;</code>
+
+**Since:** 4.0.0
 
 --------------------
 

--- a/keyboard/android/src/main/java/com/capacitorjs/plugins/keyboard/KeyboardPlugin.java
+++ b/keyboard/android/src/main/java/com/capacitorjs/plugins/keyboard/KeyboardPlugin.java
@@ -68,6 +68,11 @@ public class KeyboardPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void getResizeMode(PluginCall call) {
+        call.unimplemented();
+    }
+
+    @PluginMethod
     public void setScroll(PluginCall call) {
         call.unimplemented();
     }

--- a/keyboard/ios/Plugin/Keyboard.m
+++ b/keyboard/ios/Plugin/Keyboard.m
@@ -324,6 +324,24 @@ static IMP WKOriginalImp;
   [call resolve];
 }
 
+- (void)getResizeMode:(CAPPluginCall *)call
+{
+    NSString *mode;
+    
+    if (self.keyboardResizes == ResizeIonic) {
+        mode = @"ionic";
+    } else if(self.keyboardResizes == ResizeBody) {
+        mode = @"body";
+    } else if (self.keyboardResizes == ResizeNative) {
+        mode = @"native";
+    } else {
+        mode = @"none";
+    }
+    
+    NSDictionary *response = [NSDictionary dictionaryWithObject:mode forKey:@"mode"];
+    [call resolve: response];
+}
+
 - (void)setScroll:(CAPPluginCall *)call {
   self.disableScroll = [call getBool:@"isDisabled" defaultValue:FALSE];
   [call resolve];

--- a/keyboard/ios/Plugin/KeyboardPlugin.m
+++ b/keyboard/ios/Plugin/KeyboardPlugin.m
@@ -9,6 +9,7 @@ CAP_PLUGIN(KeyboardPlugin, "Keyboard",
            CAP_PLUGIN_METHOD(setAccessoryBarVisible, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setStyle, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setResizeMode, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(getResizeMode, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setScroll, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnPromise);
 )

--- a/keyboard/src/definitions.ts
+++ b/keyboard/src/definitions.ts
@@ -188,9 +188,9 @@ export interface KeyboardPlugin {
 
   /**
    * Get the currently set resize mode.
-   * 
+   *
    * This method is only supported on iOS.
-   * 
+   *
    * @since 4.0.0
    */
   getResizeMode(): Promise<KeyboardResizeOptions>;

--- a/keyboard/src/definitions.ts
+++ b/keyboard/src/definitions.ts
@@ -186,6 +186,13 @@ export interface KeyboardPlugin {
    */
   setResizeMode(options: KeyboardResizeOptions): Promise<void>;
 
+  /**
+   * Get the currently set keyboard style.
+   * 
+   * This method is only supported on iOS.
+   * 
+   * @since 4.0.0
+   */
   getResizeMode(): Promise<KeyboardResizeOptions>;
 
   /**

--- a/keyboard/src/definitions.ts
+++ b/keyboard/src/definitions.ts
@@ -186,6 +186,8 @@ export interface KeyboardPlugin {
    */
   setResizeMode(options: KeyboardResizeOptions): Promise<void>;
 
+  getResizeMode(): Promise<KeyboardResizeOptions>;
+
   /**
    * Listen for when the keyboard is about to be shown.
    *

--- a/keyboard/src/definitions.ts
+++ b/keyboard/src/definitions.ts
@@ -187,7 +187,7 @@ export interface KeyboardPlugin {
   setResizeMode(options: KeyboardResizeOptions): Promise<void>;
 
   /**
-   * Get the currently set keyboard style.
+   * Get the currently set resize mode.
    * 
    * This method is only supported on iOS.
    * 


### PR DESCRIPTION
Adds a function for getting the current KeyboardResize mode on iOS.

Can be tested with: https://github.com/ionic-team/capacitor-testapp/pull/408