### PR TITLE
fix(push-notification): Notification not dispatching click when received in foreground

### DIFF
--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -3,6 +3,7 @@ package com.capacitorjs.plugins.pushnotifications;
 import android.Manifest;
 import android.app.Notification;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
@@ -277,15 +278,25 @@ public class PushNotificationsPlugin extends Plugin {
                     if (bundle != null && bundle.getInt("com.google.firebase.messaging.default_notification_icon") != 0) {
                         pushIcon = bundle.getInt("com.google.firebase.messaging.default_notification_icon");
                     }
+                    Intent intent = new Intent(getContext(), getActivity().getClass());
+                    intent.putExtras(remoteMessage.toIntent().getExtras());
+                    PendingIntent pendingIntent = PendingIntent.getActivity(
+                        getContext(),
+                        generateUniqueId(),
+                        intent,
+                        PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE
+                    );
                     NotificationCompat.Builder builder = new NotificationCompat.Builder(
                         getContext(),
                         NotificationChannelManager.FOREGROUND_NOTIFICATION_CHANNEL_ID
                     )
                         .setSmallIcon(pushIcon)
                         .setContentTitle(title)
+                        .setAutoCancel(true)
+                        .setContentIntent(pendingIntent)
                         .setContentText(body)
                         .setPriority(NotificationCompat.PRIORITY_DEFAULT);
-                    notificationManager.notify(0, builder.build());
+                    notificationManager.notify(generateUniqueId(), builder.build());
                 }
             }
             remoteMessageData.put("title", title);
@@ -328,5 +339,9 @@ public class PushNotificationsPlugin extends Plugin {
             e.printStackTrace();
             return null;
         }
+    }
+
+    private int generateUniqueId() {
+        return (int) (System.currentTimeMillis() % (long) 1e9);
     }
 }


### PR DESCRIPTION
Based on https://github.com/ionic-team/capacitor-plugins/pull/1478

Added generateUniqueId method to prevent overwriting the last notification