### PR TITLE
Update GoogleMapConfig

### DIFF
--- a/google-maps/src/definitions.ts
+++ b/google-maps/src/definitions.ts
@@ -70,6 +70,10 @@ export interface GoogleMapConfig {
    * Override pixel ratio for native map.
    */
   devicePixelRatio?: number;
+  /**
+   * removes the default ui navigation elements
+   */
+  disableDefaultUI?: boolean;
 }
 
 /**


### PR DESCRIPTION
Added disableDefaultUI option to remove the google maps navigation ui.  This will allow us to pass that parameter and get a clean map to use.