### PR TITLE
fix(camera): remove listener methods

### DIFF
--- a/camera/README.md
+++ b/camera/README.md
@@ -139,7 +139,7 @@ iOS 14+ Only: Allows the user to update their limited photo library selection.
 
 **Returns:** <code>Promise&lt;<a href="#galleryphotos">GalleryPhotos</a>&gt;</code>
 
-**Since:** 4.0.0
+**Since:** 4.1.0
 
 --------------------
 
@@ -154,7 +154,7 @@ iOS 14+ Only: Return an array of photos selected from the limited photo library.
 
 **Returns:** <code>Promise&lt;<a href="#galleryphotos">GalleryPhotos</a>&gt;</code>
 
-**Since:** 4.0.0
+**Since:** 4.1.0
 
 --------------------
 
@@ -165,7 +165,7 @@ iOS 14+ Only: Return an array of photos selected from the limited photo library.
 addListener(eventName: 'limitedLibrarySelectionChanged', listenerFunc: CameraLimitedLibrarySelectionChangeListener) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
-Listen for changes to selected photos within the users limited photo library.
+iOS 14+ Only: Listen for changes to selected photos within the user's limited photo library.
 
 | Param              | Type                                                                                                                |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------- |
@@ -174,7 +174,7 @@ Listen for changes to selected photos within the users limited photo library.
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
-**Since:** 4.0.0
+**Since:** 4.1.0
 
 --------------------
 
@@ -187,7 +187,7 @@ removeAllListeners() => Promise<void>
 
 Remove all listeners for this plugin.
 
-**Since:** 4.0.0
+**Since:** 4.1.0
 
 --------------------
 

--- a/camera/README.md
+++ b/camera/README.md
@@ -76,8 +76,6 @@ const takePicture = async () => {
 * [`pickImages(...)`](#pickimages)
 * [`pickLimitedLibraryPhotos()`](#picklimitedlibraryphotos)
 * [`getLimitedLibraryPhotos()`](#getlimitedlibraryphotos)
-* [`addListener('limitedLibrarySelectionChanged', ...)`](#addlistenerlimitedlibraryselectionchanged)
-* [`removeAllListeners()`](#removealllisteners)
 * [`checkPermissions()`](#checkpermissions)
 * [`requestPermissions(...)`](#requestpermissions)
 * [Interfaces](#interfaces)
@@ -153,39 +151,6 @@ getLimitedLibraryPhotos() => Promise<GalleryPhotos>
 iOS 14+ Only: Return an array of photos selected from the limited photo library.
 
 **Returns:** <code>Promise&lt;<a href="#galleryphotos">GalleryPhotos</a>&gt;</code>
-
-**Since:** 4.1.0
-
---------------------
-
-
-### addListener('limitedLibrarySelectionChanged', ...)
-
-```typescript
-addListener(eventName: 'limitedLibrarySelectionChanged', listenerFunc: CameraLimitedLibrarySelectionChangeListener) => Promise<PluginListenerHandle> & PluginListenerHandle
-```
-
-iOS 14+ Only: Listen for changes to selected photos within the user's limited photo library.
-
-| Param              | Type                                                                                                                |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| **`eventName`**    | <code>'limitedLibrarySelectionChanged'</code>                                                                       |
-| **`listenerFunc`** | <code><a href="#cameralimitedlibraryselectionchangelistener">CameraLimitedLibrarySelectionChangeListener</a></code> |
-
-**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
-
-**Since:** 4.1.0
-
---------------------
-
-
-### removeAllListeners()
-
-```typescript
-removeAllListeners() => Promise<void>
-```
-
-Remove all listeners for this plugin.
 
 **Since:** 4.1.0
 
@@ -292,13 +257,6 @@ Request camera and photo album permissions
 | **`limit`**              | <code>number</code>                    | iOS only: Maximum number of pictures the user will be able to choose.                      | <code>0 (unlimited)</code>  | 1.2.0 |
 
 
-#### PluginListenerHandle
-
-| Prop         | Type                                      |
-| ------------ | ----------------------------------------- |
-| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
-
-
 #### PermissionStatus
 
 | Prop         | Type                                                                    |
@@ -315,11 +273,6 @@ Request camera and photo album permissions
 
 
 ### Type Aliases
-
-
-#### CameraLimitedLibrarySelectionChangeListener
-
-<code>(): void</code>
 
 
 #### CameraPermissionState

--- a/camera/ios/Plugin/CameraPlugin.m
+++ b/camera/ios/Plugin/CameraPlugin.m
@@ -8,5 +8,4 @@ CAP_PLUGIN(CAPCameraPlugin, "Camera",
   CAP_PLUGIN_METHOD(requestPermissions, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(pickLimitedLibraryPhotos, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(getLimitedLibraryPhotos, CAPPluginReturnPromise);
-  CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnPromise);
 )

--- a/camera/ios/Plugin/CameraPlugin.m
+++ b/camera/ios/Plugin/CameraPlugin.m
@@ -8,4 +8,5 @@ CAP_PLUGIN(CAPCameraPlugin, "Camera",
   CAP_PLUGIN_METHOD(requestPermissions, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(pickLimitedLibraryPhotos, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(getLimitedLibraryPhotos, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnPromise);
 )

--- a/camera/ios/Plugin/CameraPlugin.swift
+++ b/camera/ios/Plugin/CameraPlugin.swift
@@ -75,7 +75,7 @@ public class CameraPlugin: CAPPlugin {
                 PHPhotoLibrary.shared().presentLimitedLibraryPicker(from: viewController)
             }
         } else {
-            call.unavailable("Not available on iOS 13 and below")
+            call.unavailable("Not available on iOS 13")
         }
     }
 
@@ -123,7 +123,7 @@ public class CameraPlugin: CAPPlugin {
                 }
             }
         } else {
-            call.unavailable("Not available on iOS 13 and below")
+            call.unavailable("Not available on iOS 13")
         }
     }
 

--- a/camera/ios/Plugin/CameraPlugin.swift
+++ b/camera/ios/Plugin/CameraPlugin.swift
@@ -51,10 +51,7 @@ public class CameraPlugin: CAPPlugin {
             case .photos:
                 group.enter()
                 if #available(iOS 14, *) {
-                    PHPhotoLibrary.requestAuthorization(for: .readWrite) { (granted) in
-                        if granted == .limited {
-                            PHPhotoLibrary.shared().register(self)
-                        }
+                    PHPhotoLibrary.requestAuthorization(for: .readWrite) { (_) in
                         group.leave()
                     }
                 } else {
@@ -83,7 +80,6 @@ public class CameraPlugin: CAPPlugin {
         if #available(iOS 14, *) {
             PHPhotoLibrary.requestAuthorization(for: .readWrite) { (granted) in
                 if granted == .limited {
-                    PHPhotoLibrary.shared().register(self)
 
                     self.call = call
 
@@ -229,7 +225,7 @@ extension CameraPlugin: UIImagePickerControllerDelegate, UINavigationControllerD
 }
 
 @available(iOS 14, *)
-extension CameraPlugin: PHPickerViewControllerDelegate, PHPhotoLibraryChangeObserver {
+extension CameraPlugin: PHPickerViewControllerDelegate {
     public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         picker.dismiss(animated: true, completion: nil)
         guard let result = results.first else {
@@ -285,10 +281,6 @@ extension CameraPlugin: PHPickerViewControllerDelegate, PHPhotoLibraryChangeObse
                 self?.call?.reject("Error loading image")
             }
         }
-    }
-
-    public func photoLibraryDidChange(_ changeInstance: PHChange) {
-        self.notifyListeners("limitedLibrarySelectionChanged", data: nil)
     }
 }
 

--- a/camera/src/definitions.ts
+++ b/camera/src/definitions.ts
@@ -1,10 +1,8 @@
-import type { PermissionState, PluginListenerHandle } from '@capacitor/core';
+import type { PermissionState } from '@capacitor/core';
 
 export type CameraPermissionState = PermissionState | 'limited';
 
 export type CameraPermissionType = 'camera' | 'photos';
-
-export type CameraLimitedLibrarySelectionChangeListener = () => void;
 
 export interface PermissionStatus {
   camera: CameraPermissionState;
@@ -44,25 +42,6 @@ export interface CameraPlugin {
    * @since 4.1.0
    */
   getLimitedLibraryPhotos(): Promise<GalleryPhotos>;
-
-  /**
-   * iOS 14+ Only: Listen for changes to selected photos within the user's limited photo library.
-   *
-   * @param eventName
-   * @param listenerFunc
-   * @since 4.1.0
-   */
-  addListener(
-    eventName: 'limitedLibrarySelectionChanged',
-    listenerFunc: CameraLimitedLibrarySelectionChangeListener,
-  ): Promise<PluginListenerHandle> & PluginListenerHandle;
-
-  /**
-   * Remove all listeners for this plugin.
-   *
-   * @since 4.1.0
-   */
-  removeAllListeners(): Promise<void>;
 
   /**
    * Check camera and photo album permissions

--- a/camera/src/definitions.ts
+++ b/camera/src/definitions.ts
@@ -35,13 +35,13 @@ export interface CameraPlugin {
   /**
    * iOS 14+ Only: Allows the user to update their limited photo library selection.
    *
-   * @since 4.0.0
+   * @since 4.1.0
    */
   pickLimitedLibraryPhotos(): Promise<GalleryPhotos>;
   /**
    * iOS 14+ Only: Return an array of photos selected from the limited photo library.
    *
-   * @since 4.0.0
+   * @since 4.1.0
    */
   getLimitedLibraryPhotos(): Promise<GalleryPhotos>;
 
@@ -50,7 +50,7 @@ export interface CameraPlugin {
    *
    * @param eventName
    * @param listenerFunc
-   * @since 4.0.0
+   * @since 4.1.0
    */
   addListener(
     eventName: 'limitedLibrarySelectionChanged',
@@ -60,7 +60,7 @@ export interface CameraPlugin {
   /**
    * Remove all listeners for this plugin.
    *
-   * @since 4.0.0
+   * @since 4.1.0
    */
   removeAllListeners(): Promise<void>;
 

--- a/camera/src/web.ts
+++ b/camera/src/web.ts
@@ -270,11 +270,11 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
   }
 
   async pickLimitedLibraryPhotos(): Promise<GalleryPhotos> {
-    throw this.unavailable('Not implemented on the web.');
+    throw this.unavailable('Not implemented on web.');
   }
 
   async getLimitedLibraryPhotos(): Promise<GalleryPhotos> {
-    throw this.unavailable('Not implemented on the web.');
+    throw this.unavailable('Not implemented on web.');
   }
 }
 


### PR DESCRIPTION
The new methods introduced on https://github.com/ionic-team/capacitor-plugins/pull/1125 will be available in next 4.1.0 release, not in 4.0.0, update docs accordingly.

Add missing `removeAllListeners` method in `CameraPlugin.m`, calling it errors at the moment.

Removed `and below` from `iOS 13 and below` error messages since we don't support older versions.

Also noticed that `photoLibraryDidChange` is called every time a change is made in the user's photo library, not only when the limited selection is changed (i.e. if the user takes a new picture or deletes it), so `limitedLibrarySelectionChanged` event is fired for every change and not for selection changes, so maybe the name should be changed to `photoLibraryDidChange` (to match the native name). Current name is misleading and also the description of it is not accurate.
Do we really need that listener? it doesn't provide any useful information to the user.