### PR TITLE
Avoid crashing by catching and rejecting the call.

### DIFF
--- a/preferences/android/src/main/java/com/capacitorjs/plugins/preferences/PreferencesPlugin.java
+++ b/preferences/android/src/main/java/com/capacitorjs/plugins/preferences/PreferencesPlugin.java
@@ -43,11 +43,15 @@ public class PreferencesPlugin extends Plugin {
             return;
         }
 
-        String value = preferences.get(key);
+        try{
+            String value = preferences.get(key);
 
-        JSObject ret = new JSObject();
-        ret.put("value", value == null ? JSObject.NULL : value);
-        call.resolve(ret);
+            JSObject ret = new JSObject();
+            ret.put("value", value == null ? JSObject.NULL : value);
+            call.resolve(ret);
+        } catch (ClassCastException exception){
+            call.reject(exception.getMessage());
+        }
     }
 
     @PluginMethod


### PR DESCRIPTION
There is an issue when using preferences. Right now the preferences plugin assume that they are always Strings. 

The plugin has no way to pass more information on which type it should fetch. When you are getting a preference that is for example Long, the app will crash.

Wrapping the JS in a try/catch does not catch the exception. This change catches class cast exceptions to avoid crashing the app if the types don't match.