### PR TITLE
chore(android): fix local-notification deprecation warning

### DIFF
--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
@@ -29,13 +29,7 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
-        Notification notification;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            notification = intent.getParcelableExtra(NOTIFICATION_KEY, Notification.class);
-        } else {
-            notification = intent.getParcelableExtra(NOTIFICATION_KEY);
-        }
-
+        Notification notification = getNotification(intent, NOTIFICATION_KEY);
         notification.when = System.currentTimeMillis();
 
         int id = intent.getIntExtra(LocalNotificationManager.NOTIFICATION_INTENT_KEY, Integer.MIN_VALUE);
@@ -48,6 +42,15 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
         notificationManager.notify(id, notification);
         if (!rescheduleNotificationIfNeeded(context, intent, id)) {
             storage.deleteNotification(Integer.toString(id));
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private Notification getNotification(Intent intent, String string) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return intent.getParcelableExtra(NOTIFICATION_KEY, Notification.class);
+        } else {
+            return intent.getParcelableExtra(NOTIFICATION_KEY);
         }
     }
 

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
@@ -28,7 +28,14 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        Notification notification = intent.getParcelableExtra(NOTIFICATION_KEY);
+
+        Notification notification;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            notification = intent.getParcelableExtra(NOTIFICATION_KEY, Notification.class);
+        } else {
+            notification = intent.getParcelableExtra(NOTIFICATION_KEY);
+        }
+
         notification.when = System.currentTimeMillis();
 
         int id = intent.getIntExtra(LocalNotificationManager.NOTIFICATION_INTENT_KEY, Integer.MIN_VALUE);

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/TimedNotificationPublisher.java
@@ -29,7 +29,14 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
-        Notification notification = getNotification(intent, NOTIFICATION_KEY);
+        Notification notification;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            notification = intent.getParcelableExtra(NOTIFICATION_KEY, Notification.class);
+        } else {
+            notification = getParcelableExtraLegacy(intent, NOTIFICATION_KEY);
+        }
+
         notification.when = System.currentTimeMillis();
 
         int id = intent.getIntExtra(LocalNotificationManager.NOTIFICATION_INTENT_KEY, Integer.MIN_VALUE);
@@ -46,12 +53,8 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
     }
 
     @SuppressWarnings("deprecation")
-    private Notification getNotification(Intent intent, String string) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            return intent.getParcelableExtra(NOTIFICATION_KEY, Notification.class);
-        } else {
-            return intent.getParcelableExtra(NOTIFICATION_KEY);
-        }
+    private Notification getParcelableExtraLegacy(Intent intent, String string) {
+        return intent.getParcelableExtra(NOTIFICATION_KEY);
     }
 
     private boolean rescheduleNotificationIfNeeded(Context context, Intent intent, int id) {


### PR DESCRIPTION
- Replace getParcelableExtra(String) with getParcelableExtra(String, Class<T>)