### PR TITLE
feat(local-notifications): support subtitle on iOS

### DIFF
--- a/local-notifications/ios/Plugin/LocalNotificationsHandler.swift
+++ b/local-notifications/ios/Plugin/LocalNotificationsHandler.swift
@@ -86,6 +86,7 @@ public class LocalNotificationsHandler: NSObject, NotificationHandlerProtocol {
         var notification: JSObject = [
             "id": Int(request.identifier) ?? -1,
             "title": request.content.title,
+            "subtitle": request.content.subtitle,
             "body": request.content.body
         ]
 

--- a/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
+++ b/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
@@ -213,6 +213,9 @@ public class LocalNotificationsPlugin: CAPPlugin {
         content.title = NSString.localizedUserNotificationString(forKey: title, arguments: nil)
         content.body = NSString.localizedUserNotificationString(forKey: body,
                                                                 arguments: nil)
+        if let subtitle = notification["subtitle"] as? String {
+            content.subtitle = NSString.localizedUserNotificationString(forKey: subtitle, arguments: nil)
+        }
 
         content.userInfo = [
             "cap_extra": extra,

--- a/local-notifications/src/definitions.ts
+++ b/local-notifications/src/definitions.ts
@@ -520,6 +520,13 @@ export interface LocalNotificationSchema {
   title: string;
 
   /**
+   * The subtitle of the notification.
+   *
+   * @since 4.0.0
+   */
+  subtitle?: string;
+
+  /**
    * The body of the notification, shown below the title.
    *
    * @since 1.0.0


### PR DESCRIPTION
On iOS you can add a second line of title to the notification like this:

<a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification"><img width="300" alt="demonstration of iOS notification subtitle" src="https://user-images.githubusercontent.com/22457086/181408662-b97c4f2e-28c6-450c-b9e4-106f626be885.png" /></a>


The subtitle property of UNMutableNotificationContent is documented here: https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent/1649873-subtitle

On other platforms it is just ignored. Did I miss anywhere that should be updated to handle a subtitle?