### PR TITLE
feat(google-maps): Add more config options

### DIFF
--- a/google-maps/README.md
+++ b/google-maps/README.md
@@ -683,16 +683,21 @@ An interface containing the options used when creating a map.
 
 #### GoogleMapConfig
 
-| Prop                   | Type                                      | Description                                                    | Default            |
-| ---------------------- | ----------------------------------------- | -------------------------------------------------------------- | ------------------ |
-| **`width`**            | <code>number</code>                       | Override width for native map.                                 |                    |
-| **`height`**           | <code>number</code>                       | Override height for native map.                                |                    |
-| **`x`**                | <code>number</code>                       | Override absolute x coordinate position for native map.        |                    |
-| **`y`**                | <code>number</code>                       | Override absolute y coordinate position for native map.        |                    |
-| **`center`**           | <code><a href="#latlng">LatLng</a></code> | Default location on the Earth towards which the camera points. |                    |
-| **`zoom`**             | <code>number</code>                       | Sets the zoom of the map.                                      |                    |
-| **`androidLiteMode`**  | <code>boolean</code>                      | Enables image-based lite mode on Android.                      | <code>false</code> |
-| **`devicePixelRatio`** | <code>number</code>                       | Override pixel ratio for native map.                           |                    |
+For web, all the javascript Google Maps options are available as
+GoogleMapConfig extends google.maps.MapOptions.
+For iOS and Android only the config options declared on <a href="#googlemapconfig">GoogleMapConfig</a> are available.
+
+| Prop                   | Type                                      | Description                                                                                                                                               | Default            | Since |
+| ---------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
+| **`width`**            | <code>number</code>                       | Override width for native map.                                                                                                                            |                    |       |
+| **`height`**           | <code>number</code>                       | Override height for native map.                                                                                                                           |                    |       |
+| **`x`**                | <code>number</code>                       | Override absolute x coordinate position for native map.                                                                                                   |                    |       |
+| **`y`**                | <code>number</code>                       | Override absolute y coordinate position for native map.                                                                                                   |                    |       |
+| **`center`**           | <code><a href="#latlng">LatLng</a></code> | Default location on the Earth towards which the camera points.                                                                                            |                    |       |
+| **`zoom`**             | <code>number</code>                       | Sets the zoom of the map.                                                                                                                                 |                    |       |
+| **`androidLiteMode`**  | <code>boolean</code>                      | Enables image-based lite mode on Android.                                                                                                                 | <code>false</code> |       |
+| **`devicePixelRatio`** | <code>number</code>                       | Override pixel ratio for native map.                                                                                                                      |                    |       |
+| **`styles`**           | <code>MapTypeStyle[] \| null</code>       | Styles to apply to each of the default map types. Note that for satellite, hybrid and terrain modes, these styles will only apply to labels and geometry. |                    | 4.3.0 |
 
 
 #### LatLng

--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
@@ -66,7 +66,6 @@ class CapacitorGoogleMap(
                         mapView.onStart()
                         mapView.getMapAsync(this@CapacitorGoogleMap)
                         mapView.setWillNotDraw(false)
-
                         isReadyChannel.receive()
 
                         render()
@@ -101,6 +100,9 @@ class CapacitorGoogleMap(
 
                 bridge.webView.bringToFront()
                 bridge.webView.setBackgroundColor(Color.TRANSPARENT)
+                if (config.styles != null) {
+                    googleMap?.setMapStyle(MapStyleOptions(config.styles!!));
+                }
             }
         }
     }

--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/GoogleMapConfig.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/GoogleMapConfig.kt
@@ -15,6 +15,7 @@ class GoogleMapConfig(fromJSONObject: JSONObject) {
     var zoom: Int = 0
     var liteMode: Boolean = false
     var devicePixelRatio: Float = 1.00f
+    var styles: String? = null
 
     init {
         if (!fromJSONObject.has("width")) {
@@ -81,5 +82,7 @@ class GoogleMapConfig(fromJSONObject: JSONObject) {
 
         val cameraPosition = CameraPosition(center, zoom.toFloat(), 0.0F, 0.0F)
         googleMapOptions = GoogleMapOptions().camera(cameraPosition).liteMode(liteMode)
+
+        styles = fromJSONObject.getString("styles")
     }
 }

--- a/google-maps/ios/Plugin/GoogleMapConfig.swift
+++ b/google-maps/ios/Plugin/GoogleMapConfig.swift
@@ -8,6 +8,7 @@ public struct GoogleMapConfig: Codable {
     let y: Double
     let center: LatLng
     let zoom: Double
+    let styles: String?
 
     init(fromJSObject: JSObject) throws {
         guard let width = fromJSObject["width"] as? Double else {
@@ -44,5 +45,10 @@ public struct GoogleMapConfig: Codable {
         self.y = y
         self.zoom = zoom
         self.center = LatLng(lat: lat, lng: lng)
+        if let stylesArray = fromJSObject["styles"] as? JSArray, let jsonData = try? JSONSerialization.data(withJSONObject: stylesArray, options: []) {
+            self.styles = String(data: jsonData, encoding: .utf8)
+        } else {
+            self.styles = nil
+        }
     }
 }

--- a/google-maps/ios/Plugin/Map.swift
+++ b/google-maps/ios/Plugin/Map.swift
@@ -116,6 +116,14 @@ public class Map {
                     self.mapViewController.GMapView.delegate = self.delegate
                 }
 
+                if let styles = self.config.styles {
+                    do {
+                        self.mapViewController.GMapView.mapStyle = try GMSMapStyle(jsonString: styles)
+                    } catch {
+                        CAPLog.print("Invalid Google Maps styles")
+                    }
+                }
+
                 self.delegate.notifyListeners("onMapReady", data: [
                     "mapId": self.id
                 ])

--- a/google-maps/src/definitions.ts
+++ b/google-maps/src/definitions.ts
@@ -33,9 +33,11 @@ export interface Point {
 }
 
 /**
- *
+ * For web, all the javascript Google Maps options are available as
+ * GoogleMapConfig extends google.maps.MapOptions.
+ * For iOS and Android only the config options declared on GoogleMapConfig are available.
  */
-export interface GoogleMapConfig {
+export interface GoogleMapConfig extends google.maps.MapOptions {
   /**
    * Override width for native map.
    */
@@ -70,6 +72,14 @@ export interface GoogleMapConfig {
    * Override pixel ratio for native map.
    */
   devicePixelRatio?: number;
+  /**
+   * Styles to apply to each of the default map types. Note that for
+   * satellite, hybrid and terrain modes,
+   * these styles will only apply to labels and geometry.
+   *
+   * @since 4.3.0
+   */
+  styles?: google.maps.MapTypeStyle[] | null;
 }
 
 /**


### PR DESCRIPTION
Make GoogleMapConfig extend `google.maps.MapOptions` son any javascript SDK config option can be used on web.

Also implement [styles](https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.styles) for iOS and android.


closes https://github.com/ionic-team/capacitor-plugins/issues/946
closes https://github.com/ionic-team/capacitor-plugins/issues/992
closes https://github.com/ionic-team/capacitor-plugins/issues/1017