### PR TITLE
fix(google-maps/android): dispatch touch events to correct y position

### DIFF
--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
@@ -540,17 +540,16 @@ class CapacitorGoogleMapsPlugin : Plugin() {
 
             val events = cachedTouchEvents[id]
             if (events != null) {
-                for (event in events) {
+                while(events.size > 0) {
+                    val event = events.first()
                     if (focus) {
                         map.dispatchTouchEvent(event)
                     } else {
-                        event.source = -1
-                        this.bridge.webView.dispatchTouchEvent(event)
+                        this.bridge.webView.onTouchEvent(event)
                     }
+                    events.removeFirst()
                 }
             }
-
-            cachedTouchEvents[id]?.clear()
 
             call.resolve()
         } catch (e: GoogleMapsError) {


### PR DESCRIPTION
This PR fixes #1357, where the touch position was being dispatched to the wrong y coordinate.

Sample reproduction: https://github.com/marlon-ionic/ng14-ssfcu-cap-map-sidemenu