### PR TITLE
feat(push-notifications): allow more control over foreground notifications

### DIFF
--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -56,9 +56,13 @@ Android Studio has an icon generator you can use to create your Push Notificatio
 
 You can configure the way the push notifications are displayed when the app is in foreground.
 
-| Prop                      | Type                              | Description                                                                                                                                                                                                                                                                                                                                                                                          | Since |
-| ------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| **`presentationOptions`** | <code>PresentationOption[]</code> | This is an array of strings you can combine. Possible values in the array are: - `badge`: badge count on the app icon is updated (default value) - `sound`: the device will ring/vibrate when the push notification is received - `alert`: the push notification is displayed in a native dialog An empty array can be provided if none of the options are desired. badge is only available for iOS. | 1.0.0 |
+| Prop                                      | Type                                        | Description                                                                                                                                                                                                                                                                                                                                                                                          | Since |
+| ----------------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`presentationOptions`**                 | <code>PresentationOption[]</code>           | This is an array of strings you can combine. Possible values in the array are: - `badge`: badge count on the app icon is updated (default value) - `sound`: the device will ring/vibrate when the push notification is received - `alert`: the push notification is displayed in a native dialog An empty array can be provided if none of the options are desired. badge is only available for iOS. | 1.0.0 |
+| **`androidForegroundChannelId`**          | <code>AndroidForegroundChannelOption</code> | The channel for android foreground notifications. - 'default': Use the default channel for foreground notifications. - 'auto': Use the channel specified in the notification for foreground notifications. - string: Use the specified channel for foreground notifications. You must create the channel manually.                                                                                   |       |
+| **`androidForegroundChannelName`**        | <code>string</code>                         | The name of the channel for android background notifications if using 'default' for androidForegroundChannelId.                                                                                                                                                                                                                                                                                      |       |
+| **`androidForegroundChannelDescription`** | <code>string</code>                         | The description of the channel for android background notifications if using 'default' for androidForegroundChannelId.                                                                                                                                                                                                                                                                               |       |
+| **`androidForegroundChannelSound`**       | <code>string</code>                         | The sound for the notification channel if using 'default' for androidForegroundChannelId. This is the name of the sound file in the app's raw folder.                                                                                                                                                                                                                                                |       |
 
 ### Examples
 
@@ -68,7 +72,11 @@ In `capacitor.config.json`:
 {
   "plugins": {
     "PushNotifications": {
-      "presentationOptions": ["badge", "sound", "alert"]
+      "presentationOptions": ["badge", "sound", "alert"],
+      "androidForegroundChannelId": undefined,
+      "androidForegroundChannelName": undefined,
+      "androidForegroundChannelDescription": undefined,
+      "androidForegroundChannelSound": undefined
     }
   }
 }
@@ -85,6 +93,10 @@ const config: CapacitorConfig = {
   plugins: {
     PushNotifications: {
       presentationOptions: ["badge", "sound", "alert"],
+      androidForegroundChannelId: undefined,
+      androidForegroundChannelName: undefined,
+      androidForegroundChannelDescription: undefined,
+      androidForegroundChannelSound: undefined,
     },
   },
 };

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/NotificationChannelManager.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/NotificationChannelManager.java
@@ -142,27 +142,35 @@ public class NotificationChannelManager {
     }
 
     /**
-     * Create notification channel
+     * Create foreground notification channel
      */
     public void createForegroundNotificationChannel() {
         // Create the NotificationChannel only if presentationOptions is defined
+        // and the android.foregroundChannelId is set to "default"
         // Because the channel can't be changed after creation
         String[] presentation = config.getArray("presentationOptions");
-        if (presentation != null) {
+        String foregroundChannelId = config.getString("androidForegroundChannelId", "default");
+        if ((presentation != null) && (androidForegroundChannelId.equals("default"))) {
             // And only on API 26+ because the NotificationChannel class
             // is new and not in the support library
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                CharSequence name = "Push Notifications Foreground";
-                String description = "Push notifications in foreground";
+                CharSequence name = config.getString("androidForegroundChannelName", "Push Notifications Foreground");
+                String description = config.getString("androidForegroundChannelDescription", "Push notifications in foreground");
                 int importance = NotificationManager.IMPORTANCE_HIGH;
                 NotificationChannel channel = new NotificationChannel(FOREGROUND_NOTIFICATION_CHANNEL_ID, name, importance);
                 channel.setDescription(description);
                 if (Arrays.asList(presentation).contains("sound")) {
+                    String sound = config.getString("androidForegroundChannelSound", null);
+                    if (sound != null) {
+                        Uri soundUri = Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + context.getPackageName() + "/raw/" + sound);
+                    } else {
+                        Uri soundUri = Settings.System.DEFAULT_NOTIFICATION_URI;
+                    };
                     AudioAttributes audioAttributes = new AudioAttributes.Builder()
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                         .setUsage(AudioAttributes.USAGE_ALARM)
                         .build();
-                    channel.setSound(Settings.System.DEFAULT_NOTIFICATION_URI, audioAttributes);
+                    channel.setSound(soundUri, audioAttributes);
                 }
                 // Register the channel with the system; you can't change the importance
                 // or other notification behaviors after this

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/NotificationChannelManager.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/NotificationChannelManager.java
@@ -146,10 +146,10 @@ public class NotificationChannelManager {
      */
     public void createForegroundNotificationChannel() {
         // Create the NotificationChannel only if presentationOptions is defined
-        // and the android.foregroundChannelId is set to "default"
+        // and the androidForegroundChannelId is set to "default"
         // Because the channel can't be changed after creation
         String[] presentation = config.getArray("presentationOptions");
-        String foregroundChannelId = config.getString("androidForegroundChannelId", "default");
+        String androidForegroundChannelId = config.getString("androidForegroundChannelId", "default");
         if ((presentation != null) && (androidForegroundChannelId.equals("default"))) {
             // And only on API 26+ because the NotificationChannel class
             // is new and not in the support library
@@ -161,12 +161,13 @@ public class NotificationChannelManager {
                 channel.setDescription(description);
                 if (Arrays.asList(presentation).contains("sound")) {
                     String sound = config.getString("androidForegroundChannelSound", null);
+                    Uri soundUri;
                     if (sound != null) {
-                        Uri soundUri = Uri.parse(
+                        soundUri = Uri.parse(
                             ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + context.getPackageName() + "/raw/" + sound
                         );
                     } else {
-                        Uri soundUri = Settings.System.DEFAULT_NOTIFICATION_URI;
+                        soundUri = Settings.System.DEFAULT_NOTIFICATION_URI;
                     }
                     AudioAttributes audioAttributes = new AudioAttributes.Builder()
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/NotificationChannelManager.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/NotificationChannelManager.java
@@ -162,10 +162,12 @@ public class NotificationChannelManager {
                 if (Arrays.asList(presentation).contains("sound")) {
                     String sound = config.getString("androidForegroundChannelSound", null);
                     if (sound != null) {
-                        Uri soundUri = Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + context.getPackageName() + "/raw/" + sound);
+                        Uri soundUri = Uri.parse(
+                            ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + context.getPackageName() + "/raw/" + sound
+                        );
                     } else {
                         Uri soundUri = Settings.System.DEFAULT_NOTIFICATION_URI;
-                    };
+                    }
                     AudioAttributes audioAttributes = new AudioAttributes.Builder()
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                         .setUsage(AudioAttributes.USAGE_ALARM)

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -20,6 +20,8 @@ import com.google.firebase.messaging.RemoteMessage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -232,7 +234,7 @@ public class PushNotificationsPlugin extends Plugin {
                     }
                     int pushIcon = android.R.drawable.ic_dialog_info;
 
-                    if (bundle != null && bundle.getInt("com.google.firebase.messaging.default_notification_icon") != 0) {
+                    if (bundle != null && bundle.containsKey("com.google.firebase.messaging.default_notification_icon")) {
                         pushIcon = bundle.getInt("com.google.firebase.messaging.default_notification_icon");
                     }
                     Intent intent = new Intent(getContext(), getActivity().getClass());
@@ -243,14 +245,14 @@ public class PushNotificationsPlugin extends Plugin {
                         intent,
                         PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE
                     );
-                    String notificationChannel = getConfig().getString("androidForegroundChannelId", null);
-                    if (notificationChannel == "auto") {
-                        notificationChannel = notification.getChannelId();
+                    String notificationChannelId = getConfig().getString("androidForegroundChannelId", null);
+                    if (Objects.equals(notificationChannelId, "auto")) {
+                        notificationChannelId = notification.getChannelId();
                     }
-                    if ((notificationChannel == "default") || (notificationChannel == null)) {
-                        notificationChannel = NotificationChannelManager.FOREGROUND_NOTIFICATION_CHANNEL_ID;
+                    if ((Objects.equals(notificationChannelId, "default") || (notificationChannelId == null))) {
+                        notificationChannelId = NotificationChannelManager.FOREGROUND_NOTIFICATION_CHANNEL_ID;
                     }
-                    NotificationCompat.Builder builder = new NotificationCompat.Builder(getContext(), notificationChannel)
+                    NotificationCompat.Builder builder = new NotificationCompat.Builder(getContext(), notificationChannelId)
                         .setSmallIcon(pushIcon)
                         .setContentTitle(title)
                         .setAutoCancel(true)

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -250,10 +250,7 @@ public class PushNotificationsPlugin extends Plugin {
                     if ((notificationChannel == "default") || (notificationChannel == null)) {
                         notificationChannel = NotificationChannelManager.FOREGROUND_NOTIFICATION_CHANNEL_ID;
                     }
-                    NotificationCompat.Builder builder = new NotificationCompat.Builder(
-                        getContext(),
-                        notificationChannel
-                    )
+                    NotificationCompat.Builder builder = new NotificationCompat.Builder(getContext(), notificationChannel)
                         .setSmallIcon(pushIcon)
                         .setContentTitle(title)
                         .setAutoCancel(true)

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -243,7 +243,7 @@ public class PushNotificationsPlugin extends Plugin {
                         intent,
                         PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE
                     );
-                    String notificationChannel = config.getString("androidForegroundChannelId", null);
+                    String notificationChannel = getConfig().getString("androidForegroundChannelId", null);
                     if (notificationChannel == "auto") {
                         notificationChannel = notification.getChannelId();
                     }

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -2,6 +2,7 @@ package com.capacitorjs.plugins.pushnotifications;
 
 import android.app.Notification;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
@@ -234,12 +235,29 @@ public class PushNotificationsPlugin extends Plugin {
                     if (bundle != null && bundle.getInt("com.google.firebase.messaging.default_notification_icon") != 0) {
                         pushIcon = bundle.getInt("com.google.firebase.messaging.default_notification_icon");
                     }
+                    Intent intent = new Intent(getContext(), getActivity().getClass());
+                    intent.putExtras(remoteMessage.toIntent().getExtras());
+                    PendingIntent pendingIntent = PendingIntent.getActivity(
+                        getContext(),
+                        0,
+                        intent,
+                        PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE
+                    );
+                    String notificationChannel = config.getString("androidForegroundChannelId", null);
+                    if (notificationChannel == "auto") {
+                        notificationChannel = notification.getChannelId();
+                    }
+                    if ((notificationChannel == "default") || (notificationChannel == null)) {
+                        notificationChannel = NotificationChannelManager.FOREGROUND_NOTIFICATION_CHANNEL_ID;
+                    }
                     NotificationCompat.Builder builder = new NotificationCompat.Builder(
                         getContext(),
-                        NotificationChannelManager.FOREGROUND_NOTIFICATION_CHANNEL_ID
+                        notificationChannel
                     )
                         .setSmallIcon(pushIcon)
                         .setContentTitle(title)
+                        .setAutoCancel(true)
+                        .setContentIntent(pendingIntent)
                         .setContentText(body)
                         .setPriority(NotificationCompat.PRIORITY_DEFAULT);
                     notificationManager.notify(0, builder.build());

--- a/push-notifications/src/definitions.ts
+++ b/push-notifications/src/definitions.ts
@@ -4,6 +4,8 @@ import type { PermissionState, PluginListenerHandle } from '@capacitor/core';
 
 export type PresentationOption = 'badge' | 'sound' | 'alert';
 
+export type AndroidForegroundChannelOption = 'default' | 'auto' | string;
+
 declare module '@capacitor/cli' {
   export interface PluginsConfig {
     /**
@@ -24,6 +26,30 @@ declare module '@capacitor/cli' {
        * @example ["badge", "sound", "alert"]
        */
       presentationOptions: PresentationOption[];
+
+      /**
+       * The channel for android foreground notifications.
+       * - 'default': Use the default channel for foreground notifications.
+       * - 'auto': Use the channel specified in the notification for foreground notifications.
+       * - string: Use the specified channel for foreground notifications. You must create the channel manually.
+       */
+      androidForegroundChannelId?: AndroidForegroundChannelOption;
+
+      /**
+       * The name of the channel for android background notifications if using 'default' for androidForegroundChannelId.
+       */
+      androidForegroundChannelName?: string;
+
+      /**
+       * The description of the channel for android background notifications if using 'default' for androidForegroundChannelId.
+       */
+      androidForegroundChannelDescription?: string;
+
+      /**
+       * The sound for the notification channel if using 'default' for androidForegroundChannelId.
+       * This is the name of the sound file in the app's raw folder.
+       */
+      androidForegroundChannelSound?: string;
     };
   }
 }


### PR DESCRIPTION
Adds options for customising the android foreground notifications, while maintaining default behaviour if the settings are not specified.
Also addresses issue with clicking notifications - see #1324 

Fixes #1368
Fixes #1388