### PR TITLE
feat(local-notifications): support Android 13 notification permissions

### DIFF
--- a/local-notifications/README.md
+++ b/local-notifications/README.md
@@ -11,6 +11,12 @@ npx cap sync
 
 ## Android
 
+Android 13 requires a permission to be added to your `AndroidManifest.xml` to send [non-exempt](https://developer.android.com/develop/ui/views/notifications/notification-permission#exemptions) notifications from your app:
+
+```xml
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+```
+
 Starting on Android 12, scheduled notifications won't be exact unless this permission is added to your `AndroidManifest.xml`:
 
 ```xml

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
@@ -8,7 +8,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.service.notification.StatusBarNotification;
-import androidx.annotation.RequiresApi;
 import com.getcapacitor.Bridge;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
@@ -217,7 +217,7 @@ public class LocalNotificationsPlugin extends Plugin {
 
     @PluginMethod
     public void requestPermissions(PluginCall call) {
-        if (Build.VERSION.SDK_INT >= 33) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (getPermissionState(LOCAL_NOTIFICATIONS) != PermissionState.GRANTED) {
                 requestPermissionForAlias(LOCAL_NOTIFICATIONS, call, "permissionsCallback");
                 return;

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
@@ -7,7 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.service.notification.StatusBarNotification;
-
+import androidx.annotation.RequiresApi;
 import com.getcapacitor.Bridge;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
@@ -19,7 +19,6 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
-
 import java.util.List;
 import java.util.Map;
 import org.json.JSONArray;
@@ -28,9 +27,10 @@ import org.json.JSONObject;
 
 @CapacitorPlugin(
     name = "LocalNotifications",
-    permissions = @Permission(strings = {Manifest.permission.POST_NOTIFICATIONS}, alias = LocalNotificationsPlugin.LOCAL_NOTIFICATIONS)
+    permissions = @Permission(strings = { Manifest.permission.POST_NOTIFICATIONS }, alias = LocalNotificationsPlugin.LOCAL_NOTIFICATIONS)
 )
 public class LocalNotificationsPlugin extends Plugin {
+
     static final String LOCAL_NOTIFICATIONS = "display";
 
     private static Bridge staticBridge = null;
@@ -215,7 +215,7 @@ public class LocalNotificationsPlugin extends Plugin {
 
     @PluginMethod
     public void requestPermissions(PluginCall call) {
-        if (Build.VERSION.SDK_INT  >= 33) {
+        if (Build.VERSION.SDK_INT >= 33) {
             if (getPermissionState(LOCAL_NOTIFICATIONS) != PermissionState.GRANTED) {
                 requestPermissionForAlias(LOCAL_NOTIFICATIONS, call, "permissionsCallback");
                 return;

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
@@ -1,6 +1,7 @@
 package com.capacitorjs.plugins.localnotifications;
 
 import android.Manifest;
+import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -25,6 +26,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+@TargetApi(Build.VERSION_CODES.TIRAMISU)
 @CapacitorPlugin(
     name = "LocalNotifications",
     permissions = @Permission(strings = { Manifest.permission.POST_NOTIFICATIONS }, alias = LocalNotificationsPlugin.LOCAL_NOTIFICATIONS)


### PR DESCRIPTION
Implements support for notifications permissions in Android 13 (API 33):
https://developer.android.com/develop/ui/views/notifications/notification-permission

closes: https://github.com/ionic-team/capacitor-plugins/issues/1116