### PR TITLE
Update getConfig to getConfigValue

### DIFF
--- a/push-notifications/ios/Plugin/PushNotificationsHandler.swift
+++ b/push-notifications/ios/Plugin/PushNotificationsHandler.swift
@@ -29,7 +29,7 @@ public class PushNotificationsHandler: NSObject, NotificationHandlerProtocol {
             }
         }
 
-        if let optionsArray = self.plugin?.getConfig().getArray("presentationOptions") as? [String] {
+        if let optionsArray = self.plugin?.getConfigValue("presentationOptions") as? [String] {
             var presentationOptions = UNNotificationPresentationOptions.init()
 
             optionsArray.forEach { option in


### PR DESCRIPTION
Ran into a little bug here. CAAPlugin now uses getConfigValue and we can pass "presentationOptions" in directly.