### PR TITLE
fix(google-maps): problems on get/setMapType on web

### DIFF
--- a/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.swift
+++ b/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.swift
@@ -753,7 +753,7 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate {
             let mapBounds = try CGRect.fromJSObject(mapBoundsObj)
 
             map.updateRender(mapBounds: mapBounds)
-            
+
             call.resolve()
         } catch {
             handleError(call, error: error)

--- a/google-maps/src/web.ts
+++ b/google-maps/src/web.ts
@@ -160,14 +160,14 @@ export class CapacitorGoogleMapsWeb
       if (type === 'roadmap') {
         type = MapType.Normal;
       }
-      return { type };
+      return { type: `${type.charAt(0).toUpperCase()}${type.slice(1)}` };
     }
     throw new Error('Map type is undefined');
   }
 
   async setMapType(_args: MapTypeArgs): Promise<void> {
     let mapType = _args.mapType.toLowerCase();
-    if (mapType === MapType.Normal) {
+    if (_args.mapType === MapType.Normal) {
       mapType = 'roadmap';
     }
     this.maps[_args.id].map.setMapTypeId(mapType);


### PR DESCRIPTION
`setMapType` is not working for `MapType.Normal` because `Normal` doesn't exist on google maps and we replace it with `roadmap`, but the check where we compare with `Normal` is not working because we compare after the lowercase. 
So changed `setMapType` to compare the `MapType.Normal` with the non lowercased value.

Also noticed that `getMapType` was returning the google maps values, which are lowercased, so they don't match with the types and return undefined, so changed them to return our values with the first letter capitalized.

closes https://github.com/ionic-team/capacitor-plugins/issues/1726