### PR TITLE
Improve logging when permissions are not granted

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -256,7 +256,7 @@ public class CameraPlugin extends Plugin {
                 }
                 PermissionState permissionState = getPermissionState(alias);
                 if (permissionState != PermissionState.GRANTED) {
-                    Logger.debug(getLogTag(), "User denied photos permission: " + permissionState.toString());
+                    Logger.debug(getLogTag(), "User denied photos (" + alias + ") permission: " + permissionState.toString());
                     call.reject(PERMISSION_DENIED_ERROR_PHOTOS);
                     return;
                 }


### PR DESCRIPTION
Trying to diagnose why permissions aren't working right (and thus the plugin crashes), would help to know what `alias` is being used, so add that to the logged message on failure