### PR TITLE
fix(google-maps): install google.maps types as dependency

### DIFF
--- a/google-maps/package.json
+++ b/google-maps/package.json
@@ -63,7 +63,6 @@
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "^1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",
-    "@types/google.maps": "^3.48.1",
     "@types/supercluster": "^7.1.0",
     "downlevel-dts": "^0.7.0",
     "eslint": "^7.11.0",
@@ -95,6 +94,7 @@
   },
   "dependencies": {
     "@googlemaps/js-api-loader": "^1.13.7",
-    "@googlemaps/markerclusterer": "^2.0.7"
+    "@googlemaps/markerclusterer": "^2.0.7",
+    "@types/google.maps": "^3.50.5"
   }
 }


### PR DESCRIPTION
The types introduced in https://github.com/ionic-team/capacitor-plugins/pull/1233 come from @types/google-maps, but since they are a dev dependency, apps using the latest version of the plugin fail to build if they don't have @types/google-maps installed.
Making it a dependency fixes the build issue without users having to install @types/google-maps themselves.

closes https://github.com/ionic-team/capacitor-plugins/issues/1261
