### PR TITLE
docs(google-maps): fix typo in dependency name

### DIFF
--- a/google-maps/README.md
+++ b/google-maps/README.md
@@ -22,7 +22,7 @@ The Google Maps SDK supports the use of showing the users current location via `
 
 Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode.
 
-> The main Google Maps SDK now supports running on simulators on Apple Silicon Macs, however, a dependency from Google called [Google-Maps-Utils-iOS](https://github.com/googlemaps/google-maps-ios-utils) does not yet support Apple Silicon. This is requires a new release of the library from Google. If you are developing on an Apple Silicon Mac, building and running on physical devices is still supported and is the recommended approach.
+> The main Google Maps SDK now supports running on simulators on Apple Silicon Macs, however, a dependency from Google called [Google-Maps-iOS-Utils](https://github.com/googlemaps/google-maps-ios-utils) does not yet support Apple Silicon. This is requires a new release of the library from Google. If you are developing on an Apple Silicon Mac, building and running on physical devices is still supported and is the recommended approach.
 
 > A workaround on Apple Silicon Macs if you want/need to use the simulator is adding the following line to your Podfile in the `target 'App'` section after the `# Add your Pods here` line:
 


### PR DESCRIPTION
The dependency name is Google-Maps-iOS-Utils, not Google-Maps-Utils-iOS