### PR TITLE
feat(android): use default or incoming notification channelId for foreground notifications

### DIFF
--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -51,6 +51,18 @@ If no icon is specified Android will use the application icon, but push icon sho
 
 Android Studio has an icon generator you can use to create your Push Notifications icon.
 
+## Default Push Notification channel
+
+From Android 8.0 (API level 26) and higher, notification channels are supported and recommended. FCM provides a default notification channel with basic settings. If you prefer to create and use your own default channel, set `default_notification_channel_id` to the ID of your notification channel object as shown; FCM will use this value whenever incoming messages do not explicitly set a notification channel.
+
+```xml
+<meta-data
+    android:name="com.google.firebase.messaging.default_notification_channel_id"
+    android:value="@string/default_notification_channel_id" />
+```
+
+Note: You are still required to create a notification channel in code with an ID that matches the one defined in the manifest. You can use [`createChannel(...)`](#createchannel) for this.
+
 ## Push notifications appearance in foreground
 
 <docgen-config>

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/NotificationChannelManager.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/NotificationChannelManager.java
@@ -16,8 +16,6 @@ import java.util.List;
 
 public class NotificationChannelManager {
 
-    public static final String FOREGROUND_NOTIFICATION_CHANNEL_ID = "PushDefaultForeground";
-
     private Context context;
     private NotificationManager notificationManager;
     private PluginConfig config;
@@ -26,7 +24,6 @@ public class NotificationChannelManager {
         this.context = context;
         this.notificationManager = manager;
         this.config = config;
-        createForegroundNotificationChannel();
     }
 
     private static String CHANNEL_ID = "id";
@@ -138,37 +135,6 @@ public class NotificationChannelManager {
             call.resolve(result);
         } else {
             call.unavailable();
-        }
-    }
-
-    /**
-     * Create notification channel
-     */
-    public void createForegroundNotificationChannel() {
-        // Create the NotificationChannel only if presentationOptions is defined
-        // Because the channel can't be changed after creation
-        String[] presentation = config.getArray("presentationOptions");
-        if (presentation != null) {
-            // And only on API 26+ because the NotificationChannel class
-            // is new and not in the support library
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                CharSequence name = "Push Notifications Foreground";
-                String description = "Push notifications in foreground";
-                int importance = NotificationManager.IMPORTANCE_HIGH;
-                NotificationChannel channel = new NotificationChannel(FOREGROUND_NOTIFICATION_CHANNEL_ID, name, importance);
-                channel.setDescription(description);
-                if (Arrays.asList(presentation).contains("sound")) {
-                    AudioAttributes audioAttributes = new AudioAttributes.Builder()
-                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                        .setUsage(AudioAttributes.USAGE_ALARM)
-                        .build();
-                    channel.setSound(Settings.System.DEFAULT_NOTIFICATION_URI, audioAttributes);
-                }
-                // Register the channel with the system; you can't change the importance
-                // or other notification behaviors after this
-                android.app.NotificationManager notificationManager = context.getSystemService(android.app.NotificationManager.class);
-                notificationManager.createNotificationChannel(channel);
-            }
         }
     }
 }

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -245,7 +245,7 @@ public class PushNotificationsPlugin extends Plugin {
 
         if (channelId == null) {
             if (bundle != null && bundle.getInt("com.google.firebase.messaging.default_notification_channel_id") != 0) {
-                 channelId = bundle.getString("com.google.firebase.messaging.default_notification_channel_id");
+                channelId = bundle.getString("com.google.firebase.messaging.default_notification_channel_id");
             }
         }
 
@@ -295,9 +295,7 @@ public class PushNotificationsPlugin extends Plugin {
 
                     String notificationChannelId = getChannelId(notification, bundle);
 
-                    NotificationCompat.Builder builder = new NotificationCompat.Builder(
-                        getContext(), notificationChannelId
-                    )
+                    NotificationCompat.Builder builder = new NotificationCompat.Builder(getContext(), notificationChannelId)
                         .setSmallIcon(pushIcon)
                         .setContentTitle(title)
                         .setContentText(body)

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -11,6 +11,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.service.notification.StatusBarNotification;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 import com.getcapacitor.*;
 import com.getcapacitor.annotation.CapacitorPlugin;
@@ -237,6 +239,19 @@ public class PushNotificationsPlugin extends Plugin {
         }
     }
 
+    @NonNull
+    private String getChannelId(@NonNull RemoteMessage.Notification notification, @Nullable Bundle bundle) {
+        String channelId = notification.getChannelId();
+
+        if (channelId == null) {
+            if (bundle != null && bundle.getInt("com.google.firebase.messaging.default_notification_channel_id") != 0) {
+                 channelId = bundle.getString("com.google.firebase.messaging.default_notification_channel_id");
+            }
+        }
+
+        return channelId == null ? "fcm_fallback_notification_channel" : channelId;
+    }
+
     public void fireNotification(RemoteMessage remoteMessage) {
         JSObject remoteMessageData = new JSObject();
 
@@ -277,9 +292,11 @@ public class PushNotificationsPlugin extends Plugin {
                     if (bundle != null && bundle.getInt("com.google.firebase.messaging.default_notification_icon") != 0) {
                         pushIcon = bundle.getInt("com.google.firebase.messaging.default_notification_icon");
                     }
+
+                    String notificationChannelId = getChannelId(notification, bundle);
+
                     NotificationCompat.Builder builder = new NotificationCompat.Builder(
-                        getContext(),
-                        NotificationChannelManager.FOREGROUND_NOTIFICATION_CHANNEL_ID
+                        getContext(), notificationChannelId
                     )
                         .setSmallIcon(pushIcon)
                         .setContentTitle(title)


### PR DESCRIPTION
This PR drops the creation of a custom foreground channel on Android. Instead if will derive the `channelId` to be used for the foreground in the following order:

1. Firstly it will check if the incoming notification has a `channelId` set
2. Then it will check for a possible given value in the `AndroidManifest.xml`<sup>1</sup>
3. Lastly it will use the fallback `channelId` that the Firebase SDK provides for us. This channel will be created by the Firebase SDK upon receiving the first push message<sup>2</sup>

<sup>1</sup> From the [Firebase docs](https://firebase.google.com/docs/cloud-messaging/android/client#:~:text=(Optional)%20From%20Android,Manage%20notification%20channels):

> From Android 8.0 (API level 26) and higher, notification channels are supported and recommended. FCM provides a default notification channel with basic settings. If you prefer to create and use your own default channel, set `default_notification_channel_id` to the ID of your notification channel object as shown; FCM will use this value whenever incoming messages do not explicitly set a notification channel.

(see [README](https://github.com/firebase/quickstart-android/tree/master/messaging#set-default-channel) also)

<sup>2</sup> This is similar to how `react-native-push-notification` is handling this: https://github.com/zo0r/react-native-push-notification/blob/master/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java#LL69C19-L69C50

I think this makes way more sense than the current solution. It will also automatically inherit the channel settings set for the incoming notification. So that's more expected behaviour for the developer

---

By merging this PR #1423 becomes obsolete

Fixes https://github.com/ionic-team/capacitor-plugins/issues/1368
Fixes https://github.com/ionic-team/capacitor-plugins/issues/1388