### PR TITLE
feat(push-notifications): Send an Android broadcast with the remoteMessage inside the firebase onMessageReceived event

### DIFF
--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/MessagingService.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/MessagingService.java
@@ -1,5 +1,6 @@
 package com.capacitorjs.plugins.pushnotifications;
 
+import android.content.Intent;
 import androidx.annotation.NonNull;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
@@ -10,6 +11,10 @@ public class MessagingService extends FirebaseMessagingService {
     public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
         super.onMessageReceived(remoteMessage);
         PushNotificationsPlugin.sendRemoteMessage(remoteMessage);
+
+        Intent broadcastIntent = new Intent("android.intent.action.capacitor.pushnotification");
+        broadcastIntent.putExtra("remoteMessage", remoteMessage);
+        sendBroadcast(broadcastIntent);
     }
 
     @Override


### PR DESCRIPTION
Content of this PR
This pull request is intended to send a broadcast message in android, after an incoming firebase push notification.

Why
Unfortunately it is not possible to register more than one FirebaseMessagingService in the same app (see here). With help of the BroadcastReceiver, another plugin can hook in here and also listen to the remote messages with a broadcast listener:
registerReceiver(MyBroadcastReceiver, new IntentFilter("android.intent.action.capacitor.pushnotification"));

Example use case
https://github.com/NePheus/capacitor-fullscreen-notification
Send a (silent) data notification to the app to show a local notification with a fullscreen intent (i.e. call action). An event must be triggered by the push-notifications plugin to notify about the data notification.