### PR TITLE
fix(splash-screen): crash if splash screen is missing

### DIFF
--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
@@ -339,13 +339,13 @@ public class SplashScreen {
                     }
                     imageView.setScaleType(config.getScaleType());
                     imageView.setImageDrawable(splash);
+
+                    splashImage.setFitsSystemWindows(true);
+                    
+                    if (config.getBackgroundColor() != null) {
+                        splashImage.setBackgroundColor(config.getBackgroundColor());
+                    }
                 }
-            }
-
-            splashImage.setFitsSystemWindows(true);
-
-            if (config.getBackgroundColor() != null) {
-                splashImage.setBackgroundColor(config.getBackgroundColor());
             }
         }
 


### PR DESCRIPTION
If you choose not to use legacy splash screen below Android 12, the app crashes. This fixes the problem.