### PR TITLE
docs(google-maps): fix typo

### DIFF
--- a/google-maps/README.md
+++ b/google-maps/README.md
@@ -55,7 +55,7 @@ This plugin will use the following project variables (defined in your app's `var
 - `googleMapsUtilsKtxVersion`: version of `com.google.maps.android:maps-utils-ktx` (default: `3.4.0`)
 - `kotlinxCoroutinesVersion`: version of `org.jetbrains.kotlinx:kotlinx-coroutines-android` and `org.jetbrains.kotlinx:kotlinx-coroutines-core` (default: `1.6.4`)
 - `androidxCoreKTXVersion`: version of `androidx.core:core-ktx` (default: `1.10.0`)
-- `kotlin_version`: version of `org.jetbrains.kotlin:kotlin-stdlib-jdk7` (default: `1.8.20`)
+- `kotlin_version`: version of `org.jetbrains.kotlin:kotlin-stdlib` (default: `1.8.20`)
 
 
 ## Usage


### PR DESCRIPTION
According to:

https://github.com/ionic-team/capacitor-plugins/blob/dc5acf07d60293d53dbb33dbfb61620fc05572c6/google-maps/android/build.gradle#L93

The `kotlin_version` variable is being used as the version of `org.jetbrains.kotlin:kotlin-stdlib`, not `org.jetbrains.kotlin:kotlin-stdlib-jdk7`.