### PR TITLE
feat(pushnotifications): add support for Android 13 permissions

### DIFF
--- a/local-notifications/android/src/main/AndroidManifest.xml
+++ b/local-notifications/android/src/main/AndroidManifest.xml
@@ -17,4 +17,5 @@
     </application>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 </manifest>

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
@@ -1,5 +1,6 @@
 package com.capacitorjs.plugins.localnotifications;
 
+import android.Manifest;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -21,7 +22,9 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-@CapacitorPlugin(name = "LocalNotifications", permissions = @Permission(strings = {}, alias = "display"))
+@CapacitorPlugin(name = "LocalNotifications", permissions = @Permission(strings = {
+        Manifest.permission.POST_NOTIFICATIONS
+}, alias = "display"))
 public class LocalNotificationsPlugin extends Plugin {
 
     private static Bridge staticBridge = null;
@@ -193,16 +196,24 @@ public class LocalNotificationsPlugin extends Plugin {
 
     @PluginMethod
     public void checkPermissions(PluginCall call) {
-        JSObject permissionsResultJSON = new JSObject();
-        permissionsResultJSON.put("display", getNotificationPermissionText());
-        call.resolve(permissionsResultJSON);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            JSObject permissionsResultJSON = new JSObject();
+            permissionsResultJSON.put("display", getNotificationPermissionText());
+            call.resolve(permissionsResultJSON);
+        } else {
+            super.checkPermissions(call);
+        }
     }
 
     @PluginMethod
     public void requestPermissions(PluginCall call) {
-        JSObject permissionsResultJSON = new JSObject();
-        permissionsResultJSON.put("display", getNotificationPermissionText());
-        call.resolve(permissionsResultJSON);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            JSObject permissionsResultJSON = new JSObject();
+            permissionsResultJSON.put("display", getNotificationPermissionText());
+            call.resolve(permissionsResultJSON);
+        } else {
+            super.requestPermissions(call);
+        }
     }
 
     private String getNotificationPermissionText() {

--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -29,6 +29,9 @@ func application(_ application: UIApplication, didFailToRegisterForRemoteNotific
 
 The Push Notification API uses [Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging) SDK for handling notifications.  See [Set up a Firebase Cloud Messaging client app on Android](https://firebase.google.com/docs/cloud-messaging/android/client) and follow the instructions for creating a Firebase project and registering your application.  There is no need to add the Firebase SDK to your app or edit your app manifest - the Push Notifications provides that for you.  All that is required is your Firebase project's `google-services.json` file added to the module (app-level) directory of your app.
 
+Android 13 (API level 33) and higher supports a runtime permission for sending notifications POST_NOTIFICATIONS. You are required
+ to call `checkPermissions()` and `requestPermissions()` accordingly, when targeting SDK 33, similarily to how iOS works.
+
 ### Variables
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
@@ -99,7 +102,7 @@ export default config;
 This plugin does not support iOS Silent Push (Remote Notifications). We recommend using native code solutions for handling these types of notifications, see [Pushing Background Updates to Your App](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app).
 
 #### Android
-This plugin does support data-only notifications, but will NOT call `pushNotificationReceived` if the app has been killed. To handle this scenario, you will need to create a service that extends `FirebaseMessagingService`, see [Handling FCM Messages](https://firebase.google.com/docs/cloud-messaging/android/receive). 
+This plugin does support data-only notifications, but will NOT call `pushNotificationReceived` if the app has been killed. To handle this scenario, you will need to create a service that extends `FirebaseMessagingService`, see [Handling FCM Messages](https://firebase.google.com/docs/cloud-messaging/android/receive).
 
 ## Common Issues
 On Android, there are various system and app states that can affect the delivery of push notifications:
@@ -322,8 +325,9 @@ requestPermissions() => Promise<PermissionStatus>
 
 Request permission to receive push notifications.
 
-On Android it doesn't prompt for permission because you can always
-receive push notifications.
+On Android SDK 32 and below it doesn't prompt for permission because you can always
+receive push notifications. On Android SDK 33 and above notifications permissions
+work similar to iOS.
 
 On iOS, the first time you use the function, it will prompt the user
 for push notification permission and return granted or denied based

--- a/push-notifications/android/build.gradle
+++ b/push-notifications/android/build.gradle
@@ -12,17 +12,17 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:7.2.2'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 32
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -1,5 +1,6 @@
 package com.capacitorjs.plugins.pushnotifications;
 
+import android.Manifest;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -22,7 +23,10 @@ import java.util.List;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-@CapacitorPlugin(name = "PushNotifications", permissions = @Permission(strings = {}, alias = "receive"))
+@CapacitorPlugin(
+    name = "PushNotifications",
+    permissions = @Permission(strings = { Manifest.permission.POST_NOTIFICATIONS }, alias = "receive")
+)
 public class PushNotificationsPlugin extends Plugin {
 
     public static Bridge staticBridge = null;


### PR DESCRIPTION
This adds support for explicitly checking and requesting POST_NOTIFICATIONS permissions for Android 13 and above (SDK 33)

Tested it on Android 13 and works as expected. Android < 13 works as previously.

The current issue that this resolves is that when targeting SDK 32 then the permission request dialog is triggered at application launch and not when requested on an Android device running Android 13. Targeting SDK 33 does not ask for the permission at all.

Resolves #1135 