### PR TITLE
feat(android): allow for multiple foreground notifications

### DIFF
--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -285,7 +285,13 @@ public class PushNotificationsPlugin extends Plugin {
                         .setContentTitle(title)
                         .setContentText(body)
                         .setPriority(NotificationCompat.PRIORITY_DEFAULT);
-                    notificationManager.notify(0, builder.build());
+
+                    String tag = notification.getTag();
+                    if (tag != null) {
+                        notificationManager.notify(tag, 0, builder.build());
+                    } else {
+                        notificationManager.notify(0, builder.build());
+                    }
                 }
             }
             remoteMessageData.put("title", title);


### PR DESCRIPTION
Currently, upon receiving multiple notifications while app is foregrounded, the 'old' foreground notification will get overwritten by the 'new' one. This happens because no unique id is set (it always uses `0` as value). We can use the `getTag` and `notify(tag, ...)` methods to work around this.

I think this makes more sense, as this is what the behaviour is on iOS as well.

Also I think it makes more sense to use a unique id instead of the static 'magic number' `0`.