### PR TITLE
fix(google-maps): adding missing marker draggable property for web

### DIFF
--- a/google-maps/src/web.ts
+++ b/google-maps/src/web.ts
@@ -425,6 +425,7 @@ export class CapacitorGoogleMapsWeb
       opacity: marker.opacity,
       title: marker.title,
       icon: iconImage,
+      draggable: marker.draggable,
     };
 
     return opts;


### PR DESCRIPTION
This PR adds back the missing marker `draggable` property for web.