### PR TITLE
chore(android): remove daemon and increase mem for google-maps build

### DIFF
--- a/google-maps/android/gradle.properties
+++ b/google-maps/android/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=2g -XX:MaxPermSize=2g
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -37,7 +37,7 @@ publish_plugin () {
                 export CAP_PLUGIN_PUBLISH=true
 
                 # Build and publish
-                "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true -Pandroid.enableJetifier=true > $LOG_OUTPUT 2>&1
+                "$ANDROID_PATH"/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --no-daemon --max-workers 1 -b "$ANDROID_PATH"/build.gradle -Pandroid.useAndroidX=true -Pandroid.enableJetifier=true > $LOG_OUTPUT 2>&1
 
                 if grep --quiet "BUILD SUCCESSFUL" $LOG_OUTPUT; then
                     printf %"s\n\n" "Success: $PLUGIN_NAME published to MavenCentral."
@@ -94,7 +94,7 @@ else
     fi
 fi
 
-# -----------------------------------------------
+################################################
 # old below - for reference only
 
 # # Get the latest version of Capacitor


### PR DESCRIPTION
This fixes the metaspace issue the android build CI ran into when it got to google-maps. The daemon was running out of memory and has negligible benefit in this flow, so I disabled it and it seems to have fixed the issue in conjunction with increasing the amount of memory the gooogle-maps plugin has to build. Tested locally publishing against maven snapshot repo.