### PR TITLE
chore(android): android maven publication dependency fix

### DIFF
--- a/action-sheet/android/build.gradle
+++ b/action-sheet/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/action-sheet/android/build.gradle
+++ b/action-sheet/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/app-launcher/android/build.gradle
+++ b/app-launcher/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/app-launcher/android/build.gradle
+++ b/app-launcher/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/app-launcher/android/build.gradle
+++ b/app-launcher/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/browser/android/build.gradle
+++ b/browser/android/build.gradle
@@ -53,6 +53,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/browser/android/build.gradle
+++ b/browser/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/browser/android/build.gradle
+++ b/browser/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/camera/android/build.gradle
+++ b/camera/android/build.gradle
@@ -54,6 +54,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/camera/android/build.gradle
+++ b/camera/android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/camera/android/build.gradle
+++ b/camera/android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/clipboard/android/build.gradle
+++ b/clipboard/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/clipboard/android/build.gradle
+++ b/clipboard/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/clipboard/android/build.gradle
+++ b/clipboard/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/device/android/build.gradle
+++ b/device/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/device/android/build.gradle
+++ b/device/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/device/android/build.gradle
+++ b/device/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/dialog/android/build.gradle
+++ b/dialog/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/dialog/android/build.gradle
+++ b/dialog/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/dialog/android/build.gradle
+++ b/dialog/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/filesystem/android/build.gradle
+++ b/filesystem/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/filesystem/android/build.gradle
+++ b/filesystem/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/filesystem/android/build.gradle
+++ b/filesystem/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/geolocation/android/build.gradle
+++ b/geolocation/android/build.gradle
@@ -53,6 +53,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/geolocation/android/build.gradle
+++ b/geolocation/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/geolocation/android/build.gradle
+++ b/geolocation/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/google-maps/android/build.gradle
+++ b/google-maps/android/build.gradle
@@ -61,7 +61,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-
+    publishing {
+        singleVariant("release")
+    }
     dependencies {
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinxCoroutinesVersion")
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")

--- a/google-maps/android/build.gradle
+++ b/google-maps/android/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/google-maps/android/build.gradle
+++ b/google-maps/android/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/haptics/android/build.gradle
+++ b/haptics/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/haptics/android/build.gradle
+++ b/haptics/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/haptics/android/build.gradle
+++ b/haptics/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/keyboard/android/build.gradle
+++ b/keyboard/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/keyboard/android/build.gradle
+++ b/keyboard/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/keyboard/android/build.gradle
+++ b/keyboard/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/local-notifications/android/build.gradle
+++ b/local-notifications/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/local-notifications/android/build.gradle
+++ b/local-notifications/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/local-notifications/android/build.gradle
+++ b/local-notifications/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/network/android/build.gradle
+++ b/network/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/network/android/build.gradle
+++ b/network/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/network/android/build.gradle
+++ b/network/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/preferences/android/build.gradle
+++ b/preferences/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/preferences/android/build.gradle
+++ b/preferences/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/preferences/android/build.gradle
+++ b/preferences/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/push-notifications/android/build.gradle
+++ b/push-notifications/android/build.gradle
@@ -53,6 +53,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/push-notifications/android/build.gradle
+++ b/push-notifications/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/push-notifications/android/build.gradle
+++ b/push-notifications/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/screen-orientation/android/build.gradle
+++ b/screen-orientation/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/screen-reader/android/build.gradle
+++ b/screen-reader/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/screen-reader/android/build.gradle
+++ b/screen-reader/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/screen-reader/android/build.gradle
+++ b/screen-reader/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/scripts/android/publish-module.gradle
+++ b/scripts/android/publish-module.gradle
@@ -5,7 +5,6 @@ def LIB_VERSION = System.getenv('PLUGIN_VERSION')
 def PLUGIN_NAME = System.getenv('PLUGIN_NAME')
 
 task androidSourcesJar(type: Jar) {
-    dependsOn(':bundleReleaseAar')
     archiveClassifier.set('sources')
     if (project.plugins.findPlugin("com.android.library")) {
         from android.sourceSets.main.java.srcDirs
@@ -34,7 +33,7 @@ afterEvaluate {
 
                 // Two artifacts, the `aar` (or `jar`) and the sources
                 if (project.plugins.findPlugin("com.android.library")) {
-                    artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
+                    from components.release
                 } else {
                     artifact("$buildDir/libs/${project.getName()}-${version}.jar")
                 }

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # The default Capacitor version(s) the plugin should depend on. Latest published in a range will be pulled by the user
-DEFAULT_CAPACITOR_VERSION="[4.0,5.0)"
+DEFAULT_CAPACITOR_VERSION="[5.0,6.0)"
 
 publish_plugin () {
     PLUGIN_PATH=$1

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # The default Capacitor version(s) the plugin should depend on. Latest published in a range will be pulled by the user
-DEFAULT_CAPACITOR_VERSION="[5.0,6.0)"
+DEFAULT_CAPACITOR_VERSION="[4.0,5.0)"
 
 publish_plugin () {
     PLUGIN_PATH=$1

--- a/share/android/build.gradle
+++ b/share/android/build.gradle
@@ -53,6 +53,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/share/android/build.gradle
+++ b/share/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/share/android/build.gradle
+++ b/share/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/splash-screen/android/build.gradle
+++ b/splash-screen/android/build.gradle
@@ -53,6 +53,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/splash-screen/android/build.gradle
+++ b/splash-screen/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/splash-screen/android/build.gradle
+++ b/splash-screen/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/status-bar/android/build.gradle
+++ b/status-bar/android/build.gradle
@@ -53,6 +53,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/status-bar/android/build.gradle
+++ b/status-bar/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/status-bar/android/build.gradle
+++ b/status-bar/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/text-zoom/android/build.gradle
+++ b/text-zoom/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/text-zoom/android/build.gradle
+++ b/text-zoom/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/text-zoom/android/build.gradle
+++ b/text-zoom/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }

--- a/toast/android/build.gradle
+++ b/toast/android/build.gradle
@@ -52,6 +52,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    publishing {
+        singleVariant("release")
+    }
 }
 
 repositories {

--- a/toast/android/build.gradle
+++ b/toast/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
         }
     }
 }

--- a/toast/android/build.gradle
+++ b/toast/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.0'
         if (System.getenv("CAP_PLUGIN_PUBLISH") == "true") {
-            classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         }
     }
 }


### PR DESCRIPTION
Maven publishing fix for Cap 5/Gradle 8 introduced a new bug that stripped native dependencies from the artifact. This commit fixes that bug. Tested.