### PR TITLE
chore: fix variable naming

### DIFF
--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -35,7 +35,7 @@ Android 13 requires a permission check in order to receive push notifications.  
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-- `$firebaseMessagingVersion` version of `com.google.firebase:firebase-messaging` (default: `23.1.2`)
+- `firebaseMessagingVersion` version of `com.google.firebase:firebase-messaging` (default: `23.1.2`)
 
 ---
 


### PR DESCRIPTION
The variable name of `firebaseMessagingVersion` seems to be wrong in the docs. Removed the `$` to avoid confusion.