### PR TITLE
chore(android): native artifact publish logic

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -7,6 +7,10 @@ on:
         description: 'Specify an optional subset of plugins to publish (space delimited)'
         required: false
         default: ''
+      capacitor-version:
+        description: 'Optional. Specify the version of Capacitor the plugins should depend on. Must be in mathematical notation, eg: [4.0,5.0) for 4.x versions only, or [4.0,) for 4.x versions and higher'
+        required: false
+        default: ''
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,6 +30,7 @@ jobs:
       working-directory: ./scripts
       env:
         GITHUB_PLUGINS: ${{ github.event.inputs.plugins }}
+        GITHUB_CAPACITOR_VERSION: ${{ github.event.inputs.capacitor-version }}
         ANDROID_OSSRH_USERNAME: ${{ secrets.ANDROID_OSSRH_USERNAME }}
         ANDROID_OSSRH_PASSWORD: ${{ secrets.ANDROID_OSSRH_PASSWORD }}
         ANDROID_SIGNING_KEY_ID: ${{ secrets.ANDROID_SIGNING_KEY_ID }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -15,8 +15,6 @@ jobs:
       packages: write
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: native-publish
     - name: set up JDK 11
       uses: actions/setup-java@v2
       with:

--- a/action-sheet/android/build.gradle
+++ b/action-sheet/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxMaterialVersion = project.hasProperty('androidxMaterialVersion') ? rootProject.ext.androidxMaterialVersion : '1.6.1'

--- a/action-sheet/android/build.gradle
+++ b/action-sheet/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxMaterialVersion = project.hasProperty('androidxMaterialVersion') ? rootProject.ext.androidxMaterialVersion : '1.6.1'

--- a/action-sheet/android/build.gradle
+++ b/action-sheet/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxMaterialVersion = project.hasProperty('androidxMaterialVersion') ? rootProject.ext.androidxMaterialVersion : '1.6.1'
@@ -10,13 +11,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -50,7 +62,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "com.google.android.material:material:$androidxMaterialVersion"
     testImplementation "junit:junit:$junitVersion"

--- a/action-sheet/package.json
+++ b/action-sheet/package.json
@@ -45,10 +45,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorActionSheet.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "^4.0.0",
-    "@capacitor/core": "^4.0.0",
+    "@capacitor/android": "file:../../capacitor/android",
+    "@capacitor/core": "file:../../capacitor/core",
     "@capacitor/docgen": "0.0.18",
-    "@capacitor/ios": "^4.0.0",
+    "@capacitor/ios": "file:../../capacitor/ios",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/action-sheet/package.json
+++ b/action-sheet/package.json
@@ -45,10 +45,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorActionSheet.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "file:../../capacitor/android",
-    "@capacitor/core": "file:../../capacitor/core",
+    "@capacitor/android": "^4.0.0",
+    "@capacitor/core": "^4.0.0",
     "@capacitor/docgen": "0.0.18",
-    "@capacitor/ios": "file:../../capacitor/ios",
+    "@capacitor/ios": "^4.0.0",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/app-launcher/android/build.gradle
+++ b/app-launcher/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/app-launcher/android/build.gradle
+++ b/app-launcher/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/app-launcher/android/build.gradle
+++ b/app-launcher/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/browser/android/build.gradle
+++ b/browser/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -10,13 +11,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -50,7 +62,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.browser:browser:$androidxBrowserVersion"
     testImplementation "junit:junit:$junitVersion"

--- a/browser/android/build.gradle
+++ b/browser/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/browser/android/build.gradle
+++ b/browser/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/camera/android/build.gradle
+++ b/camera/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.4.0'
@@ -11,13 +12,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -51,7 +63,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.exifinterface:exifinterface:$androidxExifInterfaceVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "com.google.android.material:material:$androidxMaterialVersion"

--- a/camera/android/build.gradle
+++ b/camera/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.4.0'

--- a/camera/android/build.gradle
+++ b/camera/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.4.0'

--- a/clipboard/android/build.gradle
+++ b/clipboard/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/clipboard/android/build.gradle
+++ b/clipboard/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/clipboard/android/build.gradle
+++ b/clipboard/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/device/android/build.gradle
+++ b/device/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/device/android/build.gradle
+++ b/device/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/device/android/build.gradle
+++ b/device/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/dialog/android/build.gradle
+++ b/dialog/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/dialog/android/build.gradle
+++ b/dialog/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/dialog/android/build.gradle
+++ b/dialog/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/filesystem/android/build.gradle
+++ b/filesystem/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.4.0'

--- a/filesystem/android/build.gradle
+++ b/filesystem/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.4.0'

--- a/filesystem/android/build.gradle
+++ b/filesystem/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.4.0'
@@ -8,13 +9,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -48,7 +60,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/geolocation/android/build.gradle
+++ b/geolocation/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.4.0'

--- a/geolocation/android/build.gradle
+++ b/geolocation/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.4.0'

--- a/geolocation/android/build.gradle
+++ b/geolocation/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.4.0'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "com.google.android.gms:play-services-location:$playServicesLocationVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/google-maps/android/build.gradle
+++ b/google-maps/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -16,15 +17,26 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -63,7 +75,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+    
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/google-maps/android/build.gradle
+++ b/google-maps/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/google-maps/android/build.gradle
+++ b/google-maps/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/google-maps/src/map.ts
+++ b/google-maps/src/map.ts
@@ -144,7 +144,7 @@ export class GoogleMap {
     newMap.element = options.element;
     newMap.element.dataset.internalId = options.id;
 
-    const elementBounds = options.element.getBoundingClientRect();
+    const elementBounds = await GoogleMap.getElementBounds(options.element);
     options.config.width = elementBounds.width;
     options.config.height = elementBounds.height;
     options.config.x = elementBounds.x;
@@ -174,6 +174,31 @@ export class GoogleMap {
     }
 
     return newMap;
+  }
+
+  private static async getElementBounds(
+    element: HTMLElement,
+  ): Promise<DOMRect> {
+    return new Promise(resolve => {
+      let elementBounds = element.getBoundingClientRect();
+      if (elementBounds.width == 0) {
+        let retries = 0;
+        const boundsInterval = setInterval(function () {
+          if (elementBounds.width == 0 && retries < 30) {
+            elementBounds = element.getBoundingClientRect();
+            retries++;
+          } else {
+            if (retries == 30) {
+              console.warn('Map size could not be determined');
+            }
+            clearInterval(boundsInterval);
+            resolve(elementBounds);
+          }
+        }, 100);
+      } else {
+        resolve(elementBounds);
+      }
+    });
   }
 
   /**

--- a/haptics/android/build.gradle
+++ b/haptics/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/haptics/android/build.gradle
+++ b/haptics/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/haptics/android/build.gradle
+++ b/haptics/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/keyboard/android/build.gradle
+++ b/keyboard/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/keyboard/android/build.gradle
+++ b/keyboard/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/keyboard/android/build.gradle
+++ b/keyboard/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/local-notifications/android/build.gradle
+++ b/local-notifications/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/local-notifications/android/build.gradle
+++ b/local-notifications/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/local-notifications/android/build.gradle
+++ b/local-notifications/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/network/android/build.gradle
+++ b/network/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/network/android/build.gradle
+++ b/network/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/network/android/build.gradle
+++ b/network/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/preferences/android/build.gradle
+++ b/preferences/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/preferences/android/build.gradle
+++ b/preferences/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/preferences/android/build.gradle
+++ b/preferences/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/push-notifications/android/build.gradle
+++ b/push-notifications/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -10,13 +11,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -50,7 +62,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     testImplementation "junit:junit:$junitVersion"

--- a/push-notifications/android/build.gradle
+++ b/push-notifications/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/push-notifications/android/build.gradle
+++ b/push-notifications/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/screen-reader/android/build.gradle
+++ b/screen-reader/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/screen-reader/android/build.gradle
+++ b/screen-reader/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/screen-reader/android/build.gradle
+++ b/screen-reader/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,8 @@
+# Temp dir used for publish script log output
+tmp
+
+# Local configuration file (sdk path, etc) for Android plugins publishing
+local.properties
+
+# Gradle cache
+.gradle/

--- a/scripts/android/publish-module.gradle
+++ b/scripts/android/publish-module.gradle
@@ -8,8 +8,10 @@ task androidSourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     if (project.plugins.findPlugin("com.android.library")) {
         from android.sourceSets.main.java.srcDirs
+        from android.sourceSets.main.kotlin.srcDirs
     } else {
         from sourceSets.main.java.srcDirs
+        from sourceSets.main.kotlin.srcDirs
     }
 }
 

--- a/scripts/android/publish-module.gradle
+++ b/scripts/android/publish-module.gradle
@@ -1,0 +1,78 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+def LIB_VERSION = System.getenv('PLUGIN_VERSION')
+def PLUGIN_NAME = System.getenv('PLUGIN_NAME')
+
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    if (project.plugins.findPlugin("com.android.library")) {
+        from android.sourceSets.main.java.srcDirs
+    } else {
+        from sourceSets.main.java.srcDirs
+    }
+}
+
+artifacts {
+    archives androidSourcesJar
+}
+
+group = 'com.capacitorjs'
+version = LIB_VERSION
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                // Coordinates
+                groupId 'com.capacitorjs'
+                artifactId PLUGIN_NAME
+                version LIB_VERSION
+
+                // Two artifacts, the `aar` (or `jar`) and the sources
+                if (project.plugins.findPlugin("com.android.library")) {
+                    from components.release
+                } else {
+                    artifact("$buildDir/libs/${project.getName()}-${version}.jar")
+                }
+
+                artifact androidSourcesJar
+
+                // POM Data
+                pom {
+                    name = PLUGIN_NAME
+                    description = 'Capacitor Android ' + PLUGIN_NAME + ' plugin native library'
+                    url = 'https://github.com/ionic-team/capacitor-plugins'
+                    licenses {
+                        license {
+                            name = 'MIT'
+                            url = 'https://github.com/ionic-team/capacitor-plugins/blob/main/' + PLUGIN_NAME + '/LICENSE'
+                        }
+                    }
+                    developers {
+                        developer {
+                            name = 'Ionic'
+                            email = 'hi@ionic.io'
+                        }
+                    }
+
+                    // Version Control Info
+                    scm {
+                        connection = 'scm:git:github.com:ionic-team/capacitor-plugins.git'
+                        developerConnection = 'scm:git:ssh://github.com:ionic-team/capacitor-plugins.git'
+                        url = 'https://github.com/ionic-team/capacitor-plugins/tree/main'
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    useInMemoryPgpKeys(
+            rootProject.ext["signing.keyId"],
+            rootProject.ext["signing.key"],
+            rootProject.ext["signing.password"],
+    )
+    sign publishing.publications
+}

--- a/scripts/android/publish-root.gradle
+++ b/scripts/android/publish-root.gradle
@@ -1,0 +1,43 @@
+// Create variables with empty default values
+ext["signing.keyId"] = ''
+ext["signing.key"] = ''
+ext["signing.password"] = ''
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+
+File globalSecretPropsFile = file('../../scripts/android/local.properties')
+File secretPropsFile = project.rootProject.file('local.properties')
+if (globalSecretPropsFile.exists()) {
+    // Read global local.properties file first if it exists (scripts/android/local.properties)
+    Properties p = new Properties()
+    new FileInputStream(globalSecretPropsFile).withCloseable { is -> p.load(is) }
+    p.each { name, value -> ext[name] = value }
+} else if (secretPropsFile.exists()) {
+    // Read plugin project specific local.properties file next if it exists
+    Properties p = new Properties()
+    new FileInputStream(secretPropsFile).withCloseable { is -> p.load(is) }
+    p.each { name, value -> ext[name] = value }
+} else {
+    // Use system environment variables
+    ext["ossrhUsername"] = System.getenv('ANDROID_OSSRH_USERNAME')
+    ext["ossrhPassword"] = System.getenv('ANDROID_OSSRH_PASSWORD')
+    ext["sonatypeStagingProfileId"] = System.getenv('ANDROID_SONATYPE_STAGING_PROFILE_ID')
+    ext["signing.keyId"] = System.getenv('ANDROID_SIGNING_KEY_ID')
+    ext["signing.key"] = System.getenv('ANDROID_SIGNING_KEY')
+    ext["signing.password"] = System.getenv('ANDROID_SIGNING_PASSWORD')
+}
+
+// Set up Sonatype repository
+nexusPublishing {
+    repositories {
+        sonatype {
+            stagingProfileId = sonatypeStagingProfileId
+            username = ossrhUsername
+            password = ossrhPassword
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
+    }
+    repositoryDescription = 'Capacitor Android ' + System.getenv('PLUGIN_NAME') + ' plugin v' + System.getenv('PLUGIN_VERSION')
+}

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# The default Capacitor version(s) the plugin should depend on. Latest published in a range will be pulled by the user
+DEFAULT_CAPACITOR_VERSION="[4.0,5.0)"
+
 publish_plugin () {
     PLUGIN_PATH=$1
     if [ -d "$PLUGIN_PATH" ]; then
@@ -30,6 +33,7 @@ publish_plugin () {
                 # Export ENV variables used by Gradle for the plugin
                 export PLUGIN_NAME
                 export PLUGIN_VERSION
+                export CAPACITOR_VERSION
                 export CAP_PLUGIN_PUBLISH=true
 
                 # Build and publish
@@ -58,6 +62,15 @@ CAPACITOR_PUBLISHED_DATA=$(curl -s $CAPACITOR_PUBLISHED_URL)
 CAPACITOR_PUBLISHED_VERSION="$(perl -ne 'print and last if s/.*<latest>(.*)<\/latest>.*/\1/;' <<< $CAPACITOR_PUBLISHED_DATA)"
 
 printf %"s\n" "The latest published Android library version of Capacitor Core is $CAPACITOR_PUBLISHED_VERSION in MavenCentral."
+
+# Check if github actions passing in a custom native Capacitor dependency version
+if [[ $GITHUB_CAPACITOR_VERSION ]]; then
+    CAPACITOR_VERSION=$GITHUB_CAPACITOR_VERSION
+else
+    CAPACITOR_VERSION=$DEFAULT_CAPACITOR_VERSION
+fi
+
+printf %"s\n" "Publishing plugin(s) with dependency on Capacitor version $CAPACITOR_VERSION"
 
 # Check if github actions passing in a custom list of plugins
 if [[ $GITHUB_PLUGINS ]]; then

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+publish_plugin () {
+    PLUGIN_PATH=$1
+    if [ -d "$PLUGIN_PATH" ]; then
+        # Android dir path
+        ANDROID_PATH=$PLUGIN_PATH/android
+        GRADLE_FILE=$ANDROID_PATH/build.gradle
+
+        # Only try to publish if the directory contains a package.json and android package
+        if test -f "$PLUGIN_PATH/package.json" && test -d "$ANDROID_PATH" && test -f "$GRADLE_FILE"; then
+            PLUGIN_VERSION=$(grep '"version": ' "$PLUGIN_PATH"/package.json | awk '{print $2}' | tr -d '",')
+            PLUGIN_NAME=$(grep '"name": ' "$PLUGIN_PATH"/package.json | awk '{print $2}' | tr -d '",')
+            PLUGIN_NAME=${PLUGIN_NAME#@capacitor/}
+            LOG_OUTPUT=./tmp/$PLUGIN_NAME.txt
+
+            # Get latest plugin info from MavenCentral
+            PLUGIN_PUBLISHED_URL="https://repo1.maven.org/maven2/com/capacitorjs/$PLUGIN_NAME/maven-metadata.xml"
+            PLUGIN_PUBLISHED_DATA=$(curl -s $PLUGIN_PUBLISHED_URL)
+            PLUGIN_PUBLISHED_VERSION="$(perl -ne 'print and last if s/.*<latest>(.*)<\/latest>.*/\1/;' <<< $PLUGIN_PUBLISHED_DATA)"
+
+            if [[ $PLUGIN_VERSION == $PLUGIN_PUBLISHED_VERSION ]]; then
+                printf %"s\n\n" "Duplicate: a published plugin $PLUGIN_NAME exists for version $PLUGIN_VERSION, skipping..."
+            else
+                # Make log dir if doesnt exist
+                mkdir -p ./tmp
+
+                printf %"s\n" "Attempting to build and publish plugin $PLUGIN_NAME for version $PLUGIN_VERSION"
+
+                # Export ENV variables used by Gradle for the plugin
+                export PLUGIN_NAME
+                export PLUGIN_VERSION
+                export CAPACITOR_VERSION
+                export CAP_PLUGIN_PUBLISH=true
+
+                # Build and publish
+                "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true -Pandroid.enableJetifier=true > $LOG_OUTPUT 2>&1
+
+                if grep --quiet "BUILD SUCCESSFUL" $LOG_OUTPUT; then
+                    printf %"s\n\n" "Success: $PLUGIN_NAME published to MavenCentral Staging. Manually review and release from the Sonatype Repository Manager https://s01.oss.sonatype.org/"
+                else
+                    printf %"s\n\n" "Error publishing $PLUGIN_NAME, check $LOG_OUTPUT for more info!"
+                    cat $LOG_OUTPUT
+                    exit 1
+                fi
+            fi
+        else
+            printf %"s\n\n" "$PLUGIN_PATH does not appear to be a plugin (has no package.json file or Android package), skipping..."
+        fi
+    fi
+}
+
+# Plugins base location
+DIR=..
+
+# Get the latest version of Capacitor
+CAPACITOR_PACKAGE_JSON="https://raw.githubusercontent.com/ionic-team/capacitor/main/android/package.json"
+CAPACITOR_VERSION=$(curl -s $CAPACITOR_PACKAGE_JSON | awk -F\" '/"version":/ {print $4}')
+
+# for test remove after
+CAPACITOR_VERSION="4.4.0-beta1"
+
+# Don't continue if there was a problem getting the latest version of Capacitor
+if [[ $CAPACITOR_VERSION ]]; then
+    printf %"s\n\n" "Attempting to publish new plugins with dependency on Capacitor Version $CAPACITOR_VERSION"
+else
+    printf %"s\n\n" "Error resolving latest Capacitor version from $CAPACITOR_PACKAGE_JSON"
+    exit 1
+fi
+
+# Get latest com.capacitorjs:core XML version info
+CAPACITOR_PUBLISHED_URL="https://repo1.maven.org/maven2/com/capacitorjs/core/maven-metadata.xml"
+CAPACITOR_PUBLISHED_DATA=$(curl -s $CAPACITOR_PUBLISHED_URL)
+CAPACITOR_PUBLISHED_VERSION="$(perl -ne 'print and last if s/.*<latest>(.*)<\/latest>.*/\1/;' <<< $CAPACITOR_PUBLISHED_DATA)"
+
+# Check if we need to publish a new native version of the Capacitor Android library
+if [[ "$CAPACITOR_VERSION" != "$CAPACITOR_PUBLISHED_VERSION" ]]; then
+    printf %"s\n" "Publish Capacitor Core first! The latest published Android library version $CAPACITOR_PUBLISHED_VERSION in MavenCentral is outdated. There is an unpublished version $CAPACITOR_VERSION in ionic-team/capacitor."
+    exit 1
+else
+    # Capacitor version in MavenCentral is up to date, continue publishing the native Capacitor Plugins
+    printf %"s\n\n" "Latest native Capacitor Android library is version $CAPACITOR_PUBLISHED_VERSION and is up to date, continuing with plugin publishing..."
+
+    # Check if github actions passing in a custom list of plugins
+    if [[ $GITHUB_PLUGINS ]]; then
+        for var in ${GITHUB_PLUGINS[@]}; do
+            PLUGIN_DIR="$DIR"/$var
+            publish_plugin $PLUGIN_DIR
+        done
+    else
+        # If run without .sh args, process all plugins, else run over the plugins provided as args
+        if [[ "$#" -eq  "0" ]]; then
+            # Run publish task for all plugins
+            for f in "$DIR"/*; do
+                publish_plugin $f
+            done
+        else
+            # Run publish task for plugins provided as arguments
+            for var in "$@"; do
+                PLUGIN_DIR="$DIR"/$var
+                publish_plugin $PLUGIN_DIR
+            done
+        fi
+    fi
+fi

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -25,7 +25,7 @@ publish_plugin () {
                 # Make log dir if doesnt exist
                 mkdir -p ./tmp
 
-                printf %"s\n" "Attempting to build and publish plugin $PLUGIN_NAME for version $PLUGIN_VERSION"
+                printf %"s\n" "Attempting to build and publish plugin $PLUGIN_NAME for version $PLUGIN_VERSION to production..."
 
                 # Export ENV variables used by Gradle for the plugin
                 export PLUGIN_NAME
@@ -34,12 +34,12 @@ publish_plugin () {
                 export CAP_PLUGIN_PUBLISH=true
 
                 # Build and publish
-                "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true -Pandroid.enableJetifier=true > $LOG_OUTPUT 2>&1
+                "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true -Pandroid.enableJetifier=true > $LOG_OUTPUT 2>&1
 
                 if grep --quiet "BUILD SUCCESSFUL" $LOG_OUTPUT; then
-                    printf %"s\n\n" "Success: $PLUGIN_NAME published to MavenCentral Staging. Manually review and release from the Sonatype Repository Manager https://s01.oss.sonatype.org/"
+                    printf %"s\n\n" "Success: $PLUGIN_NAME published to MavenCentral."
                 else
-                    printf %"s\n\n" "Error publishing $PLUGIN_NAME, check $LOG_OUTPUT for more info!"
+                    printf %"s\n\n" "Error publishing $PLUGIN_NAME, check $LOG_OUTPUT for more info! Manual publication review may be necessary at the Sonatype Repository Manager https://s01.oss.sonatype.org/"
                     cat $LOG_OUTPUT
                     exit 1
                 fi

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -57,9 +57,6 @@ DIR=..
 CAPACITOR_PACKAGE_JSON="https://raw.githubusercontent.com/ionic-team/capacitor/main/android/package.json"
 CAPACITOR_VERSION=$(curl -s $CAPACITOR_PACKAGE_JSON | awk -F\" '/"version":/ {print $4}')
 
-# for test remove after
-CAPACITOR_VERSION="4.4.0-beta1"
-
 # Don't continue if there was a problem getting the latest version of Capacitor
 if [[ $CAPACITOR_VERSION ]]; then
     printf %"s\n\n" "Attempting to publish new plugins with dependency on Capacitor Version $CAPACITOR_VERSION"

--- a/share/android/build.gradle
+++ b/share/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxCoreVersion = project.hasProperty('androidxCoreVersion') ? rootProject.ext.androidxCoreVersion : '1.8.0'
@@ -10,13 +11,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -50,7 +62,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.core:core:$androidxCoreVersion"
     testImplementation "junit:junit:$junitVersion"

--- a/share/android/build.gradle
+++ b/share/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxCoreVersion = project.hasProperty('androidxCoreVersion') ? rootProject.ext.androidxCoreVersion : '1.8.0'

--- a/share/android/build.gradle
+++ b/share/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxCoreVersion = project.hasProperty('androidxCoreVersion') ? rootProject.ext.androidxCoreVersion : '1.8.0'

--- a/splash-screen/android/build.gradle
+++ b/splash-screen/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -10,13 +11,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -50,7 +62,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/splash-screen/android/build.gradle
+++ b/splash-screen/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/splash-screen/android/build.gradle
+++ b/splash-screen/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/status-bar/android/build.gradle
+++ b/status-bar/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxCoreVersion = project.hasProperty('androidxCoreVersion') ? rootProject.ext.androidxCoreVersion : '1.8.0'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
@@ -10,13 +11,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -50,7 +62,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.core:core:$androidxCoreVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"

--- a/status-bar/android/build.gradle
+++ b/status-bar/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxCoreVersion = project.hasProperty('androidxCoreVersion') ? rootProject.ext.androidxCoreVersion : '1.8.0'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'

--- a/status-bar/android/build.gradle
+++ b/status-bar/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxCoreVersion = project.hasProperty('androidxCoreVersion') ? rootProject.ext.androidxCoreVersion : '1.8.0'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'

--- a/text-zoom/android/build.gradle
+++ b/text-zoom/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/text-zoom/android/build.gradle
+++ b/text-zoom/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/text-zoom/android/build.gradle
+++ b/text-zoom/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/toast/android/build.gradle
+++ b/toast/android/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
@@ -9,13 +10,24 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+        if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 apply plugin: 'com.android.library'
+if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../../scripts/android/publish-root.gradle')
+    apply from: file('../../scripts/android/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
@@ -49,7 +61,13 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(':capacitor-android')
+
+    if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
+        implementation "com.capacitorjs:core:$capacitorVersion"
+    } else {
+        implementation project(':capacitor-android')
+    }
+
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/toast/android/build.gradle
+++ b/toast/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
+    capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'

--- a/toast/android/build.gradle
+++ b/toast/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    capacitorVersion = System.getenv('CAPACITOR_VERSION')
+    capacitorVersion = System.getenv('CAPACITOR_VERSION') ?: '[4.0,5.0)'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'


### PR DESCRIPTION
Similarly to https://github.com/ionic-team/capacitor/pull/6022 this pull request adds the native publication scripts into main and eliminates the need for the `native-publish` branch in the capacitor-plugins repo.

The plugins use a separate ENV variable in the flow `CAP_PLUGIN_PUBLISH` to distinguish from Capacitor so it doesn't trigger the scripts inside the Capacitor core project and cause a gradle error.

- The publish-android job will now attempt to fully publish the plugin all the way to production if the script checks are successful.

- Updated the publication script to also support Kotlin plugins like google-maps.

