### PR TITLE
feat(camera): add option to exclude Exif data on iOS

### DIFF
--- a/camera/README.md
+++ b/camera/README.md
@@ -249,14 +249,15 @@ Request camera and photo album permissions
 
 #### GalleryImageOptions
 
-| Prop                     | Type                                   | Description                                                                                | Default                     | Since |
-| ------------------------ | -------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------- | ----- |
-| **`quality`**            | <code>number</code>                    | The quality of image to return as JPEG, from 0-100                                         |                             | 1.2.0 |
-| **`width`**              | <code>number</code>                    | The desired maximum width of the saved image. The aspect ratio is respected.               |                             | 1.2.0 |
-| **`height`**             | <code>number</code>                    | The desired maximum height of the saved image. The aspect ratio is respected.              |                             | 1.2.0 |
-| **`correctOrientation`** | <code>boolean</code>                   | Whether to automatically rotate the image "up" to correct for orientation in portrait mode | <code>: true</code>         | 1.2.0 |
-| **`presentationStyle`**  | <code>'fullscreen' \| 'popover'</code> | iOS only: The presentation style of the Camera.                                            | <code>: 'fullscreen'</code> | 1.2.0 |
-| **`limit`**              | <code>number</code>                    | iOS only: Maximum number of pictures the user will be able to choose.                      | <code>0 (unlimited)</code>  | 1.2.0 |
+| Prop                     | Type                                   | Description                                                                                              | Default                     | Since |
+| ------------------------ | -------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------- | ----- |
+| **`exif`**               | <code>boolean</code>                   | Whether to include the exif data in the response. If set to `true`, the `photos` permission is required. | <code>: true</code>         | 4.2.0 |
+| **`quality`**            | <code>number</code>                    | The quality of image to return as JPEG, from 0-100                                                       |                             | 1.2.0 |
+| **`width`**              | <code>number</code>                    | The desired maximum width of the saved image. The aspect ratio is respected.                             |                             | 1.2.0 |
+| **`height`**             | <code>number</code>                    | The desired maximum height of the saved image. The aspect ratio is respected.                            |                             | 1.2.0 |
+| **`correctOrientation`** | <code>boolean</code>                   | Whether to automatically rotate the image "up" to correct for orientation in portrait mode               | <code>: true</code>         | 1.2.0 |
+| **`presentationStyle`**  | <code>'fullscreen' \| 'popover'</code> | iOS only: The presentation style of the Camera.                                                          | <code>: 'fullscreen'</code> | 1.2.0 |
+| **`limit`**              | <code>number</code>                    | iOS only: Maximum number of pictures the user will be able to choose.                                    | <code>0 (unlimited)</code>  | 1.2.0 |
 
 
 #### PermissionStatus

--- a/camera/ios/Plugin/CameraPlugin.swift
+++ b/camera/ios/Plugin/CameraPlugin.swift
@@ -434,14 +434,15 @@ private extension CameraPlugin {
     }
 
     func showPhotos() {
+        let exif = self.call?.getBool("exif") ?? true
         // check for permission
         let authStatus = PHPhotoLibrary.authorizationStatus()
-        if authStatus == .restricted || authStatus == .denied {
+        if exif && (authStatus == .restricted || authStatus == .denied) {
             call?.reject("User denied access to photos")
             return
         }
         // we either already have permission or can prompt
-        if authStatus == .authorized {
+        if !exif || authStatus == .authorized {
             presentSystemAppropriateImagePicker()
         } else {
             PHPhotoLibrary.requestAuthorization({ [weak self] (status) in

--- a/camera/ios/Plugin/ImageSaver.swift
+++ b/camera/ios/Plugin/ImageSaver.swift
@@ -4,7 +4,7 @@ class ImageSaver: NSObject {
 
     var onResult: ((Error?) -> Void) = {_ in }
 
-    init(image: UIImage, onResult:@escaping ((Error?) -> Void)) {
+    init(image: UIImage, onResult: @escaping ((Error?) -> Void)) {
         self.onResult = onResult
         super.init()
         UIImageWriteToSavedPhotosAlbum(image, self, #selector(saveResult), nil)

--- a/camera/src/definitions.ts
+++ b/camera/src/definitions.ts
@@ -277,6 +277,17 @@ export interface GalleryPhoto {
 }
 export interface GalleryImageOptions {
   /**
+   * Whether to include the exif data in the response.
+   * 
+   * If set to `true`, the `photos` permission is required.
+   * 
+   * Only available on iOS.
+   * 
+   * @default true
+   * @since 4.2.0
+   */
+  exif?: boolean;
+  /**
    * The quality of image to return as JPEG, from 0-100
    *
    * @since 1.2.0

--- a/camera/src/definitions.ts
+++ b/camera/src/definitions.ts
@@ -278,11 +278,11 @@ export interface GalleryPhoto {
 export interface GalleryImageOptions {
   /**
    * Whether to include the exif data in the response.
-   * 
+   *
    * If set to `true`, the `photos` permission is required.
-   * 
+   *
    * Only available on iOS.
-   * 
+   *
    * @default true
    * @since 4.2.0
    */


### PR DESCRIPTION
The `pickImages` function should only ask for permission if it is really necessary. 
This is the case on iOS only when you need the Exif data (see [comment](https://github.com/ionic-team/capacitor-plugins/issues/1325#issuecomment-1346182920)). My client does not need this data and therefore wants to improve the UX by not asking permission for data that is not used.

Related to #1297 and #1325