### PR TITLE
fix(browser): anchor events links

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -35,8 +35,8 @@ const openCapacitorSite = async () => {
 
 * [`open(...)`](#open)
 * [`close()`](#close)
-* [`addListener('browserFinished', ...)`](#addlistenerbrowserfinished)
-* [`addListener('browserPageLoaded', ...)`](#addlistenerbrowserpageloaded)
+* [`addListener('browserFinished', ...)`](#addlistenerbrowserfinished-)
+* [`addListener('browserPageLoaded', ...)`](#addlistenerbrowserpageloaded-)
 * [`removeAllListeners()`](#removealllisteners)
 * [Interfaces](#interfaces)
 


### PR DESCRIPTION
Fix anchors links to events because there need a hyphen at the end to point to the good section of the markdown file