### PR TITLE
chore(ci): Add ionic-issue-bot

### DIFF
--- a/.github/bot.yml
+++ b/.github/bot.yml
@@ -26,14 +26,6 @@ tasks:
     config:
       label: 'needs reply'
       exclude-labeler: true
-  - name: add-label
-    on:
-      issues:
-        types: [opened]
-    condition: |-
-      !(await getTeamMembers('capacitor')).includes(payload.sender.login)
-    config:
-      label: 'triage'
   - name: add-platform-labels
     on:
       issues:

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -1,0 +1,11 @@
+triage:
+  label: triage
+  dryRun: false
+
+lockClosed:
+  days: 30
+  maxIssuesPerRun: 100
+  message: >
+    Thanks for the issue! This issue is being locked to prevent comments that are not relevant to the original issue.
+    If this is still an issue with the latest version of Ionic, please create a new issue and ensure the template is fully filled out.
+  dryRun: false

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -7,5 +7,5 @@ lockClosed:
   maxIssuesPerRun: 100
   message: >
     Thanks for the issue! This issue is being locked to prevent comments that are not relevant to the original issue.
-    If this is still an issue with the latest version of Ionic, please create a new issue and ensure the template is fully filled out.
+    If this is still an issue with the latest version of the plugin, please create a new issue and ensure the template is fully filled out.
   dryRun: false


### PR DESCRIPTION
Add ionic-issue-bot to add triage label to new issues and lock closed issues

Removed the triage step from the old bot since it's not working