### PR TITLE
chore(ios): Update publish-ios.yml to no longer use native-publish branch

### DIFF
--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           node-version: 14.x
       - uses: actions/checkout@v2
-        with:
-          ref: native-publish
       - name: Install Cocoapods
         run: | 
           gem install cocoapods


### PR DESCRIPTION
The iOS plugin podspecs appear to have no difference between the `native-publish` branch and main. @carlpoole is working on utilizing the same strategy with the android plugins as was done in https://github.com/ionic-team/capacitor/pull/6022 to publish off of main (or any other branch) so we don't have to keep a long-lived branch in sync to publish our official plugins.