### PR TITLE
Allow setting the color for controls in the browser toolbar

### DIFF
--- a/browser/ios/Plugin/Browser.swift
+++ b/browser/ios/Plugin/Browser.swift
@@ -15,12 +15,15 @@ import SafariServices
         return safariViewController
     }
 
-    @objc public func prepare(for url: URL, withTint tint: UIColor? = nil, modalPresentation style: UIModalPresentationStyle = .fullScreen) -> Bool {
+    @objc public func prepare(for url: URL, withBarTint toolbar: UIColor? = nil, withControlsTint controls: UIColor? = nil, modalPresentation style: UIModalPresentationStyle = .fullScreen) -> Bool {
         if safariViewController == nil, let scheme = url.scheme?.lowercased(), ["http", "https"].contains(scheme) {
             let safariVC = SFSafariViewController(url: url)
             safariVC.delegate = self
-            if let color = tint {
+            if let color = toolbar {
                 safariVC.preferredBarTintColor = color
+            }
+            if let color = controls {
+                safariVC.preferredControlTintColor = color
             }
             safariVC.modalPresentationStyle = style
             if style == .popover {

--- a/browser/ios/Plugin/BrowserPlugin.swift
+++ b/browser/ios/Plugin/BrowserPlugin.swift
@@ -16,9 +16,13 @@ public class CAPBrowserPlugin: CAPPlugin {
         if let toolbarColor = call.getString("toolbarColor") {
             color = UIColor.capacitor.color(fromHex: toolbarColor)
         }
+        var controlsColor: UIColor?
+        if let controlsColorStr = call.getString("controlsColor") {
+            controlsColor = UIColor.capacitor.color(fromHex: controlsColorStr)
+        }
         let style = self.presentationStyle(for: call.getString("presentationStyle"))
         // prepare for display
-        guard implementation.prepare(for: url, withTint: color, modalPresentation: style), let viewController = implementation.viewController else {
+        guard implementation.prepare(for: url, withBarTint: color, withControlsTint: controlsColor, modalPresentation: style), let viewController = implementation.viewController else {
             call.reject("Unable to display URL")
             return
         }

--- a/browser/src/definitions.ts
+++ b/browser/src/definitions.ts
@@ -80,6 +80,13 @@ export interface OpenOptions {
   toolbarColor?: string;
 
   /**
+   * A hex color to which the color of controls in the toolbar are set.
+   *
+   * @since 1.0.0
+   */
+  controlsColor?: string;
+  
+  /**
    * iOS only: The presentation style of the browser. Defaults to fullscreen.
    *
    * Ignored on other platforms.


### PR DESCRIPTION
This PR implements setting a color for the controls in the browser overlay, as mentioned in #911 .
I only made changes for iOS, not sure if something is needed for Android.

So now next to the `toolbarColor` you can also set a `controlsColor` in the params for `Browser.open`, e.g.

```
Browser.open({
   url: "https://capacitorjs.com",
   toolbarColor: "#ff0000",
   controlsColor: "#00ff00"
});
```