### PR TITLE
chore(android): increase jvm mem size for building google-maps in gradle

### DIFF
--- a/google-maps/android/gradle.properties
+++ b/google-maps/android/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx1536m -XX:MaxMetaspaceSize=512m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
https://github.com/ionic-team/capacitor-plugins/actions/runs/3422497029/jobs/5699974730#step:5:46

Metaspace error when trying to build and publish google-maps plugin. It is related to there not being enough memory allocated for the process.

I encountered this error locally when building too but it didn't happen all the time. It occurred during GitHub publish job and failed the build. This should help prevent the issue in the future. I tested locally a few times and couldn't reproduce the error after this.