### PR TITLE
fix(google-maps): Retry getting the map size if it's 0

### DIFF
--- a/google-maps/src/map.ts
+++ b/google-maps/src/map.ts
@@ -144,7 +144,7 @@ export class GoogleMap {
     newMap.element = options.element;
     newMap.element.dataset.internalId = options.id;
 
-    const elementBounds = options.element.getBoundingClientRect();
+    const elementBounds = await GoogleMap.getElementBounds(options.element);
     options.config.width = elementBounds.width;
     options.config.height = elementBounds.height;
     options.config.x = elementBounds.x;
@@ -174,6 +174,31 @@ export class GoogleMap {
     }
 
     return newMap;
+  }
+
+  private static async getElementBounds(
+    element: HTMLElement,
+  ): Promise<DOMRect> {
+    return new Promise(resolve => {
+      let elementBounds = element.getBoundingClientRect();
+      if (elementBounds.width == 0) {
+        let retries = 0;
+        const boundsInterval = setInterval(function () {
+          if (elementBounds.width == 0 && retries < 30) {
+            elementBounds = element.getBoundingClientRect();
+            retries++;
+          } else {
+            if (retries == 30) {
+              console.warn('Map size could not be determined');
+            }
+            clearInterval(boundsInterval);
+            resolve(elementBounds);
+          }
+        }, 100);
+      } else {
+        resolve(elementBounds);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
There is a bug on ionic/vue that makes custom elements have 0 size on mounted, and probably some other edge cases that could cause the map to have 0 size.

This PR will retry trying to get the google maps custom element size for 3 seconds every 100ms to solve those problems and warn if it still couldn't get the map size after the 3 seconds.

closes https://github.com/ionic-team/capacitor-plugins/issues/1102