### PR TITLE
Add support for SDCard filesystem on Android

### DIFF
--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -99,6 +99,7 @@ const readFilePath = async () => {
 * [`stat(...)`](#stat)
 * [`rename(...)`](#rename)
 * [`copy(...)`](#copy)
+* [`isPortableStorageAvailable()`](#isportablestorageavailable)
 * [`checkPermissions()`](#checkpermissions)
 * [`requestPermissions()`](#requestpermissions)
 * [Interfaces](#interfaces)
@@ -309,6 +310,22 @@ Copy a file or directory
 --------------------
 
 
+### isPortableStorageAvailable()
+
+```typescript
+isPortableStorageAvailable() => Promise<isPortableStorageAvailableResult>
+```
+
+Check if portable storage is available (SD Card for Android)
+Only available on Android
+
+**Returns:** <code>Promise&lt;<a href="#isportablestorageavailableresult">isPortableStorageAvailableResult</a>&gt;</code>
+
+**Since:** 5.0.5
+
+--------------------
+
+
 ### checkPermissions()
 
 ```typescript
@@ -494,6 +511,13 @@ Required on Android, only when using <a href="#directory">`Directory.Documents`<
 | **`uri`** | <code>string</code> | The uri where the file was copied into | 4.0.0 |
 
 
+#### isPortableStorageAvailableResult
+
+| Prop            | Type                 | Description                                                       | Since |
+| --------------- | -------------------- | ----------------------------------------------------------------- | ----- |
+| **`available`** | <code>boolean</code> | Is portable storage available (SD Card) Only available on Android | 5.0.5 |
+
+
 #### PermissionStatus
 
 | Prop                | Type                                                        |
@@ -527,6 +551,7 @@ Required on Android, only when using <a href="#directory">`Directory.Documents`<
 | **`Cache`**           | <code>'CACHE'</code>            | The Cache directory Can be deleted in cases of low memory, so use this directory to write app-specific files that your app can re-create easily.                                                                                                                                                                                                                                                                                                  | 1.0.0 |
 | **`External`**        | <code>'EXTERNAL'</code>         | The external directory On iOS it will use the Documents directory On Android it's the directory on the primary shared/external storage device where the application can place persistent files it owns. These files are internal to the applications, and not typically visible to the user as media. Files will be deleted when the application is uninstalled.                                                                                  | 1.0.0 |
 | **`ExternalStorage`** | <code>'EXTERNAL_STORAGE'</code> | The external storage directory On iOS it will use the Documents directory On Android it's the primary shared/external storage directory. It's not accesible on Android 10 unless the app enables legacy External Storage by adding `android:requestLegacyExternalStorage="true"` in the `application` tag in the `AndroidManifest.xml`. It's not accesible on Android 11 or newer.                                                                | 1.0.0 |
+| **`PortableStorage`** | <code>'PORTABLE_STORAGE'</code> | SDCARD when configured as Portable Storage Points to application private storage on the SD Card when configured as Portable Storage. On iOS it will use the Documents directory                                                                                                                                                                                                                                                                   | 5.0.5 |
 
 
 #### Encoding

--- a/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/Filesystem.java
+++ b/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/Filesystem.java
@@ -2,8 +2,12 @@ package com.capacitorjs.plugins.filesystem;
 
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
 import android.util.Base64;
+
+import androidx.core.os.EnvironmentCompat;
+
 import com.capacitorjs.plugins.filesystem.exceptions.CopyFailedException;
 import com.capacitorjs.plugins.filesystem.exceptions.DirectoryExistsException;
 import com.capacitorjs.plugins.filesystem.exceptions.DirectoryNotFoundException;
@@ -11,6 +15,8 @@ import java.io.*;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Filesystem {
 
@@ -195,8 +201,74 @@ public class Filesystem {
                 return c.getExternalFilesDir(null);
             case "EXTERNAL_STORAGE":
                 return Environment.getExternalStorageDirectory();
+            case "PORTABLE_STORAGE":
+                return this.getPortableStorage();
         }
         return null;
+    }
+    
+    public boolean isPortableStorageAvailable() {
+        String[] storageDirectories = getFilteredStorageDirectories();
+        return storageDirectories.length > 0;
+    }
+
+    private File getPortableStorage() {
+        String[] storageDirectories = getFilteredStorageDirectories();
+
+        if(storageDirectories.length == 0){
+            return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS);
+        } else {
+            return new File(storageDirectories[0]);
+        }
+    }
+
+    private String[] getFilteredStorageDirectories() {
+        List<String> results = new ArrayList<String>();
+
+        Context c = this.context;
+
+        File[] externalDirs = c.getExternalFilesDirs(null);
+
+        // Get a list of external file systems and filter for removable storage only
+        for (File file : externalDirs) {
+            if(file == null){
+                continue;
+            }
+            String applicationPath = file.getPath();
+
+            boolean addPath = false;
+
+            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                addPath = Environment.isExternalStorageRemovable(file);
+            }
+            else{
+                addPath = Environment.MEDIA_MOUNTED.equals(EnvironmentCompat.getStorageState(file));
+            }
+
+            if(addPath){
+                results.add(applicationPath);
+            }
+        }
+
+        //Remove paths which may not be external SDCard, like OTG
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            for (int i = 0; i < results.size(); i++) {
+                if (!results.get(i).toLowerCase().matches(".*[0-9a-f]{4}[-][0-9a-f]{4}.*")) {
+                    results.remove(i--);
+                }
+            }
+        } else {
+            for (int i = 0; i < results.size(); i++) {
+                if (!results.get(i).toLowerCase().contains("ext") && !results.get(i).toLowerCase().contains("sdcard")) {
+                    results.remove(i--);
+                }
+            }
+        }
+
+        String[] storageDirectories = new String[results.size()];
+        for(int i=0; i<results.size(); ++i) storageDirectories[i] = results.get(i);
+
+        return storageDirectories;
     }
 
     public File getFileObject(String path, String directory) {

--- a/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/FilesystemPlugin.java
+++ b/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/FilesystemPlugin.java
@@ -44,6 +44,13 @@ public class FilesystemPlugin extends Plugin {
     private static final String PERMISSION_DENIED_ERROR = "Unable to do file operation, user denied permission request";
 
     @PluginMethod
+    public void isPortableStorageAvailable(PluginCall call) {
+        JSObject ret = new JSObject();
+        ret.put("available", implementation.isPortableStorageAvailable());
+        call.resolve(ret);
+    }
+
+    @PluginMethod
     public void readFile(PluginCall call) {
         String path = call.getString("path");
         String directory = getDirectoryParameter(call);

--- a/filesystem/src/definitions.ts
+++ b/filesystem/src/definitions.ts
@@ -73,6 +73,16 @@ export enum Directory {
    * @since 1.0.0
    */
   ExternalStorage = 'EXTERNAL_STORAGE',
+
+  /**
+   * SDCARD when configured as Portable Storage
+   * Points to application private storage on the SD Card when configured as
+   * Portable Storage.
+   * On iOS it will use the Documents directory
+   *
+   * @since 5.0.5
+   */
+  PortableStorage = 'PORTABLE_STORAGE',
 }
 
 export enum Encoding {
@@ -474,6 +484,17 @@ export interface CopyResult {
   uri: string;
 }
 
+export interface isPortableStorageAvailableResult {
+  /**
+   * Is portable storage available (SD Card)
+   * Only available on Android
+   *
+   * @since 5.0.5
+   */
+  available: boolean;
+}
+
+
 export interface FilesystemPlugin {
   /**
    * Read a file from disk
@@ -551,6 +572,14 @@ export interface FilesystemPlugin {
    * @since 1.0.0
    */
   copy(options: CopyOptions): Promise<CopyResult>;
+
+  /**
+   * Check if portable storage is available (SD Card for Android)
+   * Only available on Android
+   *
+   * @since 5.0.5
+   */
+  isPortableStorageAvailable(): Promise<isPortableStorageAvailableResult>;
 
   /**
    * Check read/write permissions.

--- a/filesystem/src/web.ts
+++ b/filesystem/src/web.ts
@@ -21,6 +21,7 @@ import type {
   WriteFileOptions,
   WriteFileResult,
   Directory,
+  isPortableStorageAvailableResult,
 } from './definitions';
 import { Encoding } from './definitions';
 
@@ -462,6 +463,10 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
 
   async checkPermissions(): Promise<PermissionStatus> {
     return { publicStorage: 'granted' };
+  }
+
+  async isPortableStorageAvailable(): Promise<isPortableStorageAvailableResult> {
+    return { available: false };
   }
 
   /**


### PR DESCRIPTION
Add support for checking and accessing the SD Card on Android.

add isPortableStorageAvailable() to check if SD Card is present
add Directory.PortableStorage to select the SD Card directory

Tested on simulator on Android 9
Tested on Samsung Galaxy S10 on Android 10
Tested on Samsung Galaxy A23 5G on Android 13

This is non-breaking and backward compatible.

closes #1661 