### PR TITLE
fix(geolocation): fix geolocation timeout setting

### DIFF
--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
@@ -85,9 +85,7 @@ public class Geolocation {
                 int lowPriority = networkEnabled ? Priority.PRIORITY_BALANCED_POWER_ACCURACY : Priority.PRIORITY_LOW_POWER;
                 int priority = enableHighAccuracy ? Priority.PRIORITY_HIGH_ACCURACY : lowPriority;
 
-                LocationRequest locationRequest = new LocationRequest.Builder(10000)
-                    .setMaxUpdateDelayMillis(timeout)
-                    .setMinUpdateIntervalMillis(5000)
+                LocationRequest locationRequest = new LocationRequest.Builder(timeout)
                     .setPriority(priority)
                     .build();
 


### PR DESCRIPTION
`timeout` setting doesn't work as expected as some  values are hardcoded in `LocationRequest.Builder`.

This change simplify `LocationRequest` creation and sets timeout value to `intervalMillis` setting instead of `maxUpdateDelay`.

https://developer.android.com/reference/android/location/LocationRequest.Builder

Resolves https://github.com/ionic-team/capacitor-plugins/issues/1465