### PR TITLE
fix(splash-screen): Remove extension from storyboard name

### DIFF
--- a/splash-screen/ios/Plugin/SplashScreen.swift
+++ b/splash-screen/ios/Plugin/SplashScreen.swift
@@ -89,7 +89,7 @@ import Capacitor
 
     private func buildViews() {
         let storyboardName = Bundle.main.infoDictionary?["UILaunchStoryboardName"] as? String ?? "LaunchScreen"
-        if let vc = UIStoryboard(name: storyboardName, bundle: nil).instantiateInitialViewController() {
+        if let vc = UIStoryboard(name: storyboardName.replacingOccurrences(of: ".storyboard", with: ""), bundle: nil).instantiateInitialViewController() {
             viewController = vc
         }
 


### PR DESCRIPTION
Xcode 14 appends `.storyboard` to the storyboard name if the launch storyboard is changed from there, but then getting the storyboard from the name crashes if the name contains `.storyboard` extension.
So remove it in case it's there.

closes https://github.com/ionic-team/capacitor-plugins/issues/1253