### PR TITLE
chore(ci): Fix publish-ios.yml 

### DIFF
--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -16,25 +16,17 @@ jobs:
         plugin: ${{ fromJson(github.event.inputs.plugins) }}
     steps:
       - run: sudo xcode-select --switch /Applications/Xcode_13.3.1.app
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
-      - uses: actions/checkout@v2
+          node-version: 16
+      - uses: actions/checkout@v3
       - name: Install Cocoapods
         run: | 
           gem install cocoapods
-      - name: Restore Dependency Cache
-        id: cache-modules
-        uses: actions/cache@v2
-        with:
-          path: |
-            node_modules
-            */node_modules
-          key: dependency-cache-${{ hashFiles('package.json', '*/package.json') }}
-      - run: npm install
       - name: Deploy to Cocoapods
         run: |
           set -eo pipefail
           npm run publish:cocoapod
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        working-directory: ${{ matrix.plugin }}


### PR DESCRIPTION
Updates publish-ios.yml to use the working-directory of the plugin. Removes unneeded dependency caching and npm install.