### PR TITLE
Add Preferences configuration to specify iOS app group identifier

### DIFF
--- a/preferences/ios/Plugin/Preferences.swift
+++ b/preferences/ios/Plugin/Preferences.swift
@@ -6,9 +6,11 @@ public struct PreferencesConfiguration {
     }
 
     let group: Group
+    let suiteName: String?
 
-    public init(for group: Group = .named("CapacitorStorage")) {
+    public init(for group: Group = .named("CapacitorStorage"), suiteName: String? = nil) {
         self.group = group
+        self.suiteName = suiteName
     }
 }
 
@@ -16,7 +18,7 @@ public class Preferences {
     private let configuration: PreferencesConfiguration
 
     private var defaults: UserDefaults {
-        return UserDefaults.standard
+        return UserDefaults(suiteName: suiteName)!
     }
 
     private var prefix: String {

--- a/preferences/ios/Plugin/PreferencesPlugin.swift
+++ b/preferences/ios/Plugin/PreferencesPlugin.swift
@@ -7,16 +7,17 @@ public class PreferencesPlugin: CAPPlugin {
 
     @objc func configure(_ call: CAPPluginCall) {
         let group = call.getString("group")
+        let suiteName = call.getString("iosSuiteName")
         let configuration: PreferencesConfiguration
 
         if let group = group {
             if group == "NativeStorage" {
-                configuration = PreferencesConfiguration(for: .cordovaNativeStorage)
+                configuration = PreferencesConfiguration(for: .cordovaNativeStorage, suiteName: suiteName)
             } else {
-                configuration = PreferencesConfiguration(for: .named(group))
+                configuration = PreferencesConfiguration(for: .named(group), suiteName: suiteName)
             }
         } else {
-            configuration = PreferencesConfiguration()
+            configuration = PreferencesConfiguration(suiteName: suiteName)
         }
 
         preferences = Preferences(with: configuration)

--- a/preferences/src/definitions.ts
+++ b/preferences/src/definitions.ts
@@ -13,6 +13,14 @@ export interface ConfigureOptions {
    * @since 1.0.0
    */
   group?: string;
+
+  /**
+   * Set the iOS App Group for UserDefaults.
+   *
+   * Specifically, this is the value passed to
+   * https://developer.apple.com/documentation/foundation/userdefaults/1409957-init
+   */
+  iosSuiteName?: string;
 }
 
 export interface GetOptions {


### PR DESCRIPTION
Previously, the Preferences plugin would always use `UserDefaults.standard`. This PR adds an `iosAppSuite` configuration option to use an App Group's UserDefaults as described in https://developer.apple.com/documentation/foundation/userdefaults/1409957-init