### PR TITLE
Remove redundant nil coalescing

### DIFF
--- a/splash-screen/ios/Plugin/SplashScreen.swift
+++ b/splash-screen/ios/Plugin/SplashScreen.swift
@@ -117,7 +117,7 @@ import Capacitor
     // Update the bounds for the splash image. This will also be called when
     // the parent view observers fire
     private func updateSplashImageBounds() {
-        var window: UIWindow? = UIApplication.shared.delegate?.window ?? nil
+        var window: UIWindow? = UIApplication.shared.delegate?.window
 
         if window == nil {
             let scene: UIWindowScene? = UIApplication.shared.connectedScenes.first as? UIWindowScene


### PR DESCRIPTION
Using the nil-coalescing operator (`??`) here is redundant.

If `UIApplication.shared.delegate?.window` is `nil`, then there's no need to use `??` and set it to `nil`.