### PR TITLE
fix(splash-screen): Don't show if WebView is older than supported

### DIFF
--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreenPlugin.java
@@ -18,7 +18,11 @@ public class SplashScreenPlugin extends Plugin {
     public void load() {
         config = getSplashScreenConfig();
         splashScreen = new SplashScreen(getContext(), config);
-        splashScreen.showOnLaunch(getActivity());
+        if (!bridge.isMinimumWebViewInstalled() && bridge.getConfig().getErrorPath() != null && !config.isLaunchAutoHide()) {
+            return;
+        } else {
+            splashScreen.showOnLaunch(getActivity());
+        }
     }
 
     @PluginMethod


### PR DESCRIPTION
If an error page is configured and the WebView is older than the minimum WebView version, don't show the splash screen.

closes https://github.com/ionic-team/capacitor-plugins/issues/1280