### PR TITLE
fix(filesystem): download file on web to IDB instead of Downloads folder

### DIFF
--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -387,9 +387,9 @@ Add a listener to file download progress events.
 
 #### ReadFileResult
 
-| Prop       | Type                | Description                                                 | Since |
-| ---------- | ------------------- | ----------------------------------------------------------- | ----- |
-| **`data`** | <code>string</code> | The string representation of the data contained in the file | 1.0.0 |
+| Prop       | Type             | Description                                                                                                                            | Since |
+| ---------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`data`** | <code>any</code> | The representation of the data contained in the file Note: Blob is only available on Web. On native, the data is returned as a string. | 1.0.0 |
 
 
 #### ReadFileOptions
@@ -413,7 +413,7 @@ Add a listener to file download progress events.
 | Prop            | Type                                            | Description                                                                                                                                               | Default            | Since |
 | --------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
 | **`path`**      | <code>string</code>                             | The path of the file to write                                                                                                                             |                    | 1.0.0 |
-| **`data`**      | <code>string</code>                             | The data to write                                                                                                                                         |                    | 1.0.0 |
+| **`data`**      | <code>any</code>                                | The data to write Note: Blob data is only supported on Web.                                                                                               |                    | 1.0.0 |
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to store the file in                                                                                             |                    | 1.0.0 |
 | **`encoding`**  | <code><a href="#encoding">Encoding</a></code>   | The encoding to write the file in. If not provided, data is written as base64 encoded. Pass <a href="#encoding">Encoding.UTF8</a> to write data as string |                    | 1.0.0 |
 | **`recursive`** | <code>boolean</code>                            | Whether to create any missing parent directories.                                                                                                         | <code>false</code> | 1.0.0 |
@@ -467,7 +467,7 @@ Add a listener to file download progress events.
 | Prop        | Type                               | Description                                                                          | Since |
 | ----------- | ---------------------------------- | ------------------------------------------------------------------------------------ | ----- |
 | **`name`**  | <code>string</code>                | Name of the file or directory.                                                       |       |
-| **`type`**  | <code>'file' \| 'directory'</code> | Type of the file.                                                                    | 4.0.0 |
+| **`type`**  | <code>'directory' \| 'file'</code> | Type of the file.                                                                    | 4.0.0 |
 | **`size`**  | <code>number</code>                | Size of the file in bytes.                                                           | 4.0.0 |
 | **`ctime`** | <code>number</code>                | Time of creation in milliseconds. It's not available on Android 7 and older devices. | 4.0.0 |
 | **`mtime`** | <code>number</code>                | Time of last modification in milliseconds.                                           | 4.0.0 |
@@ -501,7 +501,7 @@ Add a listener to file download progress events.
 
 | Prop        | Type                               | Description                                                                          | Since |
 | ----------- | ---------------------------------- | ------------------------------------------------------------------------------------ | ----- |
-| **`type`**  | <code>'file' \| 'directory'</code> | Type of the file.                                                                    | 1.0.0 |
+| **`type`**  | <code>'directory' \| 'file'</code> | Type of the file.                                                                    | 1.0.0 |
 | **`size`**  | <code>number</code>                | Size of the file in bytes.                                                           | 1.0.0 |
 | **`ctime`** | <code>number</code>                | Time of creation in milliseconds. It's not available on Android 7 and older devices. | 1.0.0 |
 | **`mtime`** | <code>number</code>                | Time of last modification in milliseconds.                                           | 1.0.0 |
@@ -550,11 +550,12 @@ Add a listener to file download progress events.
 
 #### DownloadFileOptions
 
-| Prop            | Type                                            | Description                                                                                                                                                                                                                      | Since |
-| --------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| **`path`**      | <code>string</code>                             | The path the downloaded file should be moved to.                                                                                                                                                                                 | 5.1.0 |
-| **`directory`** | <code><a href="#directory">Directory</a></code> | The directory to write the file to. If this option is used, filePath can be a relative path rather than absolute. The default is the `DATA` directory.                                                                           | 5.1.0 |
-| **`progress`**  | <code>boolean</code>                            | An optional listener function to receive downloaded progress events. If this option is used, progress event should be dispatched on every chunk received. Chunks are throttled to every 100ms on Android/iOS to avoid slowdowns. | 5.1.0 |
+| Prop            | Type                                            | Description                                                                                                                                                                                                                      | Default            | Since |
+| --------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
+| **`path`**      | <code>string</code>                             | The path the downloaded file should be moved to.                                                                                                                                                                                 |                    | 5.1.0 |
+| **`directory`** | <code><a href="#directory">Directory</a></code> | The directory to write the file to. If this option is used, filePath can be a relative path rather than absolute. The default is the `DATA` directory.                                                                           |                    | 5.1.0 |
+| **`progress`**  | <code>boolean</code>                            | An optional listener function to receive downloaded progress events. If this option is used, progress event should be dispatched on every chunk received. Chunks are throttled to every 100ms on Android/iOS to avoid slowdowns. |                    | 5.1.0 |
+| **`recursive`** | <code>boolean</code>                            | Whether to create any missing parent directories.                                                                                                                                                                                | <code>false</code> | 5.1.2 |
 
 
 #### PluginListenerHandle

--- a/filesystem/ios/Plugin/Filesystem.swift
+++ b/filesystem/ios/Plugin/Filesystem.swift
@@ -35,7 +35,7 @@ import Capacitor
     }
 
     public func writeFile(at fileUrl: URL, with data: String, recursive: Bool, with encoding: String?) throws -> String {
-        if !FileManager.default.fileExists(atPath: fileUrl.deletingLastPathComponent().path) {
+        if !FileManager.default.fileExists(atPath: fileUrl.deletingLastPathComponent.path) {
             if recursive {
                 try FileManager.default.createDirectory(at: fileUrl.deletingLastPathComponent(), withIntermediateDirectories: recursive, attributes: nil)
             } else {
@@ -213,7 +213,7 @@ import Capacitor
                     let dest = dir!.appendingPathComponent(path)
                     CAPLog.print("Attempting to write to file destination: \(dest.absoluteString)")
 
-                    if !FileManager.default.fileExists(atPath: dest.deletingLastPathComponent().absoluteString) {
+                    if !FileManager.default.fileExists(atPath: dest.deletingLastPathComponent.absoluteString) {
                         try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
                     }
 

--- a/filesystem/ios/Plugin/Filesystem.swift
+++ b/filesystem/ios/Plugin/Filesystem.swift
@@ -35,7 +35,7 @@ import Capacitor
     }
 
     public func writeFile(at fileUrl: URL, with data: String, recursive: Bool, with encoding: String?) throws -> String {
-        if !FileManager.default.fileExists(atPath: fileUrl.deletingLastPathComponent.path) {
+        if !FileManager.default.fileExists(atPath: fileUrl.deletingLastPathComponent().path) {
             if recursive {
                 try FileManager.default.createDirectory(at: fileUrl.deletingLastPathComponent(), withIntermediateDirectories: recursive, attributes: nil)
             } else {
@@ -213,7 +213,7 @@ import Capacitor
                     let dest = dir!.appendingPathComponent(path)
                     CAPLog.print("Attempting to write to file destination: \(dest.absoluteString)")
 
-                    if !FileManager.default.fileExists(atPath: dest.deletingLastPathComponent.absoluteString) {
+                    if !FileManager.default.fileExists(atPath: dest.deletingLastPathComponent().absoluteString) {
                         try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
                     }
 

--- a/filesystem/src/definitions.ts
+++ b/filesystem/src/definitions.ts
@@ -116,7 +116,7 @@ export interface WriteFileOptions {
 
   /**
    * The data to write
-   * 
+   *
    * Note: Blob data is only supported on Web.
    *
    * @since 1.0.0
@@ -356,7 +356,7 @@ export type RenameOptions = CopyOptions;
 export interface ReadFileResult {
   /**
    * The representation of the data contained in the file
-   * 
+   *
    * Note: Blob is only available on Web. On native, the data is returned as a string.
    *
    * @since 1.0.0

--- a/filesystem/src/definitions.ts
+++ b/filesystem/src/definitions.ts
@@ -116,10 +116,12 @@ export interface WriteFileOptions {
 
   /**
    * The data to write
+   * 
+   * Note: Blob data is only supported on Web.
    *
    * @since 1.0.0
    */
-  data: string;
+  data: string | Blob;
 
   /**
    * The `Directory` to store the file in
@@ -353,11 +355,13 @@ export type RenameOptions = CopyOptions;
 
 export interface ReadFileResult {
   /**
-   * The string representation of the data contained in the file
+   * The representation of the data contained in the file
+   * 
+   * Note: Blob is only available on Web. On native, the data is returned as a string.
    *
    * @since 1.0.0
    */
-  data: string;
+  data: string | Blob;
 }
 
 export interface WriteFileResult {
@@ -501,6 +505,13 @@ export interface DownloadFileOptions extends HttpOptions {
    * @since 5.1.0
    */
   progress?: boolean;
+  /**
+   * Whether to create any missing parent directories.
+   *
+   * @default false
+   * @since 5.1.2
+   */
+  recursive?: boolean;
 }
 
 export interface DownloadFileResult {

--- a/filesystem/src/web.ts
+++ b/filesystem/src/web.ts
@@ -198,7 +198,7 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
       }
     }
 
-    if (!encoding) {
+    if (!encoding && !(data instanceof Blob)) {
       data = data.indexOf(',') >= 0 ? data.split(',')[1] : data;
       if (!this.isBase64String(data))
         throw Error('The supplied data is not valid base64 content.');
@@ -209,7 +209,7 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
       path: path,
       folder: parentPath,
       type: 'file',
-      size: data.length,
+      size: (data instanceof Blob) ? data.size : data.length,
       ctime: now,
       mtime: now,
       content: data,
@@ -255,6 +255,10 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
       throw Error('The supplied data is not valid base64 content.');
 
     if (occupiedEntry !== undefined) {
+      if (occupiedEntry.content instanceof Blob) {
+        throw Error('The occupied entry contains a Blob object which cannot be appended to.')
+      }
+
       if (occupiedEntry.content !== undefined && !encoding) {
         data = btoa(atob(occupiedEntry.content) + atob(data));
       } else {
@@ -569,7 +573,7 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
         }
 
         let encoding;
-        if (!this.isBase64String(file.data)) {
+        if (!(file.data instanceof Blob) && !this.isBase64String(file.data)) {
           encoding = Encoding.UTF8;
         }
 
@@ -658,7 +662,7 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
     const response = await fetch(options.url, requestInit);
     let blob: Blob;
 
-    if (!options?.progress) blob = await response.blob();
+    if (!options.progress) blob = await response.blob();
     else if (!response?.body) blob = new Blob();
     else {
       const reader = response.body.getReader();
@@ -701,18 +705,14 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
       blob = new Blob([allChunks.buffer], { type: contentType || undefined });
     }
 
-    const blobUrl = URL.createObjectURL(blob);
-    const tempAnchor = document.createElement('a');
-    document.body.appendChild(tempAnchor);
+    const result = await this.writeFile({
+      path: options.path,
+      directory: options.directory ?? undefined,
+      recursive: options.recursive ?? false,
+      data: blob,
+    })
 
-    tempAnchor.href = blobUrl;
-    tempAnchor.download = options.path; // This should be a filename, not a path
-    tempAnchor.click();
-
-    URL.revokeObjectURL(blobUrl);
-    document.body.removeChild(tempAnchor);
-
-    return { path: options.path, blob };
+    return { path: result.uri, blob };
   };
 
   private isBase64String(str: string): boolean {
@@ -732,5 +732,5 @@ interface EntryObj {
   ctime: number;
   mtime: number;
   uri?: string;
-  content?: string;
+  content?: string | Blob;
 }

--- a/filesystem/src/web.ts
+++ b/filesystem/src/web.ts
@@ -209,7 +209,7 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
       path: path,
       folder: parentPath,
       type: 'file',
-      size: (data instanceof Blob) ? data.size : data.length,
+      size: data instanceof Blob ? data.size : data.length,
       ctime: now,
       mtime: now,
       content: data,
@@ -256,7 +256,9 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
 
     if (occupiedEntry !== undefined) {
       if (occupiedEntry.content instanceof Blob) {
-        throw Error('The occupied entry contains a Blob object which cannot be appended to.')
+        throw Error(
+          'The occupied entry contains a Blob object which cannot be appended to.',
+        );
       }
 
       if (occupiedEntry.content !== undefined && !encoding) {
@@ -710,7 +712,7 @@ export class FilesystemWeb extends WebPlugin implements FilesystemPlugin {
       directory: options.directory ?? undefined,
       recursive: options.recursive ?? false,
       data: blob,
-    })
+    });
 
     return { path: result.uri, blob };
   };


### PR DESCRIPTION
Closes: #1716 

This PR fixes the behavior on web for `downloadFIle` to match the other plugin methods where it writes the file to the IndexedDB instead of directly downloading it to the `Downloads` folder.