### PR TITLE
docs(filesystem): opting into the Files app

### DIFF
--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -9,6 +9,15 @@ npm install @capacitor/filesystem
 npx cap sync
 ```
 
+## iOS
+
+To have files appear in the Files app, you must set the following keys to `YES` in `Info.plist`:
+
+- `UIFileSharingEnabled` (`Application supports iTunes file sharing`)
+- `LSSupportsOpeningDocumentsInPlace` (`Supports opening documents in place`)
+
+Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode.
+
 ## Android
 
 If using <a href="#directory">`Directory.Documents`</a> or

--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -16,7 +16,7 @@ To have files appear in the Files app, you must set the following keys to `YES` 
 - `UIFileSharingEnabled` (`Application supports iTunes file sharing`)
 - `LSSupportsOpeningDocumentsInPlace` (`Supports opening documents in place`)
 
-Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode.
+Read about [Configuring iOS](https://capacitorjs.com/docs/ios/configuration) for help.
 
 ## Android
 


### PR DESCRIPTION
Add information to `@capacitor/filesystem` on how to make application files visible within the iOS Files app. 