### PR TITLE
fix(share): not sharing files on Android < 10

### DIFF
--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -141,11 +141,6 @@ public class SharePlugin extends Plugin {
                         new File(Uri.parse(file).getPath())
                     );
                     fileUris.add(fileUrl);
-
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && filesList.size() == 1) {
-                        intent.setDataAndType(fileUrl, type);
-                        intent.putExtra(Intent.EXTRA_STREAM, fileUrl);
-                    }
                 } else {
                     call.reject("only file urls are supported");
                     return;
@@ -153,6 +148,11 @@ public class SharePlugin extends Plugin {
             }
             if (fileUris.size() > 1) {
                 intent.putExtra(Intent.EXTRA_STREAM, fileUris);
+            } else if (fileUris.size() == 1) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    intent.setClipData(ClipData.newRawUri("", fileUris.get(0)));
+                }
+                intent.putExtra(Intent.EXTRA_STREAM, fileUris.get(0));
             }
             intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         } catch (Exception ex) {


### PR DESCRIPTION
The `Intent.EXTRA_STREAM` should be put outside of the SDK_INT version check.

The `setDataAndType` originally started as `setData` and was changed to `setDataAndType` because it caused problems as calling `setData` resets the type.
`setData` was added to prevent a permission error that was being displayed on Android 10+ because the share dialog didn't have permission to preview the shared image. But we shouldn't have used `setData` nor replace it with `setDataAndType` later on. For granting the uri permission to the preview `setClipData` should be used instead.

closes https://github.com/ionic-team/capacitor-plugins/issues/1353
closes https://github.com/ionic-team/capacitor-plugins/pull/1371