### PR TITLE
Fix(local-notifications): adds RTC_WAKEUP if schedule.allowWhileIdle is true

### DIFF
--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
@@ -379,13 +379,13 @@ public class LocalNotificationManager {
     ) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms()) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && schedule.allowWhileIdle()) {
-                alarmManager.setAndAllowWhileIdle(AlarmManager.RTC, trigger, pendingIntent);
+                alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, trigger, pendingIntent);
             } else {
                 alarmManager.set(AlarmManager.RTC, trigger, pendingIntent);
             }
         } else {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && schedule.allowWhileIdle()) {
-                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC, trigger, pendingIntent);
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, trigger, pendingIntent);
             } else {
                 alarmManager.setExact(AlarmManager.RTC, trigger, pendingIntent);
             }


### PR DESCRIPTION
See docs on RTC vs RTC_WAKEUP
https://developer.android.com/reference/android/app/AlarmManager#RTC

This simply updates RTC to RTC_WAKEUP so that the device wakes up when a local notification goes off and allowWhileIdle is true