### PR TITLE
fix(share): Files are ignored on old Android SDKs

### DIFF
--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -142,7 +142,7 @@ public class SharePlugin extends Plugin {
                     );
                     fileUris.add(fileUrl);
 
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1 && filesList.size() == 1) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && filesList.size() == 1) {
                         intent.setDataAndType(fileUrl, type);
                         intent.putExtra(Intent.EXTRA_STREAM, fileUrl);
                     }

--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -142,7 +142,7 @@ public class SharePlugin extends Plugin {
                     );
                     fileUris.add(fileUrl);
 
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && filesList.size() == 1) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1 && filesList.size() == 1) {
                         intent.setDataAndType(fileUrl, type);
                         intent.putExtra(Intent.EXTRA_STREAM, fileUrl);
                     }


### PR DESCRIPTION
On SDK 25 (I tested in 26, 27 and 28 too) the files area ignored if try to share just one.

I lowered the SDK level on the comparation on that file and compiled and tested between levels 25 and 28 (29 an up are not needed because previously is compared with >= 29)