### PR TITLE
fix: Add FLAG_MUTABLE to pending intents for SDK 31 support

### DIFF
--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
@@ -254,12 +254,11 @@ public class LocalNotificationManager {
         // Open intent
         Intent intent = buildIntent(localNotification, DEFAULT_PRESS_ACTION);
 
-        PendingIntent pendingIntent = PendingIntent.getActivity(
-            context,
-            localNotification.getId(),
-            intent,
-            PendingIntent.FLAG_CANCEL_CURRENT
-        );
+        int flags = PendingIntent.FLAG_CANCEL_CURRENT;
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            flags = flags | PendingIntent.FLAG_MUTABLE;
+        }
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, localNotification.getId(), intent, flags);
         mBuilder.setContentIntent(pendingIntent);
 
         // Build action types
@@ -273,7 +272,7 @@ public class LocalNotificationManager {
                     context,
                     localNotification.getId() + notificationAction.getId().hashCode(),
                     actionIntent,
-                    PendingIntent.FLAG_CANCEL_CURRENT
+                    flags
                 );
                 NotificationCompat.Action.Builder actionBuilder = new NotificationCompat.Action.Builder(
                     R.drawable.ic_transparent,
@@ -295,7 +294,11 @@ public class LocalNotificationManager {
         dissmissIntent.putExtra(ACTION_INTENT_KEY, "dismiss");
         LocalNotificationSchedule schedule = localNotification.getSchedule();
         dissmissIntent.putExtra(NOTIFICATION_IS_REMOVABLE_KEY, schedule == null || schedule.isRemovable());
-        PendingIntent deleteIntent = PendingIntent.getBroadcast(context, localNotification.getId(), dissmissIntent, 0);
+        flags = 0;
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            flags = PendingIntent.FLAG_MUTABLE;
+        }
+        PendingIntent deleteIntent = PendingIntent.getBroadcast(context, localNotification.getId(), dissmissIntent, flags);
         mBuilder.setDeleteIntent(deleteIntent);
     }
 
@@ -330,12 +333,11 @@ public class LocalNotificationManager {
         Intent notificationIntent = new Intent(context, TimedNotificationPublisher.class);
         notificationIntent.putExtra(NOTIFICATION_INTENT_KEY, request.getId());
         notificationIntent.putExtra(TimedNotificationPublisher.NOTIFICATION_KEY, notification);
-        PendingIntent pendingIntent = PendingIntent.getBroadcast(
-            context,
-            request.getId(),
-            notificationIntent,
-            PendingIntent.FLAG_CANCEL_CURRENT
-        );
+        int flags = PendingIntent.FLAG_CANCEL_CURRENT;
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            flags = flags | PendingIntent.FLAG_MUTABLE;
+        }
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(context, request.getId(), notificationIntent, flags);
 
         // Schedule at specific time (with repeating support)
         Date at = schedule.getAt();
@@ -373,7 +375,7 @@ public class LocalNotificationManager {
         if (on != null) {
             long trigger = on.nextTrigger(new Date());
             notificationIntent.putExtra(TimedNotificationPublisher.CRON_KEY, on.toMatchString());
-            pendingIntent = PendingIntent.getBroadcast(context, request.getId(), notificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
+            pendingIntent = PendingIntent.getBroadcast(context, request.getId(), notificationIntent, flags);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && schedule.allowWhileIdle()) {
                 alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC, trigger, pendingIntent);
             } else {
@@ -399,7 +401,11 @@ public class LocalNotificationManager {
 
     private void cancelTimerForNotification(Integer notificationId) {
         Intent intent = new Intent(context, TimedNotificationPublisher.class);
-        PendingIntent pi = PendingIntent.getBroadcast(context, notificationId, intent, 0);
+        int flags = 0;
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            flags = PendingIntent.FLAG_MUTABLE;
+        }
+        PendingIntent pi = PendingIntent.getBroadcast(context, notificationId, intent, flags);
         if (pi != null) {
             AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
             alarmManager.cancel(pi);

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
@@ -48,7 +48,11 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
             AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
             long trigger = date.nextTrigger(new Date());
             Intent clone = (Intent) intent.clone();
-            PendingIntent pendingIntent = PendingIntent.getBroadcast(context, id, clone, PendingIntent.FLAG_CANCEL_CURRENT);
+            int flags = PendingIntent.FLAG_CANCEL_CURRENT;
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                flags = flags | PendingIntent.FLAG_MUTABLE;
+            }
+            PendingIntent pendingIntent = PendingIntent.getBroadcast(context, id, clone, flags);
             alarmManager.setExact(AlarmManager.RTC, trigger, pendingIntent);
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
             Logger.debug(Logger.tags("LN"), "notification " + id + " will next fire at " + sdf.format(new Date(trigger)));

--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -111,13 +111,12 @@ public class SharePlugin extends Plugin {
 
             Intent chooser = null;
             if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+                int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    flags = flags | PendingIntent.FLAG_MUTABLE;
+                }
                 // requestCode parameter is not used. Providing 0
-                PendingIntent pi = PendingIntent.getBroadcast(
-                    getContext(),
-                    0,
-                    new Intent(Intent.EXTRA_CHOSEN_COMPONENT),
-                    PendingIntent.FLAG_UPDATE_CURRENT
-                );
+                PendingIntent pi = PendingIntent.getBroadcast(getContext(), 0, new Intent(Intent.EXTRA_CHOSEN_COMPONENT), flags);
                 chooser = Intent.createChooser(intent, dialogTitle, pi.getIntentSender());
                 chosenComponent = null;
             } else {


### PR DESCRIPTION
Backport of #913, #914 and #1173

I know normally you don't do backports. Especially since @jcesarmobile mentioned adding support for SDK 31 itself, would be a feature, which won't be shipped to Capacitor v3 anymore.

But please allow me to explain why I think fixes like these would still make sense to me:

(I am assuming targeting SDK 31 is required by Google Play Store, which at the moment, it is)

I can agree that adding explicit support for SDK 31 to Capacitor v3 can/should be considered a feature in itself. But if you won't be shipping fixes like this one, Capacitor v3 is essentially useless and completely unsupported as a whole for new projects. Okay, that would still be fair. But for large _existing_ projects, that means, no native updates can be done, unless you would upgrade to Capacitor v4. The migration of v3 to v4 is pretty painless, for which I applaud your team. But for enterprise-sized projects, it's still a major thing to do, and can't be done in a few days, week or even months. But during that time, I think it's fair to say you would still need to be able to ship new native updates.

Even if - after this speech ;) - you still don't agree with me on this, I think it's fair to explicitly mention in the docs, that Capacitor v3 only supports up to SDK 30. Because otherwise someone might increase the targetSdkVersion himself, and run into unexpected runtime errors (I had this myself).