### PR TITLE
feat(android): add support for notification color to foreground notifications

### DIFF
--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -288,7 +288,9 @@ public class PushNotificationsPlugin extends Plugin {
                         .setPriority(NotificationCompat.PRIORITY_DEFAULT);
 
                     if (bundle != null && bundle.getInt("com.google.firebase.messaging.default_notification_color") != 0) {
-                        builder.setColor(ContextCompat.getColor(getContext(), bundle.getInt("com.google.firebase.messaging.default_notification_color")));
+                        builder.setColor(
+                            ContextCompat.getColor(getContext(), bundle.getInt("com.google.firebase.messaging.default_notification_color"))
+                        );
                     }
 
                     notificationManager.notify(0, builder.build());

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.service.notification.StatusBarNotification;
 import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
 import com.getcapacitor.*;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
@@ -285,6 +286,11 @@ public class PushNotificationsPlugin extends Plugin {
                         .setContentTitle(title)
                         .setContentText(body)
                         .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+
+                    if (bundle != null && bundle.getInt("com.google.firebase.messaging.default_notification_color") != 0) {
+                        builder.setColor(ContextCompat.getColor(getContext(), bundle.getInt("com.google.firebase.messaging.default_notification_color")));
+                    }
+
                     notificationManager.notify(0, builder.build());
                 }
             }


### PR DESCRIPTION
Title speaks for itself. For background notifications the Firebase SDK already takes care of this itself.

Related PR to update documentation: https://github.com/ionic-team/capacitor-plugins/pull/1504/files