### PR TITLE
fix `.cut()` and `.copy()` error

### DIFF
--- a/filesystem/src/web.ts
+++ b/filesystem/src/web.ts
@@ -612,8 +612,8 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
           // Move item from the from directory to the to directory
           await this._copy(
             {
-              from: `${from}/${filename}`,
-              to: `${to}/${filename}`,
+              from: `${from}/${filename.name}`,
+              to: `${to}/${filename.name}`,
               directory: fromDirectory,
               toDirectory,
             },


### PR DESCRIPTION
Since `this.readdir` is currently returning `Promise<ReaddirResult[]>` so we need to fix this or else there will be a path that looks like `from/[object Object]` which gives the 2 functions error ` .copy()` and `.cut()`

> These functions are currently failing in my new app i hope to see a patched release asap ♥