### PR TITLE
docs(status-bar): Document animation problems on show/hide

### DIFF
--- a/status-bar/README.md
+++ b/status-bar/README.md
@@ -114,6 +114,10 @@ show(options?: AnimationOptions | undefined) => Promise<void>
 ```
 
 Show the status bar.
+On iOS, if the status bar is initially hidden and the initial style is set to
+`UIStatusBarStyleLightContent`, first show call might present a glitch on the
+animation showing the text as dark and then transition to light. It's recommended
+to use <a href="#animation">`Animation.None`</a> as the animation on the first call.
 
 | Param         | Type                                                          |
 | ------------- | ------------------------------------------------------------- |
@@ -231,10 +235,10 @@ This method is only supported on Android.
 
 #### Animation
 
-| Members     | Value                | Description                       | Since |
-| ----------- | -------------------- | --------------------------------- | ----- |
-| **`None`**  | <code>'NONE'</code>  | No animation during show/hide.    | 1.0.0 |
-| **`Slide`** | <code>'SLIDE'</code> | Slide animation during show/hide. | 1.0.0 |
-| **`Fade`**  | <code>'FADE'</code>  | Fade animation during show/hide.  | 1.0.0 |
+| Members     | Value                | Description                                                   | Since |
+| ----------- | -------------------- | ------------------------------------------------------------- | ----- |
+| **`None`**  | <code>'NONE'</code>  | No animation during show/hide.                                | 1.0.0 |
+| **`Slide`** | <code>'SLIDE'</code> | Slide animation during show/hide. It doesn't work on iOS 15+. | 1.0.0 |
+| **`Fade`**  | <code>'FADE'</code>  | Fade animation during show/hide.                              | 1.0.0 |
 
 </docgen-api>

--- a/status-bar/src/definitions.ts
+++ b/status-bar/src/definitions.ts
@@ -54,6 +54,7 @@ export enum Animation {
 
   /**
    * Slide animation during show/hide.
+   * It doesn't work on iOS 15+.
    *
    * @since 1.0.0
    */
@@ -140,6 +141,10 @@ export interface StatusBarPlugin {
 
   /**
    * Show the status bar.
+   * On iOS, if the status bar is initially hidden and the initial style is set to
+   * `UIStatusBarStyleLightContent`, first show call might present a glitch on the
+   * animation showing the text as dark and then transition to light. It's recommended
+   * to use `Animation.None` as the animation on the first call.
    *
    * @since 1.0.0
    */


### PR DESCRIPTION
Document that slide animation no longer works on iOS 15+ and a glitch that can happen on first show call

closes https://github.com/ionic-team/capacitor-plugins/issues/1238