### PR TITLE
fix(splash-screen): Avoid crash when splash resources not found

### DIFF
--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
@@ -339,6 +339,8 @@ public class SplashScreen {
                     }
                     imageView.setScaleType(config.getScaleType());
                     imageView.setImageDrawable(splash);
+                } else {
+                    return;
                 }
             }
 


### PR DESCRIPTION
related to https://github.com/ionic-team/capacitor-plugins/pull/1640

