### PR TITLE
chore(android): move package to build gradle

### DIFF
--- a/action-sheet/android/build.gradle
+++ b/action-sheet/android/build.gradle
@@ -31,6 +31,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.actionsheet"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/action-sheet/android/src/main/AndroidManifest.xml
+++ b/action-sheet/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.actionsheet">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/app-launcher/android/build.gradle
+++ b/app-launcher/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.applauncher"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/app-launcher/android/src/main/AndroidManifest.xml
+++ b/app-launcher/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.applauncher">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.app"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/app/android/src/main/AndroidManifest.xml
+++ b/app/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.app">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/browser/android/build.gradle
+++ b/browser/android/build.gradle
@@ -31,6 +31,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.browser"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/browser/android/src/main/AndroidManifest.xml
+++ b/browser/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 
-  <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      package="com.capacitorjs.plugins.browser">
+  <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   </manifest>
   

--- a/camera/android/build.gradle
+++ b/camera/android/build.gradle
@@ -32,6 +32,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.camera"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/camera/android/src/main/AndroidManifest.xml
+++ b/camera/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.camera">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <queries>
         <intent>
             <action android:name="android.media.action.IMAGE_CAPTURE" />

--- a/clipboard/android/build.gradle
+++ b/clipboard/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.clipboard"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/clipboard/android/src/main/AndroidManifest.xml
+++ b/clipboard/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.clipboard">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/device/android/build.gradle
+++ b/device/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.device"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/device/android/src/main/AndroidManifest.xml
+++ b/device/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.device">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/dialog/android/build.gradle
+++ b/dialog/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.dialog"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/dialog/android/src/main/AndroidManifest.xml
+++ b/dialog/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.dialog">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/filesystem/android/build.gradle
+++ b/filesystem/android/build.gradle
@@ -29,6 +29,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.filesystem"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/filesystem/android/src/main/AndroidManifest.xml
+++ b/filesystem/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.filesystem">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/geolocation/android/build.gradle
+++ b/geolocation/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.geolocation"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/geolocation/android/src/main/AndroidManifest.xml
+++ b/geolocation/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.geolocation">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/google-maps/android/build.gradle
+++ b/google-maps/android/build.gradle
@@ -39,6 +39,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.googlemaps"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/google-maps/android/src/main/AndroidManifest.xml
+++ b/google-maps/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.googlemaps">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/haptics/android/build.gradle
+++ b/haptics/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.haptics"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/haptics/android/src/main/AndroidManifest.xml
+++ b/haptics/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.haptics">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.VIBRATE" />
 </manifest>

--- a/keyboard/android/build.gradle
+++ b/keyboard/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.keyboard"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/keyboard/android/src/main/AndroidManifest.xml
+++ b/keyboard/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.keyboard">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/local-notifications/android/build.gradle
+++ b/local-notifications/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.localnotifications"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/local-notifications/android/src/main/AndroidManifest.xml
+++ b/local-notifications/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.localnotifications">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <receiver android:name="com.capacitorjs.plugins.localnotifications.TimedNotificationPublisher" />

--- a/network/android/build.gradle
+++ b/network/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.network"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/network/android/src/main/AndroidManifest.xml
+++ b/network/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.network">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/preferences/android/build.gradle
+++ b/preferences/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.preferences"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/preferences/android/src/main/AndroidManifest.xml
+++ b/preferences/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.preferences">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/push-notifications/android/build.gradle
+++ b/push-notifications/android/build.gradle
@@ -31,6 +31,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.pushnotifications"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/push-notifications/android/src/main/AndroidManifest.xml
+++ b/push-notifications/android/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.pushnotifications">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
         <service android:name="com.capacitorjs.plugins.pushnotifications.MessagingService" android:exported="false">
             <intent-filter>

--- a/screen-orientation/android/build.gradle
+++ b/screen-orientation/android/build.gradle
@@ -18,6 +18,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
+    namespace "com.capacitorjs.plugins.screenorientation"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/screen-orientation/android/src/main/AndroidManifest.xml
+++ b/screen-orientation/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.screenorientation">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/screen-reader/android/build.gradle
+++ b/screen-reader/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.screenreader"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/screen-reader/android/src/main/AndroidManifest.xml
+++ b/screen-reader/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.screenreader">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/share/android/build.gradle
+++ b/share/android/build.gradle
@@ -31,6 +31,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.share"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/share/android/src/main/AndroidManifest.xml
+++ b/share/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.share">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/splash-screen/android/build.gradle
+++ b/splash-screen/android/build.gradle
@@ -31,6 +31,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.splashscreen"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/splash-screen/android/src/main/AndroidManifest.xml
+++ b/splash-screen/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.splashscreen">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/status-bar/android/build.gradle
+++ b/status-bar/android/build.gradle
@@ -31,6 +31,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.statusbar"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/status-bar/android/src/main/AndroidManifest.xml
+++ b/status-bar/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.statusbar">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/text-zoom/android/build.gradle
+++ b/text-zoom/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.textzoom"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/text-zoom/android/src/main/AndroidManifest.xml
+++ b/text-zoom/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.textzoom">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/toast/android/build.gradle
+++ b/toast/android/build.gradle
@@ -30,6 +30,7 @@ if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
 }
 
 android {
+    namespace "com.capacitorjs.plugins.toast"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22

--- a/toast/android/src/main/AndroidManifest.xml
+++ b/toast/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.capacitorjs.plugins.toast">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
It's going to be required for gradle plugin 8 and already possible with gradle plugin 7.4.1, so, lets do it now for future compatibility
