### PR TITLE
[WIP] Add support for more haptics

### DIFF
--- a/haptics/ios/Plugin/HapticsPlugin.swift
+++ b/haptics/ios/Plugin/HapticsPlugin.swift
@@ -11,6 +11,10 @@ public class HapticsPlugin: CAPPlugin {
                 impactStyle = UIImpactFeedbackGenerator.FeedbackStyle.medium
             } else if style == "LIGHT" {
                 impactStyle = UIImpactFeedbackGenerator.FeedbackStyle.light
+            } else if style == "SOFT" {
+                impactStyle = UIImpactFeedbackGenerator.FeedbackStyle.soft
+            } else if style == "RIGID" {
+                impactStyle = UIImpactFeedbackGenerator.FeedbackStyle.rigid
             }
         }
         DispatchQueue.main.async {

--- a/haptics/src/definitions.ts
+++ b/haptics/src/definitions.ts
@@ -78,6 +78,20 @@ export enum ImpactStyle {
    * @since 1.0.0
    */
   Light = 'LIGHT',
+
+  /**
+   * A rigid impact between user interface elements.
+   *
+   * @since x.x.x
+   */
+  Rigid = "RIGID",
+
+  /**
+   * A soft impact between user interface elements.
+   *
+   * @since x.x.x
+   */
+  Soft = "SOFT",
 }
 
 export interface NotificationOptions {


### PR DESCRIPTION
WIP resolution of ionic-team/capacitor-haptics#5

### Todo

- [ ] Web haptics
- [ ] Android haptics
- [ ] iOS: Selection changed
- [ ] Android/web: Selection changed (maybe? see below...)
- [ ] Implement missing `vibrateOptions` for iOS
- [ ] Update tests

----

A possibly more controversial opinion: I think this lib should provide lower level, platform-specific APIs. Maybe something like:

```
haptics.ios.impact(ImpactStyle.heavy);
haptics.web.vibrate([27, 45, 50]);
```

If the lib maintainers also wish to support a common API that provides a consistent haptic experience, that should be sugar on top of the low-level APIs imo.

As a consumer I found it unexpected that this lib attempts to create haptic consistency at the expense of API flexibility.

what do you think of that API idea? If there's interest I could incorporate it into this PR, or do a follow up.