### PR TITLE
Avoid crash of HapticEngine on iOS

### DIFF
--- a/haptics/ios/Plugin/Haptics.swift
+++ b/haptics/ios/Plugin/Haptics.swift
@@ -5,6 +5,7 @@ import CoreHaptics
 @objc public class Haptics: NSObject {
 
     var selectionFeedbackGenerator: UISelectionFeedbackGenerator?
+    var engine: CHHapticEngine!
 
     @objc public func impact(_ impactStyle: UIImpactFeedbackGenerator.FeedbackStyle) {
         let generator = UIImpactFeedbackGenerator(style: impactStyle)
@@ -39,11 +40,11 @@ import CoreHaptics
     @objc public func vibrate(_ duration: Double) {
         if CHHapticEngine.capabilitiesForHardware().supportsHaptics {
             do {
-                let engine = try CHHapticEngine()
-                try engine.start()
-                engine.resetHandler = { [] in
+                self.engine = try CHHapticEngine()
+                try self.engine.start()
+                self.engine.resetHandler = { [] in
                     do {
-                        try engine.start()
+                        try self.engine.start()
                     } catch {
                         self.vibrate()
                     }
@@ -56,7 +57,7 @@ import CoreHaptics
                                                     relativeTime: 0.0,
                                                     duration: duration)
                 let pattern = try CHHapticPattern(events: [continuousEvent], parameters: [])
-                let player = try engine.makePlayer(with: pattern)
+                let player = try self.engine.makePlayer(with: pattern)
 
                 try player.start(atTime: 0)
             } catch {


### PR DESCRIPTION
Hi everybody,

I was using Haptics plugin on an app where I need to explore a canvas with touch interaction and get feedbacks using Haptics. So it was a use case where a lot and frequent events trigger Haptics `vibrate()` method. On iOS, I experienced crashes of the HapticEngine (the internal AVHapticClient went into server interruption errors) after some seconds of use.

Searching on the web, I found that Apple suggest to keep a strong reference to HapticEngine when using it (details [here](https://developer.apple.com/documentation/corehaptics/chhapticengine)).

So I modified Haptics in order to keep a strong reference to the engine when calling vibrate methods... and it worked. The bug disappeared.

I hope this get merged because it might not be a real problem for most of the use cases, where Haptics is used for short interactions, but for more complex use cases it is definitely needed.

Cheers!