### PR TITLE
Use the default referrer for launching CustomTab on Android

### DIFF
--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/Browser.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/Browser.java
@@ -105,7 +105,6 @@ public class Browser {
         }
 
         CustomTabsIntent tabsIntent = builder.build();
-        tabsIntent.intent.putExtra(Intent.EXTRA_REFERRER, Uri.parse(Intent.URI_ANDROID_APP_SCHEME + "//" + context.getPackageName()));
 
         isInitialLoad = true;
         group.reset();


### PR DESCRIPTION
Browser plugin has a bug setting the referrer of an invalid form:

1. Wrong scheme: should be android-app but set to 2
2. Missing colon

The bug results a referrer such as 2//com.package.app while the intention is to build something like android-app://com.package.app. Filed as an issue https://github.com/ionic-team/capacitor-plugins/issues/1728

This patch removes the line with the bug. Android fills out the referrer with the form the code intended by default.
