### PR TITLE
fix(filesystem): Avoid max stack size exceeded on base64 check

### DIFF
--- a/filesystem/src/web.ts
+++ b/filesystem/src/web.ts
@@ -636,9 +636,11 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
   }
 
   private isBase64String(str: string): boolean {
-    const base64regex =
-      /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
-    return base64regex.test(str);
+    try {
+      return btoa(atob(str)) == str;
+    } catch (err) {
+      return false;
+    }
   }
 }
 


### PR DESCRIPTION
Some SO comments say this check is a bit lax, but the regular expression hits max stack size exceeded and I can't find a better way that doesn't require regular expressions (tested other expressions and using match instead of test and also get max stack size exceeded).
I've been testing this check and comparing with iOS results and they both return true/false for the same string I've tested, so I think it's ok to use.
Also, we already use the btoa/atob on append call.

closes https://github.com/ionic-team/capacitor-plugins/issues/1138