### PR TITLE
fix IllegalArgumentException

### DIFF
--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -116,7 +116,9 @@ public class SharePlugin extends Plugin {
                     getContext(),
                     0,
                     new Intent(Intent.EXTRA_CHOSEN_COMPONENT),
-                    PendingIntent.FLAG_UPDATE_CURRENT
+                        (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) ?
+                                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE :
+                                PendingIntent.FLAG_UPDATE_CURRENT
                 );
                 chooser = Intent.createChooser(intent, dialogTitle, pi.getIntentSender());
                 chosenComponent = null;


### PR DESCRIPTION
Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.