### PR TITLE
feat(google-maps): Add getMapType method

### DIFF
--- a/google-maps/README.md
+++ b/google-maps/README.md
@@ -278,6 +278,7 @@ export default MyMap;
 * [`removeMarkers(...)`](#removemarkers)
 * [`destroy()`](#destroy)
 * [`setCamera(...)`](#setcamera)
+* [`getMapType()`](#getmaptype)
 * [`setMapType(...)`](#setmaptype)
 * [`enableIndoorMaps(...)`](#enableindoormaps)
 * [`enableTrafficLayer(...)`](#enabletrafficlayer)
@@ -418,6 +419,19 @@ setCamera(config: CameraConfig) => Promise<void>
 | Param        | Type                                                  |
 | ------------ | ----------------------------------------------------- |
 | **`config`** | <code><a href="#cameraconfig">CameraConfig</a></code> |
+
+--------------------
+
+
+### getMapType()
+
+```typescript
+getMapType() => Promise<MapType>
+```
+
+Get current map type
+
+**Returns:** <code>Promise&lt;<a href="#maptype">MapType</a>&gt;</code>
 
 --------------------
 

--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
@@ -416,6 +416,27 @@ class CapacitorGoogleMap(
         }
     }
 
+    fun getMapType(callback: (type: String, error: GoogleMapsError?) -> Unit) {
+        try {
+            googleMap ?: throw GoogleMapNotAvailable()
+            CoroutineScope(Dispatchers.Main).launch {
+                val mapType: String = when (googleMap?.mapType) {
+                    MAP_TYPE_NORMAL -> "Normal"
+                    MAP_TYPE_HYBRID -> "Hybrid"
+                    MAP_TYPE_SATELLITE -> "Satellite"
+                    MAP_TYPE_TERRAIN -> "Terrain"
+                    MAP_TYPE_NONE -> "None"
+                    else -> {
+                        "Normal"
+                    }
+                }
+                callback(mapType, null);
+            }
+        }  catch (e: GoogleMapsError) {
+            callback("", e)
+        }
+    }
+
     fun setMapType(mapType: String, callback: (error: GoogleMapsError?) -> Unit) {
         try {
             googleMap ?: throw GoogleMapNotAvailable()

--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
@@ -376,6 +376,31 @@ class CapacitorGoogleMapsPlugin : Plugin() {
     }
 
     @PluginMethod
+    fun getMapType(call: PluginCall) {
+        try {
+            val id = call.getString("id")
+            id ?: throw InvalidMapIdError()
+
+            val map = maps[id]
+            map ?: throw MapNotFoundError()
+
+            map.getMapType() { type, err ->
+
+                if (err != null) {
+                    throw err
+                }
+                val data = JSObject()
+                data.put("type", type)
+                call.resolve(data)
+            }
+        } catch (e: GoogleMapsError) {
+            handleError(call, e)
+        } catch (e: Exception) {
+            handleError(call, e)
+        }
+    }
+
+    @PluginMethod
     fun setMapType(call: PluginCall) {
         try {
             val id = call.getString("id")

--- a/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.m
+++ b/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.m
@@ -13,6 +13,7 @@ CAP_PLUGIN(CapacitorGoogleMapsPlugin, "CapacitorGoogleMaps",
    CAP_PLUGIN_METHOD(disableClustering, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(destroy, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(setCamera, CAPPluginReturnPromise);
+   CAP_PLUGIN_METHOD(getMapType, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(setMapType, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(enableIndoorMaps, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(enableTrafficLayer, CAPPluginReturnPromise);

--- a/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.swift
+++ b/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.swift
@@ -21,6 +21,22 @@ extension GMSMapViewType {
             return .normal
         }
     }
+    static func toString(mapType: GMSMapViewType) -> String {
+        switch mapType {
+        case .normal:
+            return "Normal"
+        case .hybrid:
+            return "Hybrid"
+        case .satellite:
+            return "Satellite"
+        case .terrain:
+            return "Terrain"
+        case .none:
+            return "None"
+        default:
+            return "Normal"
+        }
+    }
 }
 
 extension CGRect {
@@ -270,6 +286,26 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate {
             try map.setCamera(config: config)
 
             call.resolve()
+        } catch {
+            handleError(call, error: error)
+        }
+    }
+
+    @objc func getMapType(_ call: CAPPluginCall) {
+        do {
+            guard let id = call.getString("id") else {
+                throw GoogleMapErrors.invalidMapId
+            }
+
+            guard let map = self.maps[id] else {
+                throw GoogleMapErrors.mapNotFound
+            }
+
+            let mapType = GMSMapViewType.toString(mapType: map.getMapType())
+
+            call.resolve([
+                "type": mapType
+            ])
         } catch {
             handleError(call, error: error)
         }

--- a/google-maps/ios/Plugin/Map.swift
+++ b/google-maps/ios/Plugin/Map.swift
@@ -303,6 +303,10 @@ public class Map {
 
     }
 
+    func getMapType() -> GMSMapViewType {
+        return self.mapViewController.GMapView.mapType
+    }
+
     func setMapType(mapType: GMSMapViewType) throws {
         DispatchQueue.main.sync {
             self.mapViewController.GMapView.mapType = mapType

--- a/google-maps/src/implementation.ts
+++ b/google-maps/src/implementation.ts
@@ -126,6 +126,7 @@ export interface CapacitorGoogleMapsPlugin extends Plugin {
   disableClustering(args: { id: string }): Promise<void>;
   destroy(args: DestroyMapArgs): Promise<void>;
   setCamera(args: CameraArgs): Promise<void>;
+  getMapType(args: { id: string }): Promise<{ type: string }>;
   setMapType(args: MapTypeArgs): Promise<void>;
   enableIndoorMaps(args: IndoorMapArgs): Promise<void>;
   enableTrafficLayer(args: TrafficLayerArgs): Promise<void>;

--- a/google-maps/src/map.ts
+++ b/google-maps/src/map.ts
@@ -5,7 +5,6 @@ import type {
   CameraConfig,
   Marker,
   MapPadding,
-  MapType,
   MapListenerCallback,
   MapReadyCallbackData,
   CameraIdleCallbackData,
@@ -15,7 +14,7 @@ import type {
   MarkerClickCallbackData,
   MyLocationButtonClickCallbackData,
 } from './definitions';
-import { LatLngBounds } from './definitions';
+import { LatLngBounds, MapType } from './definitions';
 import type { CreateMapArgs } from './implementation';
 import { CapacitorGoogleMaps } from './implementation';
 
@@ -37,6 +36,10 @@ export interface GoogleMapInterface {
   removeMarkers(ids: string[]): Promise<void>;
   destroy(): Promise<void>;
   setCamera(config: CameraConfig): Promise<void>;
+  /**
+   * Get current map type
+   */
+  getMapType(): Promise<MapType>;
   setMapType(mapType: MapType): Promise<void>;
   enableIndoorMaps(enabled: boolean): Promise<void>;
   enableTrafficLayer(enabled: boolean): Promise<void>;
@@ -314,6 +317,11 @@ export class GoogleMap {
       id: this.id,
       config,
     });
+  }
+
+  async getMapType(): Promise<MapType> {
+    const { type } = await CapacitorGoogleMaps.getMapType({ id: this.id });
+    return MapType[type as keyof typeof MapType];
   }
 
   /**

--- a/google-maps/src/web.ts
+++ b/google-maps/src/web.ts
@@ -9,7 +9,7 @@ import {
 } from '@googlemaps/markerclusterer';
 
 import type { Marker } from './definitions';
-import { LatLngBounds } from './definitions';
+import { MapType, LatLngBounds } from './definitions';
 import type {
   AccElementsArgs,
   AddMarkerArgs,
@@ -121,6 +121,17 @@ export class CapacitorGoogleMapsWeb
       tilt: _args.config.angle,
       zoom: _args.config.zoom,
     });
+  }
+
+  async getMapType(_args: { id: string }): Promise<{ type: string }> {
+    let type = this.maps[_args.id].map.getMapTypeId();
+    if (type !== undefined) {
+      if (type === 'roadmap') {
+        type = MapType.Normal;
+      }
+      return { type };
+    }
+    throw new Error('Map type is undefined');
   }
 
   async setMapType(_args: MapTypeArgs): Promise<void> {


### PR DESCRIPTION
I've called it `getMapType` instead of the proposed `getMapTypeId` (google maps js SDK name) since we have a `setMapType` function and the native methods in google maps SDK are called `getMapType`.

Also returns our existing `MapType`  instead of the proposed `google.maps.MapTypeId` since they don't match.

closes https://github.com/ionic-team/capacitor-plugins/issues/1347