### PR TITLE
chore: format with swiftlint 0.51.0

### DIFF
--- a/clipboard/ios/Plugin/Clipboard.swift
+++ b/clipboard/ios/Plugin/Clipboard.swift
@@ -9,7 +9,7 @@ public class Clipboard {
         case image
     }
 
-    enum ClipboardError: LocalizedError {
+    public enum ClipboardError: LocalizedError {
         case invalidURL, invalidImage
 
         public var errorDescription: String? {

--- a/network/ios/Plugin/Reachability.swift
+++ b/network/ios/Plugin/Reachability.swift
@@ -168,7 +168,7 @@ public extension Reachability {
     func startNotifier() throws {
         guard !notifierRunning else { return }
 
-        let callback: SCNetworkReachabilityCallBack = { (reachability, flags, info) in
+        let callback: SCNetworkReachabilityCallBack = { (_, flags, info) in
             guard let info = info else { return }
 
             // `weakifiedReachability` is guaranteed to exist by virtue of our

--- a/toast/ios/Plugin/ToastLabel.swift
+++ b/toast/ios/Plugin/ToastLabel.swift
@@ -3,7 +3,7 @@ import UIKit
 @objc internal class ToastLabel: UILabel {
     var padding: UIEdgeInsets?
 
-    override open func draw(_ rect: CGRect) {
+    override func draw(_ rect: CGRect) {
         if let insets = padding {
             self.drawText(in: rect.inset(by: insets))
         } else {


### PR DESCRIPTION
macos-12 image has been updated to use swiftlint 0.51.0 and it's making our lint to fail

I've run `npm run fmt` with swiftlint 0.51.0, so it hopefully fixes the lint problems