### PR TITLE
chore(local-notifications): remove deprecated call

### DIFF
--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
@@ -136,11 +136,8 @@ public class LocalNotificationsPlugin extends Plugin {
                     JSObject extras = new JSObject();
 
                     for (String key : notification.extras.keySet()) {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            extras.put(key, notification.extras.getString(key));
-                        } else {
-                            extras.put(key, getBundleStringLegacy(notification, key));
-                        }
+                        extras.put(key, notification.extras.getString(key));
+                    }
                     }
 
                     jsNotif.put("data", extras);
@@ -258,10 +255,5 @@ public class LocalNotificationsPlugin extends Plugin {
             return (LocalNotificationsPlugin) handle.getInstance();
         }
         return null;
-    }
-
-    @SuppressWarnings("deprecated")
-    private Object getBundleStringLegacy(Notification notification, String key) {
-        return notification.extras.get(key);
     }
 }

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
@@ -136,7 +136,11 @@ public class LocalNotificationsPlugin extends Plugin {
                     JSObject extras = new JSObject();
 
                     for (String key : notification.extras.keySet()) {
-                        extras.put(key, notification.extras.get(key));
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            extras.put(key, notification.extras.getString(key));
+                        } else {
+                            extras.put(key, getBundleStringLegacy(notification, key));
+                        }
                     }
 
                     jsNotif.put("data", extras);
@@ -254,5 +258,10 @@ public class LocalNotificationsPlugin extends Plugin {
             return (LocalNotificationsPlugin) handle.getInstance();
         }
         return null;
+    }
+
+    @SuppressWarnings("deprecated")
+    private Object getBundleStringLegacy(Notification notification, String key) {
+        return notification.extras.get(key);
     }
 }

--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationsPlugin.java
@@ -138,7 +138,6 @@ public class LocalNotificationsPlugin extends Plugin {
                     for (String key : notification.extras.keySet()) {
                         extras.put(key, notification.extras.getString(key));
                     }
-                    }
 
                     jsNotif.put("data", extras);
                 }


### PR DESCRIPTION
Move Deprecated `Bundle.get` call to it's own function and update.