### PR TITLE
chore: Improve bot message for requesting reproductions

### DIFF
--- a/.github/bot.yml
+++ b/.github/bot.yml
@@ -6,9 +6,11 @@ tasks:
     condition: 'payload.label.name == "needs reproduction"'
     config:
       comment: |
-        This issue may need more information before it can be addressed. In particular, it will need a reliable Code Reproduction that demonstrates the issue.
+        This issue needs more information before it can be addressed.
+        In particular, the reporter needs to provide a minimal sample app that demonstrates the issue.
+        If no sample app is provided within 15 days, the issue will be closed.
 
-        Please see the Contributing Guide for [how to create a Code Reproduction](https://github.com/ionic-team/capacitor/blob/HEAD/CONTRIBUTING.md#creating-a-code-reproduction).
+        Please see the Contributing Guide for [how to create a Sample App](https://github.com/ionic-team/capacitor/blob/HEAD/CONTRIBUTING.md#creating-a-code-reproduction).
 
         Thanks!
         Ionitron 💙

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -4,9 +4,17 @@ triage:
   dryRun: false
 
 lockClosed:
-  days: 30
+  days: 15
   maxIssuesPerRun: 100
   message: >
     Thanks for the issue! This issue is being locked to prevent comments that are not relevant to the original issue.
     If this is still an issue with the latest version of the plugin, please create a new issue and ensure the template is fully filled out.
+  dryRun: false
+
+comment:
+  labels:
+    - label: "type: bug"
+      message: >
+        This issue has been labeled as `type: bug`. This label is added to issues
+        that that have been reproduced and are being tracked in our internal issue tracker.
   dryRun: false


### PR DESCRIPTION
Improve the needs reproduction bot message
Also add a message when `type: bug` label is added as feedback to users.
