### PR TITLE
chore(local-notifications): ignore body length lint error

### DIFF
--- a/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
+++ b/local-notifications/ios/Plugin/LocalNotificationsPlugin.swift
@@ -23,6 +23,7 @@ enum LocalNotificationError: LocalizedError {
     }
 }
 
+// swiftlint:disable type_body_length
 @objc(LocalNotificationsPlugin)
 public class LocalNotificationsPlugin: CAPPlugin {
     private let notificationDelegationHandler = LocalNotificationsHandler()


### PR DESCRIPTION
A new version of swiftlint was released that makes local-notifications plugin fail to lint because of body length of the LocalNotificationsPlugin class (see https://github.com/ionic-team/capacitor-plugins/pull/1303)

This PR ignores body length of the class.