### PR TITLE
fix(camera): make pickLimitedLibraryPhotos return photos

### DIFF
--- a/camera/README.md
+++ b/camera/README.md
@@ -134,6 +134,8 @@ pickLimitedLibraryPhotos() => Promise<GalleryPhotos>
 ```
 
 iOS 14+ Only: Allows the user to update their limited photo library selection.
+On iOS 15+ returns all the limited photos after the picker dismissal.
+On iOS 14 or if the user gave full access to the photos it returns an empty array.
 
 **Returns:** <code>Promise&lt;<a href="#galleryphotos">GalleryPhotos</a>&gt;</code>
 

--- a/camera/ios/Plugin/CameraPlugin.swift
+++ b/camera/ios/Plugin/CameraPlugin.swift
@@ -76,9 +76,10 @@ public class CameraPlugin: CAPPlugin {
                                 self.getLimitedLibraryPhotos(call)
                             }
                         } else {
-                            PHPhotoLibrary.shared().register(self)
                             PHPhotoLibrary.shared().presentLimitedLibraryPicker(from: viewController)
-                            self.call = call
+                            call.resolve([
+                                "photos": []
+                            ])
                         }
                     }
                 } else {
@@ -241,7 +242,7 @@ extension CameraPlugin: UIImagePickerControllerDelegate, UINavigationControllerD
 }
 
 @available(iOS 14, *)
-extension CameraPlugin: PHPickerViewControllerDelegate, PHPhotoLibraryChangeObserver {
+extension CameraPlugin: PHPickerViewControllerDelegate {
     public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         picker.dismiss(animated: true, completion: nil)
         guard let result = results.first else {
@@ -296,14 +297,6 @@ extension CameraPlugin: PHPickerViewControllerDelegate, PHPhotoLibraryChangeObse
                 }
                 self?.call?.reject("Error loading image")
             }
-        }
-    }
-
-    public func photoLibraryDidChange(_ changeInstance: PHChange) {
-        if let call = self.call {
-            self.getLimitedLibraryPhotos(call)
-            PHPhotoLibrary.shared().unregisterChangeObserver(self)
-            self.call = nil
         }
     }
 }

--- a/camera/src/definitions.ts
+++ b/camera/src/definitions.ts
@@ -32,6 +32,8 @@ export interface CameraPlugin {
 
   /**
    * iOS 14+ Only: Allows the user to update their limited photo library selection.
+   * On iOS 15+ returns all the limited photos after the picker dismissal.
+   * On iOS 14 or if the user gave full access to the photos it returns an empty array.
    *
    * @since 4.1.0
    */


### PR DESCRIPTION
closes https://github.com/ionic-team/capacitor-plugins/issues/1158

Note: On iOS 14 it's not possible to know when the limited image picker is closed as the method with the completion is only available for iOS 15.
So, for being able to return the pictures, it relies on the `PHPhotoLibraryChangeObserver`. But if the users calls `pickLimitedLibraryPhotos` and then doesn't change the selection, `pickLimitedLibraryPhotos` will not reject nor resolve until some change is made on the user's photo gallery in the future.
Not sure if we want that behavior or if it would be better to just return the pictures on iOS 15+ and document that on iOS 14 it returns an empty array?


