### PR TITLE
fix(motion): example code fix to work on ios/android

### DIFF
--- a/motion/README.md
+++ b/motion/README.md
@@ -16,7 +16,7 @@ permission before using this API. To request permission, prompt the user for
 permission on any user-initiated action (such as a button click):
 
 ```typescript
-import { Capacitor, PluginListenerHandle } from '@capacitor/core';
+import { PluginListenerHandle } from '@capacitor/core';
 import { Motion } from '@capacitor/motion';
 
 
@@ -24,11 +24,16 @@ let accelHandler: PluginListenerHandle;
 
 myButton.addEventListener('click', async () => {
   try {
-    if (!Capacitor.isNativePlatform()) {
-       await (DeviceMotionEvent as any).requestPermission();
+    // On Web and iOS we need to request permissions
+    if ((DeviceMotionEvent as any).requestPermission) {
+      const result = await (DeviceMotionEvent as any).requestPermission();
+      // This should return a result of 'granted'
+    } else {
+      // Chrome/Android does not have this API
     }
   } catch (e) {
     // Handle error
+    console.error(e);
     return;
   }
 

--- a/motion/README.md
+++ b/motion/README.md
@@ -16,7 +16,7 @@ permission before using this API. To request permission, prompt the user for
 permission on any user-initiated action (such as a button click):
 
 ```typescript
-import { PluginListenerHandle } from '@capacitor/core';
+import { Capacitor, PluginListenerHandle } from '@capacitor/core';
 import { Motion } from '@capacitor/motion';
 
 
@@ -24,7 +24,9 @@ let accelHandler: PluginListenerHandle;
 
 myButton.addEventListener('click', async () => {
   try {
-    await DeviceMotionEvent.requestPermission();
+    if (!Capacitor.isNativePlatform()) {
+       await (DeviceMotionEvent as any).requestPermission();
+    }
   } catch (e) {
     // Handle error
     return;


### PR DESCRIPTION
This resolves [https://github.com/ionic-team/capacitor-docs/issues/91](https://github.com/ionic-team/capacitor-docs/issues/91)

The DeviceMotionEvent.requestPermission API is only present on Safari and iOS. It also needs to be typecast to any in Typescript.