### PR TITLE
fix(share): Prevent crash on no shareable files

### DIFF
--- a/share/README.md
+++ b/share/README.md
@@ -11,6 +11,9 @@ API](https://web.dev/web-share/)), though web support is currently spotty.
 npm install @capacitor/share
 npx cap sync
 ```
+## Android
+
+By default, Capacitor apps only allow to share files from caches folder. To make other Android folders shareable, they have to be added in `android/app/src/main/res/xml/file_paths.xml` file. Check the Specifying Available Files section in [FileProvider docs](https://developer.android.com/reference/androidx/core/content/FileProvider) for the available locations.
 
 ## Example
 

--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -91,15 +91,21 @@ public class SharePlugin extends Plugin {
                     type = "*/*";
                 }
                 intent.setType(type);
-                Uri fileUrl = FileProvider.getUriForFile(
-                    getActivity(),
-                    getContext().getPackageName() + ".fileprovider",
-                    new File(Uri.parse(url).getPath())
-                );
-                intent.putExtra(Intent.EXTRA_STREAM, fileUrl);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    intent.setDataAndType(fileUrl, type);
+                try {
+                    Uri fileUrl = FileProvider.getUriForFile(
+                        getActivity(),
+                        getContext().getPackageName() + ".fileprovider",
+                        new File(Uri.parse(url).getPath())
+                    );
+                    intent.putExtra(Intent.EXTRA_STREAM, fileUrl);
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        intent.setDataAndType(fileUrl, type);
+                    }
+                } catch (Exception ex) {
+                    call.reject(ex.getLocalizedMessage());
+                    return;
                 }
+
                 intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             }
 


### PR DESCRIPTION
Reject if the file is in a non shareable location instead of crashing.
Also add a section in docs with information about how to make other locations shareable.
