### PR TITLE
fix(filesystem): failing to remove folder content on rmdir

### DIFF
--- a/filesystem/src/web.ts
+++ b/filesystem/src/web.ts
@@ -348,7 +348,7 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
       throw Error('Folder is not empty');
 
     for (const entry of readDirResult.files) {
-      const entryPath = `${path}/${entry}`;
+      const entryPath = `${path}/${entry.name}`;
       const entryObj = await this.stat({ path: entryPath, directory });
       if (entryObj.type === 'file') {
         await this.deleteFile({ path: entryPath, directory });


### PR DESCRIPTION
readdir now returns an object instead of just the file name, so we need to get the file name from the object to properly delete folder content

closes https://github.com/ionic-team/capacitor-plugins/issues/1111