### PR TITLE
feat(google-maps): add zIndex to markers

### DIFF
--- a/google-maps/README.md
+++ b/google-maps/README.md
@@ -752,6 +752,7 @@ A marker is an icon placed at a particular point on the map's surface.
 | **`iconAnchor`** | <code><a href="#point">Point</a></code>                      | The position at which to anchor an image in correspondence to the location of the marker on the map. By default, the anchor is located along the center point of the bottom of the image. |                    | 4.2.0 |
 | **`tintColor`**  | <code>{ r: number; g: number; b: number; a: number; }</code> | Customizes the color of the default marker image. Each value must be between 0 and 255. Only for iOS and Android.                                                                         |                    | 4.2.0 |
 | **`draggable`**  | <code>boolean</code>                                         | Controls whether this marker can be dragged interactively                                                                                                                                 | <code>false</code> |       |
+| **`zIndex`**     | <code>number</code>                                          | Specifies the stack order of this marker, relative to other markers on the map. A marker with a high z-index is drawn on top of markers with lower z-indexes                              | <code>0</code>     |       |
 
 
 #### Size

--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapMarker.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapMarker.kt
@@ -13,6 +13,7 @@ class CapacitorGoogleMapMarker(fromJSONObject: JSONObject): ClusterItem {
     var opacity: Float = 1.0f
     private var title: String
     private var snippet: String
+    private var zIndex: Float? = null
     var isFlat: Boolean = false
     var iconUrl: String? = null
     var iconSize: Size? = null
@@ -61,6 +62,7 @@ class CapacitorGoogleMapMarker(fromJSONObject: JSONObject): ClusterItem {
         }
 
         draggable = fromJSONObject.optBoolean("draggable", false)
+        zIndex = fromJSONObject.optLong("zIndex").toFloat()
     }
 
     override fun getPosition(): LatLng {
@@ -73,6 +75,10 @@ class CapacitorGoogleMapMarker(fromJSONObject: JSONObject): ClusterItem {
 
     override fun getSnippet(): String {
         return snippet
+    }
+
+    override fun getZIndex(): Float? {
+        return zIndex
     }
 
     private fun buildIconAnchorPoint(iconAnchor: CapacitorGoogleMapsPoint): CapacitorGoogleMapsPoint? {

--- a/google-maps/ios/Plugin/Map.swift
+++ b/google-maps/ios/Plugin/Map.swift
@@ -393,6 +393,7 @@ public class Map {
         newMarker.isFlat = marker.isFlat ?? false
         newMarker.opacity = marker.opacity ?? 1
         newMarker.isDraggable = marker.draggable ?? false
+        newMarker.zIndex = marker.zIndex
         if let iconAnchor = marker.iconAnchor {
             newMarker.groundAnchor = iconAnchor
         }

--- a/google-maps/ios/Plugin/Marker.swift
+++ b/google-maps/ios/Plugin/Marker.swift
@@ -12,6 +12,7 @@ public struct Marker {
     let iconAnchor: CGPoint?
     let draggable: Bool?
     let color: UIColor?
+    let zIndex: Int32
 
     init(fromJSObject: JSObject) throws {
         guard let latLngObj = fromJSObject["coordinate"] as? JSObject else {
@@ -62,6 +63,7 @@ public struct Marker {
         self.iconSize = iconSize
         self.iconAnchor = iconAnchor
         self.color = tintColor
+        self.zIndex = Int32((fromJSObject["zIndex"] as? Int) ?? 0)
     }
 }
 

--- a/google-maps/src/definitions.ts
+++ b/google-maps/src/definitions.ts
@@ -262,6 +262,14 @@ export interface Marker {
    * @default false
    */
   draggable?: boolean;
+
+  /**
+   * Specifies the stack order of this marker, relative to other markers on the map.
+   * A marker with a high z-index is drawn on top of markers with lower z-indexes
+   *
+   * @default 0
+   */
+  zIndex?: number;
 }
 
 /**

--- a/google-maps/src/web.ts
+++ b/google-maps/src/web.ts
@@ -460,6 +460,7 @@ export class CapacitorGoogleMapsWeb
       title: marker.title,
       icon: iconImage,
       draggable: marker.draggable,
+      zIndex: marker.zIndex,
     };
 
     return opts;


### PR DESCRIPTION
This PR adds the `zIndex` property to Markers. It is also required to update the Maps Util Verion #1449 