### PR TITLE
fix(google-maps): Added null check to addMarkers method

### DIFF
--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
@@ -183,12 +183,14 @@ class CapacitorGoogleMap(
                     val googleMapMarker = googleMap?.addMarker(markerOptions.await())
                     it.googleMapMarker = googleMapMarker
 
-                    if (clusterManager != null) {
-                        googleMapMarker?.remove()
-                    }
+                    if (googleMapMarker != null) {
+                        if (clusterManager != null) {
+                            googleMapMarker.remove()
+                        }
 
-                    markers[googleMapMarker!!.id] = it
-                    markerIds.add(googleMapMarker.id)
+                        markers[googleMapMarker.id] = it
+                        markerIds.add(googleMapMarker.id)
+                    }
                 }
 
                 if (clusterManager != null) {


### PR DESCRIPTION
This PR adds a null check to the addMarkers method for Android. `googleMap` in line 183 can be null here, when the map is destroyed but the method is still processing. Then `googleMapMarker` is also null which crashs in line 191.

Closes https://github.com/ionic-team/capacitor-plugins/issues/1570