### PR TITLE
feat(device): allowing to get region from the device

### DIFF
--- a/device/README.md
+++ b/device/README.md
@@ -103,6 +103,20 @@ Get the device's current language locale code.
 
 --------------------
 
+### getRegionCode()
+
+```typescript
+getRegionCode() => Promise<GetRegionCodeResult>
+```
+
+Get the device's current language locale code.
+
+**Returns:** <code>Promise&lt;<a href="#getregioncoderesult">GetRegionCodeResult</a>&gt;</code>
+
+**Since:** 4.2.0
+
+--------------------
+
 
 ### getLanguageTag()
 
@@ -162,6 +176,12 @@ Get the device's current language locale tag.
 | ----------- | ------------------- | ---------------------------- | ----- |
 | **`value`** | <code>string</code> | Two character language code. | 1.0.0 |
 
+
+#### GetRegionCodeResult
+
+| Prop        | Type                | Description                       | Since |
+| ----------- | ------------------- | --------------------------------- | ----- |
+| **`value`** | <code>string</code> | Two character of the region code. | 4.2.0 |
 
 #### LanguageTag
 

--- a/device/android/src/main/java/com/capacitorjs/plugins/device/DevicePlugin.java
+++ b/device/android/src/main/java/com/capacitorjs/plugins/device/DevicePlugin.java
@@ -65,6 +65,13 @@ public class DevicePlugin extends Plugin {
     }
 
     @PluginMethod
+    public void getRegionCode(PluginCall call) {
+        JSObject ret = new JSObject();
+        ret.put("value", Locale.getDefault().getCountry());
+        call.resolve(ret);
+    }
+
+    @PluginMethod
     public void getLanguageTag(PluginCall call) {
         JSObject ret = new JSObject();
         ret.put("value", Locale.getDefault().toLanguageTag());

--- a/device/ios/Plugin/Device.swift
+++ b/device/ios/Plugin/Device.swift
@@ -66,6 +66,10 @@ import Foundation
         return String(Locale.preferredLanguages[0].prefix(2))
     }
 
+    public func getRegionCode() -> String {
+        return String(Locale.current.regionCode)
+    }
+
     public func getLanguageTag() -> String {
         return String(Locale.preferredLanguages[0])
     }

--- a/device/ios/Plugin/DevicePlugin.m
+++ b/device/ios/Plugin/DevicePlugin.m
@@ -8,5 +8,6 @@ CAP_PLUGIN(DevicePlugin, "Device",
            CAP_PLUGIN_METHOD(getInfo, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getBatteryInfo, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getLanguageCode, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(getRegionCode, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getLanguageTag, CAPPluginReturnPromise);
 )

--- a/device/ios/Plugin/DevicePlugin.swift
+++ b/device/ios/Plugin/DevicePlugin.swift
@@ -64,6 +64,13 @@ public class DevicePlugin: CAPPlugin {
         ])
     }
 
+    @objc func getRegionCode(_ call: CAPPluginCall) {
+        let code = implementation.getRegionCode()
+        call.resolve([
+            "value": code
+        ])
+    }
+
     @objc func getLanguageTag(_ call: CAPPluginCall) {
         let tag = implementation.getLanguageTag()
         call.resolve([

--- a/device/src/definitions.ts
+++ b/device/src/definitions.ts
@@ -144,6 +144,15 @@ export interface GetLanguageCodeResult {
   value: string;
 }
 
+export interface GetRegionCodeResult {
+  /**
+   * Two character of the region code.
+   *
+   * @since 4.2.0
+   */
+  value: string;
+}
+
 export interface LanguageTag {
   /**
    * Returns a well-formed IETF BCP 47 language tag.

--- a/device/src/web.ts
+++ b/device/src/web.ts
@@ -6,6 +6,7 @@ import type {
   DeviceInfo,
   DevicePlugin,
   GetLanguageCodeResult,
+  GetRegionCodeResult,
   LanguageTag,
 } from './definitions';
 
@@ -70,6 +71,10 @@ export class DeviceWeb extends WebPlugin implements DevicePlugin {
     return {
       value: navigator.language.split('-')[0].toLowerCase(),
     };
+  }
+
+  async getRegionCode(): Promise<GetRegionCodeResult> {
+    throw this.unavailable('Region code not available in this browser');
   }
 
   async getLanguageTag(): Promise<LanguageTag> {


### PR DESCRIPTION
This PR will allow applications get the region/country from the device, allowing them select the right experience depending on which country the device is from.

On android it will get from the language but on iOS there is a defined field for it. Web will throw an error saying that isn't supported.

## Android
![Screenshot 2023-03-21 at 15 48 10](https://user-images.githubusercontent.com/1237234/226663930-76fc82cb-c451-46e9-8f53-56ba5b9c7bb4.png)

## iOS
![Screenshot 2023-03-21 at 15 48 45](https://user-images.githubusercontent.com/1237234/226664183-c0589eb8-97b1-4378-89f6-9879a0d34c9d.png)
