### PR TITLE
chore: fix all plugins always publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ci:publish:alpha": "lerna version prerelease --conventional-commits --conventional-prerelease --preid alpha --force-publish --yes && lerna exec -- npm publish --tag next --provenance",
     "ci:publish:beta": "lerna version prerelease --conventional-commits --conventional-prerelease --preid beta --force-publish --yes && lerna exec -- npm publish --tag next --provenance",
     "ci:publish:rc": "lerna version prerelease --conventional-commits --conventional-prerelease --preid rc --force-publish --yes && lerna exec -- npm publish --tag next --provenance",
-    "ci:publish:latest": "lerna version --conventional-commits --force-publish --yes && lerna exec -- npm publish --tag latest --provenance",
+    "ci:publish:latest": "lerna version --conventional-commits --yes && lerna exec -- npm publish --tag latest --provenance",
     "ci:publish:latest-from-pre": "lerna version --conventional-graduate --conventional-commits --force-publish --yes && lerna exec -- npm publish --tag latest --provenance",
     "ci:publish:dev": "lerna version prerelease --conventional-commits --conventional-prerelease --preid dev-$(date +\"%Y%m%dT%H%M%S\") --force-publish --no-changelog --no-git-tag-version --no-push --yes && lerna exec -- npm publish --tag dev --provenance"
   },


### PR DESCRIPTION
This stops all the plugins getting a new publish whenever only a few have changed.