### PR TITLE
Fix light impact haptic

### DIFF
--- a/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/Haptics.java
+++ b/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/Haptics.java
@@ -63,9 +63,7 @@ public class Haptics {
 
     public void performHaptics(HapticsVibrationType type) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && vibrator.hasAmplitudeControl()) {
-            long[] timings = type.getTimings();
-            int[] amplitudes = type.getAmplitudes();
-            vibrator.vibrate(VibrationEffect.createWaveform(timings, amplitudes, -1));
+            vibrator.vibrate(VibrationEffect.createWaveform(type.getTimings(), type.getAmplitudes(), -1));
         } else {
             vibratePre26(type.getOldSDKPattern(), -1);
         }

--- a/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/Haptics.java
+++ b/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/Haptics.java
@@ -14,8 +14,6 @@ public class Haptics {
     private boolean selectionStarted = false;
     private final Vibrator vibrator;
 
-    private int MINIMUM_VIBRATION_TIME = 40;
-
     Haptics(Context context) {
         this.context = context;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -64,27 +62,12 @@ public class Haptics {
     }
 
     public void performHaptics(HapticsVibrationType type) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && vibrator.hasAmplitudeControl()) {
             long[] timings = type.getTimings();
             int[] amplitudes = type.getAmplitudes();
-
-            if (vibrator.hasAmplitudeControl() && amplitudes != null) {
-                vibrator.vibrate(VibrationEffect.createWaveform(timings, amplitudes, -1));
-            } else {
-                if (timings != null) {
-                    for (int i = 0; i < timings.length; i++) {
-                        if (timings[i] < MINIMUM_VIBRATION_TIME && timings[i] > 0) {
-                            timings[i] = MINIMUM_VIBRATION_TIME;
-                        }
-                    }
-                    vibrator.vibrate(VibrationEffect.createWaveform(timings, amplitudes, -1));
-                }
-            }
+            vibrator.vibrate(VibrationEffect.createWaveform(timings, amplitudes, -1));
         } else {
             vibratePre26(type.getOldSDKPattern(), -1);
         }
     }
-
-
-
 }

--- a/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/Haptics.java
+++ b/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/Haptics.java
@@ -14,6 +14,8 @@ public class Haptics {
     private boolean selectionStarted = false;
     private final Vibrator vibrator;
 
+    private int MINIMUM_VIBRATION_TIME = 40;
+
     Haptics(Context context) {
         this.context = context;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -63,9 +65,26 @@ public class Haptics {
 
     public void performHaptics(HapticsVibrationType type) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            vibrator.vibrate(VibrationEffect.createWaveform(type.getTimings(), type.getAmplitudes(), -1));
+            long[] timings = type.getTimings();
+            int[] amplitudes = type.getAmplitudes();
+
+            if (vibrator.hasAmplitudeControl() && amplitudes != null) {
+                vibrator.vibrate(VibrationEffect.createWaveform(timings, amplitudes, -1));
+            } else {
+                if (timings != null) {
+                    for (int i = 0; i < timings.length; i++) {
+                        if (timings[i] < MINIMUM_VIBRATION_TIME && timings[i] > 0) {
+                            timings[i] = MINIMUM_VIBRATION_TIME;
+                        }
+                    }
+                    vibrator.vibrate(VibrationEffect.createWaveform(timings, amplitudes, -1));
+                }
+            }
         } else {
             vibratePre26(type.getOldSDKPattern(), -1);
         }
     }
+
+
+
 }

--- a/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/arguments/HapticsImpactType.java
+++ b/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/arguments/HapticsImpactType.java
@@ -1,9 +1,9 @@
 package com.capacitorjs.plugins.haptics.arguments;
 
 public enum HapticsImpactType implements HapticsVibrationType {
-    LIGHT("LIGHT", new long[] { 0, 1 }, new int[] { 0, 60 }, new long[] { 0, 20 }),
-    MEDIUM("MEDIUM", new long[] { 0, 43 }, new int[] { 0, 180 }, new long[] { 0, 43 }),
-    HEAVY("HEAVY", new long[] { 0, 60 }, new int[] { 0, 255 }, new long[] { 0, 61 });
+    LIGHT("LIGHT", new long[] { 0, 1 }, new int[] { 0, 60 }, new long[] { 0, 35 }),
+    MEDIUM("MEDIUM", new long[] { 0, 43 }, new int[] { 0, 180 }, new long[] { 0, 50 }),
+    HEAVY("HEAVY", new long[] { 0, 60 }, new int[] { 0, 255 }, new long[] { 0, 65 });
 
     private final String type;
     private final long[] timings;

--- a/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/arguments/HapticsImpactType.java
+++ b/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/arguments/HapticsImpactType.java
@@ -1,7 +1,7 @@
 package com.capacitorjs.plugins.haptics.arguments;
 
 public enum HapticsImpactType implements HapticsVibrationType {
-    LIGHT("LIGHT", new long[] { 0, 50 }, new int[] { 0, 110 }, new long[] { 0, 20 }),
+    LIGHT("LIGHT", new long[] { 0, 1 }, new int[] { 0, 60 }, new long[] { 0, 20 }),
     MEDIUM("MEDIUM", new long[] { 0, 43 }, new int[] { 0, 180 }, new long[] { 0, 43 }),
     HEAVY("HEAVY", new long[] { 0, 60 }, new int[] { 0, 255 }, new long[] { 0, 61 });
 


### PR DESCRIPTION
## The problem

The light impact style is way too strong on modern Android haptic engines, such as the Pixel 7a.

## Solution

Reduce light impact haptic strength

## Complications

In order to reduce the haptic strength to match my iPhone control device, the duration is reduced so far that it actually doesn't seem to fire on device without haptic engine (just a standard vibrator).

So, I check if the device has amplitude control and fall back if necessary.

Please note: I had to adjust the durations for the oldSDKPattern because it was too faint. This property should perhaps also be renamed.

## Other factors

- `oldSDKPattern` didn't seem to be right for me, so I adjusted. Since all devices without haptic engine will now use `oldSDKPattern`, other style haptics should perhaps be verified.
- If you'd like, I can update the web vibrator durations to match these new `oldSDKPattern` durations

## Testing devices

I've tested the light impact effect with the following devices:

- iPhone 13 mini (control device with desired haptic affect)
- Google Pixel 7a (has haptic engine)
- TCL 20xe (no haptic engine, standard vibrator)