### PR TITLE
fix(local-notifications): Showing correct scheduled notification time

### DIFF
--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
@@ -211,15 +211,6 @@ public class LocalNotificationManager {
             }
         }
 
-        // make sure scheduled time is shown instead of display time
-        if (localNotification.isScheduled() && localNotification.getSchedule().getAt() != null) {
-            mBuilder.setWhen(localNotification.getSchedule().getAt().getTime()).setShowWhen(true);
-        }
-
-        if (localNotification.isScheduled() && localNotification.getSchedule().getOn() != null) {
-            mBuilder.setWhen(localNotification.getSchedule().getOn().nextTrigger(new Date())).setShowWhen(true);
-        }
-
         mBuilder.setVisibility(NotificationCompat.VISIBILITY_PRIVATE);
         mBuilder.setOnlyAlertOnce(true);
 
@@ -362,9 +353,6 @@ public class LocalNotificationManager {
         if (every != null) {
             Long everyInterval = schedule.getEveryInterval();
             if (everyInterval != null) {
-                notificationIntent.putExtra(TimedNotificationPublisher.EVERY_KEY, true);
-                pendingIntent = PendingIntent.getBroadcast(context, request.getId(), notificationIntent, flags);
-
                 long startTime = new Date().getTime() + everyInterval;
                 alarmManager.setRepeating(AlarmManager.RTC, startTime, everyInterval, pendingIntent);
             }

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
@@ -216,6 +216,10 @@ public class LocalNotificationManager {
             mBuilder.setWhen(localNotification.getSchedule().getAt().getTime()).setShowWhen(true);
         }
 
+        if (localNotification.isScheduled() && localNotification.getSchedule().getOn() != null) {
+            mBuilder.setWhen(localNotification.getSchedule().getOn().nextTrigger(new Date())).setShowWhen(true);
+        }
+
         mBuilder.setVisibility(NotificationCompat.VISIBILITY_PRIVATE);
         mBuilder.setOnlyAlertOnce(true);
 

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
@@ -362,6 +362,9 @@ public class LocalNotificationManager {
         if (every != null) {
             Long everyInterval = schedule.getEveryInterval();
             if (everyInterval != null) {
+                notificationIntent.putExtra(TimedNotificationPublisher.EVERY_KEY, true);
+                pendingIntent = PendingIntent.getBroadcast(context, request.getId(), notificationIntent, flags);
+
                 long startTime = new Date().getTime() + everyInterval;
                 alarmManager.setRepeating(AlarmManager.RTC, startTime, everyInterval, pendingIntent);
             }

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
@@ -43,7 +43,7 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
             storage.deleteNotification(Integer.toString(id));
         }
     }
-    
+
     private boolean rescheduleNotificationIfNeeded(Context context, Intent intent, int id) {
         String dateString = intent.getStringExtra(CRON_KEY);
         if (dateString != null) {

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
@@ -21,7 +21,6 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
 
     public static String NOTIFICATION_KEY = "NotificationPublisher.notification";
     public static String CRON_KEY = "NotificationPublisher.cron";
-    public static String EVERY_KEY = "NotificationPublisher.every";
 
     /**
      * Restore and present notification
@@ -30,6 +29,8 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         Notification notification = intent.getParcelableExtra(NOTIFICATION_KEY);
+        notification.when = System.currentTimeMillis();
+
         int id = intent.getIntExtra(LocalNotificationManager.NOTIFICATION_INTENT_KEY, Integer.MIN_VALUE);
         if (id == Integer.MIN_VALUE) {
             Logger.error(Logger.tags("LN"), "No valid id supplied", null);
@@ -37,20 +38,12 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
         NotificationStorage storage = new NotificationStorage(context);
         JSObject notificationJson = storage.getSavedNotificationAsJSObject(Integer.toString(id));
         LocalNotificationsPlugin.fireReceived(notificationJson);
-        setWhenForEverySchedule(intent, notification);
         notificationManager.notify(id, notification);
         if (!rescheduleNotificationIfNeeded(context, intent, id)) {
             storage.deleteNotification(Integer.toString(id));
         }
     }
-
-    private void setWhenForEverySchedule(Intent intent, Notification notification) {
-        boolean isEverySchedule = intent.getBooleanExtra(EVERY_KEY, false);
-        if (isEverySchedule) {
-            notification.when = System.currentTimeMillis();
-        }
-    }
-
+    
     private boolean rescheduleNotificationIfNeeded(Context context, Intent intent, int id) {
         String dateString = intent.getStringExtra(CRON_KEY);
         if (dateString != null) {

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
@@ -47,7 +47,7 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
     private void setWhenForEverySchedule(Intent intent, Notification notification) {
         boolean isEverySchedule = intent.getBooleanExtra(EVERY_KEY, false);
         if (isEverySchedule) {
-            notification.when =  System.currentTimeMillis();
+            notification.when = System.currentTimeMillis();
         }
     }
 

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
@@ -21,6 +21,7 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
 
     public static String NOTIFICATION_KEY = "NotificationPublisher.notification";
     public static String CRON_KEY = "NotificationPublisher.cron";
+    public static String EVERY_KEY = "NotificationPublisher.every";
 
     /**
      * Restore and present notification
@@ -36,9 +37,17 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
         NotificationStorage storage = new NotificationStorage(context);
         JSObject notificationJson = storage.getSavedNotificationAsJSObject(Integer.toString(id));
         LocalNotificationsPlugin.fireReceived(notificationJson);
+        setWhenForEverySchedule(intent, notification);
         notificationManager.notify(id, notification);
         if (!rescheduleNotificationIfNeeded(context, intent, id)) {
             storage.deleteNotification(Integer.toString(id));
+        }
+    }
+
+    private void setWhenForEverySchedule(Intent intent, Notification notification) {
+        boolean isEverySchedule = intent.getBooleanExtra(EVERY_KEY, false);
+        if (isEverySchedule) {
+            notification.when =  System.currentTimeMillis();
         }
     }
 


### PR DESCRIPTION
Fixes an issue where `on` and `every` notification schedules did not show the current notification time.

closes: https://github.com/ionic-team/capacitor-plugins/issues/433