### PR TITLE
fix(google-maps): Update Clusters when moving map

### DIFF
--- a/google-maps/README.md
+++ b/google-maps/README.md
@@ -270,7 +270,7 @@ export default MyMap;
 <docgen-index>
 
 * [`create(...)`](#create)
-* [`enableClustering()`](#enableclustering)
+* [`enableClustering(...)`](#enableclustering)
 * [`disableClustering()`](#disableclustering)
 * [`addMarker(...)`](#addmarker)
 * [`addMarkers(...)`](#addmarkers)
@@ -322,11 +322,15 @@ create(options: CreateMapArgs, callback?: MapListenerCallback<MapReadyCallbackDa
 --------------------
 
 
-### enableClustering()
+### enableClustering(...)
 
 ```typescript
-enableClustering() => Promise<void>
+enableClustering(minClusterSize?: number | undefined) => Promise<void>
 ```
+
+| Param                | Type                |
+| -------------------- | ------------------- |
+| **`minClusterSize`** | <code>number</code> |
 
 --------------------
 

--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
@@ -239,16 +239,18 @@ class CapacitorGoogleMapsPlugin : Plugin() {
             val id = call.getString("id")
             id ?: throw InvalidMapIdError()
 
+            val minClusterSize = call.getInt("minClusterSize")
+
             val map = maps[id]
             map ?: throw MapNotFoundError()
 
-            map.enableClustering { err ->
+            map.enableClustering(minClusterSize,  { err ->
                 if (err != null) {
                     throw err
                 }
 
                 call.resolve()
-            }
+            })
         } catch (e: GoogleMapsError) {
             handleError(call, e)
         } catch (e: Exception) {

--- a/google-maps/e2e-tests/ios/App/App.xcodeproj/project.pbxproj
+++ b/google-maps/e2e-tests/ios/App/App.xcodeproj/project.pbxproj
@@ -362,7 +362,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 3HC6X87AYW;
+				DEVELOPMENT_TEAM = 9YN2HU59K8;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -381,7 +381,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 3HC6X87AYW;
+				DEVELOPMENT_TEAM = 9YN2HU59K8;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/google-maps/e2e-tests/src/pages/Markers/MultipleMarkers.tsx
+++ b/google-maps/e2e-tests/src/pages/Markers/MultipleMarkers.tsx
@@ -3,264 +3,274 @@ import { GoogleMap, Marker } from '@capacitor/google-maps';
 import { IonButton, IonTextarea } from '@ionic/react';
 import BaseTestingPage from '../../components/BaseTestingPage';
 
-
 const MultipleMarkers: React.FC = () => {
-    const [map, setMap] = useState<GoogleMap | null>(null);
-    const [markerIds, setMarkerIds] = useState<string[]>([]);
-    const [commandOutput, setCommandOutput] = useState('');
-    const [commandOutput2, setCommandOutput2] = useState('');
-    const apiKey = process.env.REACT_APP_GOOGLE_MAPS_API_KEY;
+  const [map, setMap] = useState<GoogleMap | null>(null);
+  const [markerIds, setMarkerIds] = useState<string[]>([]);
+  const [commandOutput, setCommandOutput] = useState('');
+  const [commandOutput2, setCommandOutput2] = useState('');
+  const apiKey = process.env.REACT_APP_GOOGLE_MAPS_API_KEY;
 
-    const onBoundsChanged = (data: any) => {
-        setCommandOutput(`BOUNDS CHANGED:  ${JSON.stringify(data)}`);
+  const onBoundsChanged = (data: any) => {
+    setCommandOutput(`BOUNDS CHANGED:  ${JSON.stringify(data)}`);
+  };
+
+  const onCameraIdle = (data: any) => {
+    setCommandOutput(`CAMERA IDLE:  ${JSON.stringify(data)}`);
+  };
+
+  const onCameraMoveStarted = (data: any) => {
+    setCommandOutput(`CAMERA MOVE STARTED:  ${JSON.stringify(data)}`);
+  };
+
+  const onClusterClick = (data: any) => {
+    setCommandOutput2(`CLUSTER CLICKED:  ${JSON.stringify(data)}`);
+  };
+
+  const onClusterInfoWindowClick = (data: any) => {
+    setCommandOutput2(`CLUSTER INFO WINDOW CLICKED:  ${JSON.stringify(data)}`);
+  };
+
+  const onInfoWindowClick = (data: any) => {
+    setCommandOutput2(`INFO WINDOW CLICKED:  ${JSON.stringify(data)}`);
+  };
+
+  const onMapClick = (data: any) => {
+    setCommandOutput(`MAP CLICKED:  ${JSON.stringify(data)}`);
+    setCommandOutput2('');
+  };
+
+  const onMarkerClick = (data: any) => {
+    setCommandOutput2(`MARKER CLICKED:  ${JSON.stringify(data)}`);
+  };
+
+  const onMyLocationButtonClick = (data: any) => {
+    setCommandOutput2(`MY LOCATION BUTTON CLICKED:  ${JSON.stringify(data)}`);
+  };
+
+  const onMyLocationClick = (data: any) => {
+    setCommandOutput2(`MY LOCATION CLICKED:  ${JSON.stringify(data)}`);
+  };
+
+  async function createMap() {
+    try {
+      const element = document.getElementById('multipleMarkers_map1');
+      if (element !== null) {
+        const newMap = await GoogleMap.create({
+          element: element,
+          id: 'test-map',
+          apiKey: apiKey!,
+          config: {
+            center: {
+              lat: 47.6,
+              lng: -122.33,
+            },
+            zoom: 5,
+          },
+        });
+
+        setMap(newMap);
+
+        setCommandOutput('Map created');
+        setCommandOutput2('');
+      }
+    } catch (err: any) {
+      setCommandOutput(err.message);
+      setCommandOutput2('');
     }
+  }
 
-    const onCameraIdle = (data: any) => {
-        setCommandOutput(`CAMERA IDLE:  ${JSON.stringify(data)}`);
+  async function setEventListeners() {
+    map?.setOnBoundsChangedListener(onBoundsChanged);
+    map?.setOnCameraIdleListener(onCameraIdle);
+    map?.setOnCameraMoveStartedListener(onCameraMoveStarted);
+    map?.setOnClusterClickListener(onClusterClick);
+    map?.setOnClusterInfoWindowClickListener(onClusterInfoWindowClick);
+    map?.setOnInfoWindowClickListener(onInfoWindowClick);
+    map?.setOnMapClickListener(onMapClick);
+    map?.setOnMarkerClickListener(onMarkerClick);
+    map?.setOnMyLocationButtonClickListener(onMyLocationButtonClick);
+    map?.setOnMyLocationClickListener(onMyLocationClick);
+    setCommandOutput('Set Event Listeners!');
+    setCommandOutput2('');
+  }
+
+  async function removeEventListeners() {
+    map?.removeAllMapListeners();
+    setCommandOutput('Removed Event Listeners!');
+    setCommandOutput2('');
+  }
+
+  async function enableClustering() {
+    try {
+      if (map) {
+        await map.enableClustering(2);
+        setCommandOutput('marker clustering enabled');
+        setCommandOutput2('');
+      }
+    } catch (err: any) {
+      setCommandOutput(err.message);
+      setCommandOutput2('');
     }
+  }
 
-    const onCameraMoveStarted = (data: any) => {
-        setCommandOutput(`CAMERA MOVE STARTED:  ${JSON.stringify(data)}`);
+  async function addMultipleMarkers() {
+    try {
+      if (map) {
+        const markers: Marker[] = [
+          {
+            coordinate: {
+              lat: 47.6,
+              lng: -122.33,
+            },
+            title: 'Title 1',
+            snippet: 'Snippet 1',
+          },
+          {
+            coordinate: {
+              lat: 47.6,
+              lng: -122.46,
+            },
+            title: 'Title 2',
+            snippet: 'Snippet 2',
+          },
+          {
+            coordinate: {
+              lat: 47.3,
+              lng: -122.46,
+            },
+            title: 'Title 3',
+            snippet: 'Snippet 3',
+          },
+          {
+            coordinate: {
+              lat: 47.2,
+              lng: -122.23,
+            },
+            title: 'Title 4',
+            snippet: 'Snippet 4',
+          },
+        ];
+
+        const ids = await map.addMarkers(markers);
+        console.log('@@IDS: ', ids);
+        setMarkerIds(ids);
+        setCommandOutput(`${ids.length} markers added`);
+        setCommandOutput2('');
+      }
+    } catch (err: any) {
+      setCommandOutput(err.message);
+      setCommandOutput2('');
     }
+  }
 
-    const onClusterClick = (data: any) => {
-        setCommandOutput2(`CLUSTER CLICKED:  ${JSON.stringify(data)}`);
+  async function removeAllMarkers() {
+    try {
+      if (map) {
+        await map.removeMarkers(markerIds);
+        setCommandOutput(`${markerIds.length} markers removed`);
+        setCommandOutput2('');
+        setMarkerIds([]);
+      }
+    } catch (err: any) {
+      setCommandOutput(err.message);
+      setCommandOutput2('');
     }
+  }
 
-    const onClusterInfoWindowClick = (data: any) => {
-        setCommandOutput2(`CLUSTER INFO WINDOW CLICKED:  ${JSON.stringify(data)}`);
+  async function disableClustering() {
+    try {
+      if (map) {
+        await map.disableClustering();
+        setCommandOutput('marker clustering disabled');
+        setCommandOutput2('');
+      }
+    } catch (err: any) {
+      setCommandOutput(err.message);
+      setCommandOutput2('');
     }
+  }
 
-    const onInfoWindowClick = (data: any) => {
-        setCommandOutput2(`INFO WINDOW CLICKED:  ${JSON.stringify(data)}`);
+  async function destroyMap() {
+    setCommandOutput('');
+    try {
+      if (map) {
+        await map.destroy();
+        setCommandOutput('Map destroyed');
+        setCommandOutput2('');
+      }
+    } catch (err: any) {
+      setCommandOutput(err.message);
+      setCommandOutput2('');
     }
+  }
 
-    const onMapClick = (data: any) => {
-        setCommandOutput(`MAP CLICKED:  ${JSON.stringify(data)}`);
-        setCommandOutput2("");
-    }
+  async function showCurrentLocation() {
+    await map?.setCamera({
+      zoom: 1,
+      animate: true,
+      animationDuration: 50,
+    });
+    await map?.enableCurrentLocation(true);
+  }
 
-    const onMarkerClick = (data: any) => {
-        setCommandOutput2(`MARKER CLICKED:  ${JSON.stringify(data)}`);
-    }
+  async function showCurrentBounds() {
+    const bounds = await map?.getMapBounds();
+    setCommandOutput(JSON.stringify(bounds));
+  }
 
-    const onMyLocationButtonClick = (data: any) => {
-        setCommandOutput2(`MY LOCATION BUTTON CLICKED:  ${JSON.stringify(data)}`);
-    }
-
-    const onMyLocationClick = (data: any) => {
-        setCommandOutput2(`MY LOCATION CLICKED:  ${JSON.stringify(data)}`);
-    }
-
-    async function createMap() {
-        try {
-            const element = document.getElementById('multipleMarkers_map1');
-            if (element !== null) {
-                const newMap = await GoogleMap.create({
-                    element: element, 
-                    id: "test-map", 
-                    apiKey: apiKey!, 
-                    config: {
-                        center: {
-                            lat: 47.60,
-                            lng: -122.33,
-                        },
-                        zoom: 5,
-                    }
-                });
-
-                setMap(newMap);
-
-                setCommandOutput("Map created");
-                setCommandOutput2("");
-            }
-        } catch (err: any) {
-            setCommandOutput(err.message);
-            setCommandOutput2("");
-        }
-    }
-
-    async function setEventListeners() {
-        map?.setOnBoundsChangedListener(onBoundsChanged);
-        map?.setOnCameraIdleListener(onCameraIdle);
-        map?.setOnCameraMoveStartedListener(onCameraMoveStarted);
-        map?.setOnClusterClickListener(onClusterClick);
-        map?.setOnClusterInfoWindowClickListener(onClusterInfoWindowClick);
-        map?.setOnInfoWindowClickListener(onInfoWindowClick);
-        map?.setOnMapClickListener(onMapClick);
-        map?.setOnMarkerClickListener(onMarkerClick);
-        map?.setOnMyLocationButtonClickListener(onMyLocationButtonClick);
-        map?.setOnMyLocationClickListener(onMyLocationClick);
-        setCommandOutput('Set Event Listeners!');
-        setCommandOutput2("");
-    }
-
-    async function removeEventListeners() {
-        map?.removeAllMapListeners();
-        setCommandOutput('Removed Event Listeners!');
-        setCommandOutput2("");
-    }
-
-    async function enableClustering() {
-        try {
-            if (map) {
-                await map.enableClustering();
-                setCommandOutput("marker clustering enabled")
-                setCommandOutput2("");
-            }
-        } catch (err: any) {
-            setCommandOutput(err.message);
-            setCommandOutput2("");
-        }
-    }
-
-    async function addMultipleMarkers() {
-        try {
-            if (map) {
-                const markers: Marker[] = [{
-                    coordinate: {
-                        lat: 47.60,
-                        lng: -122.33,
-                    },
-                    title: "Title 1",
-                    snippet: "Snippet 1",
-                }, {
-                    coordinate: {
-                        lat: 47.60,
-                        lng: -122.46,
-                    },
-                    title: "Title 2",
-                    snippet: "Snippet 2",
-                }, {
-                    coordinate: {
-                        lat: 47.30,
-                        lng: -122.46,
-                    },
-                    title: "Title 3",
-                    snippet: "Snippet 3",
-                }, {
-                    coordinate: {
-                        lat: 47.20,
-                        lng: -122.23,
-                    },
-                    title: "Title 4",
-                    snippet: "Snippet 4",
-                }];
-
-                const ids = await map.addMarkers(markers);
-                console.log("@@IDS: ", ids);
-                setMarkerIds(ids)
-                setCommandOutput(`${ids.length} markers added`)
-                setCommandOutput2("");
-            }
-        } catch (err: any) {
-            setCommandOutput(err.message);
-            setCommandOutput2("");
-        }
-    }
-
-    async function removeAllMarkers() {
-        try {
-            if (map) {
-                await map.removeMarkers(markerIds)
-                setCommandOutput(`${markerIds.length} markers removed`)
-                setCommandOutput2("");
-                setMarkerIds([])
-            }
-        } catch (err: any) {
-            setCommandOutput(err.message);
-            setCommandOutput2("");
-        }
-    }
-
-    async function disableClustering() {
-        try {
-            if (map) {
-                await map.disableClustering();
-                setCommandOutput("marker clustering disabled")
-                setCommandOutput2("");
-            }
-        } catch (err: any) {
-            setCommandOutput(err.message);
-            setCommandOutput2("");
-        }
-    }
-
-    async function destroyMap() {
-        setCommandOutput("");
-        try {
-            if (map) {
-                await map.destroy();
-                setCommandOutput('Map destroyed');
-                setCommandOutput2("");
-            }
-        } catch (err: any) {
-            setCommandOutput(err.message);
-            setCommandOutput2("");
-        }
-    }
-
-    async function showCurrentLocation() {
-        await map?.setCamera({               
-            zoom: 1,
-            animate: true,
-            animationDuration: 50,
-        })
-        await map?.enableCurrentLocation(true);
-    }
-
-    async function showCurrentBounds() {
-        const bounds = await map?.getMapBounds();
-        setCommandOutput(JSON.stringify(bounds));
-    }
-
-    return (
-        <BaseTestingPage pageTitle="Multiple Markers">
-            <div>
-                <IonButton id="createMapButton" onClick={createMap}>
-                    Create Map
-                </IonButton>
-                <IonButton  id="setOnMarkerClickButton" onClick={setEventListeners}>
-                    Set Event Listeners
-                </IonButton>
-                <IonButton  id="removeOnMarkerClickButton" onClick={removeEventListeners}>
-                    Remove Event Listeners
-                </IonButton>
-                <IonButton  id="showCurrentLocationButton" onClick={showCurrentLocation}>
-                    Show Current Location
-                </IonButton>
-                <IonButton  id="showCurrentBoundsButton" onClick={showCurrentBounds}>
-                    Show Current Bounds
-                </IonButton>
-                <IonButton id="addMarkersButton" onClick={addMultipleMarkers}>
-                    Add Multiple Markers
-                </IonButton>
-                <IonButton id="enableClusteringButton" onClick={enableClustering}>
-                    Enable Clustering
-                </IonButton>
-                <IonButton id="disableClusteringButton" onClick={disableClustering}>
-                    Disable Clustering
-                </IonButton>
-                <IonButton id="removeMarkersButton" onClick={removeAllMarkers}>
-                    Remove Markers
-                </IonButton>
-                <IonButton id="destroyMapButton" onClick={destroyMap}>
-                    Destroy Map
-                </IonButton> 
-            </div>
-            <div>
-                <IonTextarea id="commandOutput" value={commandOutput}></IonTextarea>
-                <IonTextarea id="commandOutput2" value={commandOutput2}></IonTextarea>
-            </div>
-            <capacitor-google-map id="multipleMarkers_map1" style={{
-                position: "absolute",
-                top: window.innerHeight - 150,
-                left: 0,
-                width: window.innerWidth,
-                height: 150,
-            }}></capacitor-google-map>
-        </BaseTestingPage>
-    )
-}
+  return (
+    <BaseTestingPage pageTitle="Multiple Markers">
+      <div>
+        <IonButton id="createMapButton" onClick={createMap}>
+          Create Map
+        </IonButton>
+        <IonButton id="setOnMarkerClickButton" onClick={setEventListeners}>
+          Set Event Listeners
+        </IonButton>
+        <IonButton
+          id="removeOnMarkerClickButton"
+          onClick={removeEventListeners}
+        >
+          Remove Event Listeners
+        </IonButton>
+        <IonButton id="showCurrentLocationButton" onClick={showCurrentLocation}>
+          Show Current Location
+        </IonButton>
+        <IonButton id="showCurrentBoundsButton" onClick={showCurrentBounds}>
+          Show Current Bounds
+        </IonButton>
+        <IonButton id="addMarkersButton" onClick={addMultipleMarkers}>
+          Add Multiple Markers
+        </IonButton>
+        <IonButton id="enableClusteringButton" onClick={enableClustering}>
+          Enable Clustering
+        </IonButton>
+        <IonButton id="disableClusteringButton" onClick={disableClustering}>
+          Disable Clustering
+        </IonButton>
+        <IonButton id="removeMarkersButton" onClick={removeAllMarkers}>
+          Remove Markers
+        </IonButton>
+        <IonButton id="destroyMapButton" onClick={destroyMap}>
+          Destroy Map
+        </IonButton>
+      </div>
+      <div>
+        <IonTextarea id="commandOutput" value={commandOutput}></IonTextarea>
+        <IonTextarea id="commandOutput2" value={commandOutput2}></IonTextarea>
+      </div>
+      <capacitor-google-map
+        id="multipleMarkers_map1"
+        style={{
+          position: 'absolute',
+          top: window.innerHeight - 150,
+          left: 0,
+          width: window.innerWidth,
+          height: 150,
+        }}
+      ></capacitor-google-map>
+    </BaseTestingPage>
+  );
+};
 
 export default MultipleMarkers;

--- a/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.swift
+++ b/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.swift
@@ -425,7 +425,9 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate {
                 throw GoogleMapErrors.mapNotFound
             }
 
-            map.enableClustering()
+            let minClusterSize = call.getInt("minClusterSize")
+
+            map.enableClustering(minClusterSize)
             call.resolve()
 
         } catch {

--- a/google-maps/ios/Plugin/Map.swift
+++ b/google-maps/ios/Plugin/Map.swift
@@ -12,6 +12,7 @@ class GMViewController: UIViewController {
     var mapViewBounds: [String: Double]!
     var GMapView: GMSMapView!
     var cameraPosition: [String: Double]!
+    var minimumClusterSize: Int?
 
     private var clusterManager: GMUClusterManager?
 
@@ -28,11 +29,14 @@ class GMViewController: UIViewController {
         self.view = GMapView
     }
 
-    func initClusterManager() {
+    func initClusterManager(_ minClusterSize: Int?) {
         let iconGenerator = GMUDefaultClusterIconGenerator()
         let algorithm = GMUNonHierarchicalDistanceBasedAlgorithm()
         let renderer = GMUDefaultClusterRenderer(mapView: self.GMapView, clusterIconGenerator: iconGenerator)
-
+        self.minimumClusterSize = minClusterSize
+        if let minClusterSize = minClusterSize {
+            renderer.minimumClusterSize = UInt(minClusterSize)
+        }
         self.clusterManager = GMUClusterManager(map: self.GMapView, algorithm: algorithm, renderer: renderer)
     }
 
@@ -224,10 +228,10 @@ public class Map {
         return markerHashes
     }
 
-    func enableClustering() {
+    func enableClustering(_ minClusterSize: Int?) {
         if !self.mapViewController.clusteringEnabled {
             DispatchQueue.main.sync {
-                self.mapViewController.initClusterManager()
+                self.mapViewController.initClusterManager(minClusterSize)
 
                 // add existing markers to the cluster
                 if !self.markers.isEmpty {
@@ -240,6 +244,9 @@ public class Map {
                     self.mapViewController.addMarkersToCluster(markers: existingMarkers)
                 }
             }
+        } else if self.mapViewController.minimumClusterSize != minClusterSize {
+            self.mapViewController.destroyClusterManager()
+            enableClustering(minClusterSize)
         }
     }
 

--- a/google-maps/src/implementation.ts
+++ b/google-maps/src/implementation.ts
@@ -105,13 +105,23 @@ export interface OnScrollArgs {
   };
 }
 
+export interface EnableClusteringArgs {
+  id: string;
+  /**
+   * The minimum number of markers that can be clustered together.
+   *
+   * @default 4
+   */
+  minClusterSize?: number;
+}
+
 export interface CapacitorGoogleMapsPlugin extends Plugin {
   create(options: CreateMapArgs): Promise<void>;
   addMarker(args: AddMarkerArgs): Promise<{ id: string }>;
   addMarkers(args: AddMarkersArgs): Promise<{ ids: string[] }>;
   removeMarker(args: RemoveMarkerArgs): Promise<void>;
   removeMarkers(args: RemoveMarkersArgs): Promise<void>;
-  enableClustering(args: { id: string }): Promise<void>;
+  enableClustering(args: EnableClusteringArgs): Promise<void>;
   disableClustering(args: { id: string }): Promise<void>;
   destroy(args: DestroyMapArgs): Promise<void>;
   setCamera(args: CameraArgs): Promise<void>;

--- a/google-maps/src/map.ts
+++ b/google-maps/src/map.ts
@@ -24,7 +24,7 @@ export interface GoogleMapInterface {
     options: CreateMapArgs,
     callback?: MapListenerCallback<MapReadyCallbackData>,
   ): Promise<GoogleMap>;
-  enableClustering(): Promise<void>;
+  enableClustering(minClusterSize?: number): Promise<void>;
   disableClustering(): Promise<void>;
   addMarker(marker: Marker): Promise<string>;
   addMarkers(markers: Marker[]): Promise<string[]>;
@@ -206,9 +206,10 @@ export class GoogleMap {
    *
    * @returns void
    */
-  async enableClustering(): Promise<void> {
+  async enableClustering(minClusterSize?: number): Promise<void> {
     return CapacitorGoogleMaps.enableClustering({
       id: this.id,
+      minClusterSize,
     });
   }
 

--- a/google-maps/src/web.ts
+++ b/google-maps/src/web.ts
@@ -3,7 +3,10 @@ import type {
   Cluster,
   onClusterClickHandler,
 } from '@googlemaps/markerclusterer';
-import { MarkerClusterer } from '@googlemaps/markerclusterer';
+import {
+  MarkerClusterer,
+  SuperClusterAlgorithm,
+} from '@googlemaps/markerclusterer';
 
 import type { LatLngBounds, Marker } from './definitions';
 import type {
@@ -22,6 +25,7 @@ import type {
   TrafficLayerArgs,
   RemoveMarkersArgs,
   OnScrollArgs,
+  EnableClusteringArgs,
 } from './implementation';
 
 export class CapacitorGoogleMapsWeb
@@ -254,7 +258,7 @@ export class CapacitorGoogleMapsWeb
     delete this.maps[_args.id].markers[_args.markerId];
   }
 
-  async enableClustering(_args: { id: string }): Promise<void> {
+  async enableClustering(_args: EnableClusteringArgs): Promise<void> {
     const markers: google.maps.Marker[] = [];
 
     for (const id in this.maps[_args.id].markers) {
@@ -264,6 +268,9 @@ export class CapacitorGoogleMapsWeb
     this.maps[_args.id].markerClusterer = new MarkerClusterer({
       map: this.maps[_args.id].map,
       markers: markers,
+      algorithm: new SuperClusterAlgorithm({
+        minPoints: _args.minClusterSize ?? 4,
+      }),
       onClusterClick: this.onClusterClickHandler,
     });
   }


### PR DESCRIPTION
This PR addresses #1309, where (on android) clustering does not update when the map is moved, rotated, or zoomed in/out. It also allows modification of the minimum cluster size so behavior can be matched across all platforms.