### PR TITLE
feat(google-maps): add extend to LatLngBounds

### DIFF
--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
@@ -527,27 +527,6 @@ class CapacitorGoogleMap(
         return googleMap?.projection?.visibleRegion?.latLngBounds ?: throw BoundsNotFoundError()
     }
 
-    fun getLatLngBoundsJSObject(bounds: LatLngBounds): JSObject {
-        val data = JSObject()
-
-        val southwestJS = JSObject()
-        val centerJS = JSObject()
-        val northeastJS = JSObject()
-
-        southwestJS.put("lat", bounds.southwest.latitude)
-        southwestJS.put("lng", bounds.southwest.longitude)
-        centerJS.put("lat", bounds.center.latitude)
-        centerJS.put("lng", bounds.center.longitude)
-        northeastJS.put("lat", bounds.northeast.latitude)
-        northeastJS.put("lng", bounds.northeast.longitude)
-
-        data.put("southwest", southwestJS)
-        data.put("center", centerJS)
-        data.put("northeast", northeastJS)
-
-        return data
-    }
-
     private fun getScaledPixels(bridge: Bridge, pixels: Int): Int {
         // Get the screen's density scale
         val scale = bridge.activity.resources.displayMetrics.density
@@ -845,4 +824,25 @@ class CapacitorGoogleMap(
             clusterManager?.cluster()
         }
     }
+}
+
+fun getLatLngBoundsJSObject(bounds: LatLngBounds): JSObject {
+    val data = JSObject()
+
+    val southwestJS = JSObject()
+    val centerJS = JSObject()
+    val northeastJS = JSObject()
+
+    southwestJS.put("lat", bounds.southwest.latitude)
+    southwestJS.put("lng", bounds.southwest.longitude)
+    centerJS.put("lat", bounds.center.latitude)
+    centerJS.put("lng", bounds.center.longitude)
+    northeastJS.put("lat", bounds.northeast.latitude)
+    northeastJS.put("lng", bounds.northeast.longitude)
+
+    data.put("southwest", southwestJS)
+    data.put("center", centerJS)
+    data.put("northeast", northeastJS)
+
+    return data
 }

--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPlugin.kt
@@ -597,7 +597,7 @@ class CapacitorGoogleMapsPlugin : Plugin() {
 
             CoroutineScope(Dispatchers.Main).launch {
                 val bounds = map.getLatLngBounds()
-                val data = map.getLatLngBoundsJSObject(bounds)
+                val data = getLatLngBoundsJSObject(bounds)
                 call.resolve(data)
             }
         } catch (e: GoogleMapsError) {
@@ -619,6 +619,27 @@ class CapacitorGoogleMapsPlugin : Plugin() {
                 val contains = bounds.contains(point)
                 val data = JSObject()
                 data.put("contains", contains)
+                call.resolve(data)
+            }
+        } catch (e: GoogleMapsError) {
+            handleError(call, e)
+        } catch (e: Exception) {
+            handleError(call, e)
+        }
+    }
+
+    @PluginMethod
+    fun mapBoundsExtend(call: PluginCall) {
+        try {
+            val boundsObject = call.getObject("bounds")
+            val pointObject = call.getObject("point")
+
+            CoroutineScope(Dispatchers.Main).launch {
+                val bounds = createLatLngBounds(boundsObject)
+                val point = createLatLng(pointObject)
+                val newBounds = bounds.including(point)
+                val data = JSObject()
+                data.put("bounds", getLatLngBoundsJSObject(newBounds))
                 call.resolve(data)
             }
         } catch (e: GoogleMapsError) {

--- a/google-maps/e2e-tests/src/pages/Map/Bounds.tsx
+++ b/google-maps/e2e-tests/src/pages/Map/Bounds.tsx
@@ -82,6 +82,20 @@ const BoundsMapPage: React.FC = () => {
     }
   }
 
+  async function extendBounds() {
+    setCommandOutput('');
+    try {
+      const bounds = await map!.getMapBounds();
+      const newBounds = await bounds.extend({
+        lat,
+        lng,
+      });
+      setCommandOutput(JSON.stringify(newBounds));
+    } catch (err: any) {
+      setCommandOutput(err.message);
+    }
+  }
+
   return (
     <BaseTestingPage pageTitle="Bounds">
       <div>
@@ -121,11 +135,22 @@ const BoundsMapPage: React.FC = () => {
             >
               Bounds Contains Point
             </IonButton>
+            <IonButton
+              expand="block"
+              id="extendBoundsButton"
+              onClick={extendBounds}
+            >
+              Extend Bounds
+            </IonButton>
           </IonCol>
         </IonRow>
       </div>
       <div>
-        <IonTextarea id="commandOutput" value={commandOutput}></IonTextarea>
+        <IonTextarea
+          id="commandOutput"
+          value={commandOutput}
+          autoGrow={true}
+        ></IonTextarea>
       </div>
       <capacitor-google-map
         id="map"

--- a/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.m
+++ b/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.m
@@ -23,4 +23,5 @@ CAP_PLUGIN(CapacitorGoogleMapsPlugin, "CapacitorGoogleMaps",
    CAP_PLUGIN_METHOD(onScroll, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(getMapBounds, CAPPluginReturnPromise);
    CAP_PLUGIN_METHOD(mapBoundsContains, CAPPluginReturnPromise);
+   CAP_PLUGIN_METHOD(mapBoundsExtend, CAPPluginReturnPromise);
 )

--- a/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.swift
+++ b/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.swift
@@ -540,6 +540,30 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate {
         }
     }
 
+    @objc func mapBoundsExtend(_ call: CAPPluginCall) {
+        do {
+            guard let boundsObject = call.getObject("bounds") else {
+                throw GoogleMapErrors.invalidArguments("Invalid bounds provided")
+            }
+
+            guard let pointObject = call.getObject("point") else {
+                throw GoogleMapErrors.invalidArguments("Invalid point provided")
+            }
+
+            let bounds = try getGMSCoordinateBounds(boundsObject)
+            let point = try getCLLocationCoordinate(pointObject)
+
+            DispatchQueue.main.sync {
+                let newBounds = bounds.includingCoordinate(point)
+                call.resolve([
+                    "bounds": formatMapBoundsForResponse(newBounds)
+                ])
+            }
+        } catch {
+            handleError(call, error: error)
+        }
+    }
+
     private func getGMSCoordinateBounds(_ bounds: JSObject) throws -> GMSCoordinateBounds {
         guard let southwest = bounds["southwest"] as? JSObject else {
             throw GoogleMapErrors.unhandledError("Bounds southwest property not formatted properly.")
@@ -580,6 +604,26 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate {
             "northeast": [
                 "lat": bounds?.northEast.latitude,
                 "lng": bounds?.northEast.longitude
+            ]
+        ]
+    }
+
+    private func formatMapBoundsForResponse(_ bounds: GMSCoordinateBounds) -> PluginCallResultData {
+        let centerLatitude = (bounds.southWest.latitude + bounds.northEast.latitude) / 2.0
+        let centerLongitude = (bounds.southWest.longitude + bounds.northEast.longitude) / 2.0
+
+        return [
+            "southwest": [
+                "lat": bounds.southWest.latitude,
+                "lng": bounds.southWest.longitude
+            ],
+            "center": [
+                "lat": centerLatitude,
+                "lng": centerLongitude
+            ],
+            "northeast": [
+                "lat": bounds.northEast.latitude,
+                "lng": bounds.northEast.longitude
             ]
         ]
     }

--- a/google-maps/src/definitions.ts
+++ b/google-maps/src/definitions.ts
@@ -27,6 +27,17 @@ export class LatLngBounds {
     });
     return result['contains'];
   }
+
+  async extend(point: LatLng): Promise<LatLngBounds> {
+    const result = await CapacitorGoogleMaps.mapBoundsExtend({
+      bounds: this,
+      point,
+    });
+    this.southwest = result['bounds']['southwest'];
+    this.center = result['bounds']['center'];
+    this.northeast = result['bounds']['northeast'];
+    return this;
+  }
 }
 
 /**

--- a/google-maps/src/implementation.ts
+++ b/google-maps/src/implementation.ts
@@ -111,6 +111,8 @@ export interface MapBoundsContainsArgs {
   point: LatLng;
 }
 
+export type MapBoundsExtendArgs = MapBoundsContainsArgs;
+
 export interface EnableClusteringArgs {
   id: string;
   minClusterSize?: number;
@@ -139,6 +141,7 @@ export interface CapacitorGoogleMapsPlugin extends Plugin {
   mapBoundsContains(
     args: MapBoundsContainsArgs,
   ): Promise<{ contains: boolean }>;
+  mapBoundsExtend(args: MapBoundsExtendArgs): Promise<{ bounds: LatLngBounds }>;
 }
 
 const CapacitorGoogleMaps = registerPlugin<CapacitorGoogleMapsPlugin>(

--- a/google-maps/src/web.ts
+++ b/google-maps/src/web.ts
@@ -28,6 +28,7 @@ import type {
   OnScrollArgs,
   MapBoundsContainsArgs,
   EnableClusteringArgs,
+  MapBoundsExtendArgs,
 } from './implementation';
 
 export class CapacitorGoogleMapsWeb
@@ -322,6 +323,29 @@ export class CapacitorGoogleMapsWeb
     const bounds = this.getLatLngBounds(_args.bounds);
     const point = new google.maps.LatLng(_args.point.lat, _args.point.lng);
     return { contains: bounds.contains(point) };
+  }
+
+  async mapBoundsExtend(
+    _args: MapBoundsExtendArgs,
+  ): Promise<{ bounds: LatLngBounds }> {
+    const bounds = this.getLatLngBounds(_args.bounds);
+    const point = new google.maps.LatLng(_args.point.lat, _args.point.lng);
+    bounds.extend(point);
+    const result = new LatLngBounds({
+      southwest: {
+        lat: bounds.getSouthWest().lat(),
+        lng: bounds.getSouthWest().lng(),
+      },
+      center: {
+        lat: bounds.getCenter().lat(),
+        lng: bounds.getCenter().lng(),
+      },
+      northeast: {
+        lat: bounds.getNorthEast().lat(),
+        lng: bounds.getNorthEast().lng(),
+      },
+    });
+    return { bounds: result };
   }
 
   private getLatLngBounds(_args: LatLngBounds): google.maps.LatLngBounds {


### PR DESCRIPTION
This PR adds the [extend](https://developers.google.com/maps/documentation/javascript/reference/coordinates#LatLngBounds.extend) method to the LatLngBounds class.