### PR TITLE
fix(filesystem): close InputStream

### DIFF
--- a/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/Filesystem.java
+++ b/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/Filesystem.java
@@ -161,6 +161,7 @@ public class Filesystem {
         while ((length = is.read(buffer)) != -1) {
             outputStream.write(buffer, 0, length);
         }
+        is.close();
 
         return outputStream.toString(encoding);
     }


### PR DESCRIPTION
Found a warning log:

```
W/System: A resource failed to call close.
```

After enabling `StrictMode`, the warning is caused by:

```
D/StrictMode: StrictMode policy violation: android.os.strictmode.LeakedClosableViolation: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
        at android.os.StrictMode$AndroidCloseGuardReporter.report(StrictMode.java:1987)
        at dalvik.system.CloseGuard.warnIfOpen(CloseGuard.java:345)
        at java.io.FileInputStream.finalize(FileInputStream.java:503)
        at java.lang.Daemons$FinalizerDaemon.doFinalize(Daemons.java:291)
        at java.lang.Daemons$FinalizerDaemon.runInternal(Daemons.java:278)
        at java.lang.Daemons$Daemon.run(Daemons.java:139)
        at java.lang.Thread.run(Thread.java:920)
     Caused by: java.lang.Throwable: Explicit termination method 'close' not called
        at dalvik.system.CloseGuard.openWithCallSite(CloseGuard.java:295)
        at dalvik.system.CloseGuard.open(CloseGuard.java:263)
        at java.io.FileInputStream.<init>(FileInputStream.java:176)
        at com.capacitorjs.plugins.filesystem.Filesystem.getInputStream(Filesystem.java:142)
        at com.capacitorjs.plugins.filesystem.Filesystem.readFile(Filesystem.java:24)
        at com.capacitorjs.plugins.filesystem.FilesystemPlugin.readFile(FilesystemPlugin.java:62)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.getcapacitor.PluginHandle.invoke(PluginHandle.java:125)
        at com.getcapacitor.Bridge.lambda$callPluginMethod$0$com-getcapacitor-Bridge(Bridge.java:704)
        at com.getcapacitor.Bridge$$ExternalSyntheticLambda5.run(Unknown Source:8)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:346)
        at android.os.Looper.loop(Looper.java:475)
        at android.os.HandlerThread.run(HandlerThread.java:67)
```