### PR TITLE
getRawGoogleMapInstance

### DIFF
--- a/google-maps/README.md
+++ b/google-maps/README.md
@@ -301,6 +301,7 @@ export default MyMap;
 * [`setCamera(...)`](#setcamera)
 * [`getMapType()`](#getmaptype)
 * [`setMapType(...)`](#setmaptype)
+* [`getRawGoogleMapInstance()`](#getrawgooglemapinstance)
 * [`enableIndoorMaps(...)`](#enableindoormaps)
 * [`enableTrafficLayer(...)`](#enabletrafficlayer)
 * [`enableAccessibilityElements(...)`](#enableaccessibilityelements)
@@ -572,6 +573,19 @@ setMapType(mapType: MapType) => Promise<void>
 | Param         | Type                                        |
 | ------------- | ------------------------------------------- |
 | **`mapType`** | <code><a href="#maptype">MapType</a></code> |
+
+--------------------
+
+
+### getRawGoogleMapInstance(...)
+
+```typescript
+getRawGoogleMapInstance(id: string) => Promise<google.maps.Map>
+```
+
+| Param         | Type                                        |
+| ------------- | ------------------------------------------- |
+| **`id`** | <code>string</code> |
 
 --------------------
 

--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
@@ -611,6 +611,10 @@ class CapacitorGoogleMap(
         }
     }
 
+    fun getRawGoogleMapInstance(callback: (type: String, error: GoogleMapsError?) -> Unit) {
+        throw GoogleMapsError('Not implemented on Android platform.');
+    }
+
     fun enableIndoorMaps(enabled: Boolean, callback: (error: GoogleMapsError?) -> Unit) {
         try {
             googleMap ?: throw GoogleMapNotAvailable()

--- a/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.swift
+++ b/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.swift
@@ -579,6 +579,10 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate {
         }
     }
 
+    @objc func getRawGoogleMapInstance(_ call: CAPPluginCall) {
+        throw GoogleMapErrors.unhandledError("Not implemented on iOS platform");
+    }
+
     @objc func enableIndoorMaps(_ call: CAPPluginCall) {
         do {
             guard let id = call.getString("id") else {

--- a/google-maps/src/implementation.ts
+++ b/google-maps/src/implementation.ts
@@ -189,6 +189,7 @@ export interface CapacitorGoogleMapsPlugin extends Plugin {
   setCamera(args: CameraArgs): Promise<void>;
   getMapType(args: { id: string }): Promise<{ type: string }>;
   setMapType(args: MapTypeArgs): Promise<void>;
+  getRawGoogleMapInstance(id: string): google.maps.Map;
   enableIndoorMaps(args: IndoorMapArgs): Promise<void>;
   enableTrafficLayer(args: TrafficLayerArgs): Promise<void>;
   enableAccessibilityElements(args: AccElementsArgs): Promise<void>;

--- a/google-maps/src/implementation.ts
+++ b/google-maps/src/implementation.ts
@@ -112,6 +112,10 @@ export interface MapTypeArgs {
   mapType: MapType;
 }
 
+export interface RawGoogleMapInstanceArgs {
+  id: string
+}
+
 export interface IndoorMapArgs {
   id: string;
   enabled: boolean;
@@ -189,7 +193,7 @@ export interface CapacitorGoogleMapsPlugin extends Plugin {
   setCamera(args: CameraArgs): Promise<void>;
   getMapType(args: { id: string }): Promise<{ type: string }>;
   setMapType(args: MapTypeArgs): Promise<void>;
-  getRawGoogleMapInstance(id: string): google.maps.Map;
+  getRawGoogleMapInstance(args: RawGoogleMapInstanceArgs): google.maps.Map;
   enableIndoorMaps(args: IndoorMapArgs): Promise<void>;
   enableTrafficLayer(args: TrafficLayerArgs): Promise<void>;
   enableAccessibilityElements(args: AccElementsArgs): Promise<void>;

--- a/google-maps/src/map.ts
+++ b/google-maps/src/map.ts
@@ -55,6 +55,7 @@ export interface GoogleMapInterface {
    */
   getMapType(): Promise<MapType>;
   setMapType(mapType: MapType): Promise<void>;
+  getRawGoogleMapInstance(): Promise<google.maps.Map>;
   enableIndoorMaps(enabled: boolean): Promise<void>;
   enableTrafficLayer(enabled: boolean): Promise<void>;
   enableAccessibilityElements(enabled: boolean): Promise<void>;
@@ -523,6 +524,10 @@ export class GoogleMap {
       id: this.id,
       mapType,
     });
+  }
+
+  public async getRawGoogleMapInstance(): Promise<google.maps.Map> {
+    return await CapacitorGoogleMaps.getRawGoogleMapInstance(this.id);
   }
 
   /**

--- a/google-maps/src/web.ts
+++ b/google-maps/src/web.ts
@@ -173,6 +173,10 @@ export class CapacitorGoogleMapsWeb
     this.maps[_args.id].map.setMapTypeId(mapType);
   }
 
+  public getRawGoogleMapInstance(id: string): google.maps.Map {
+    return this.maps[id].map;
+  }
+
   async enableIndoorMaps(): Promise<void> {
     throw new Error('Method not supported on web.');
   }

--- a/google-maps/src/web.ts
+++ b/google-maps/src/web.ts
@@ -33,6 +33,7 @@ import type {
   RemoveCirclesArgs,
   AddPolylinesArgs,
   RemovePolylinesArgs,
+  RawGoogleMapInstanceArgs,
 } from './implementation';
 
 export class CapacitorGoogleMapsWeb
@@ -173,8 +174,8 @@ export class CapacitorGoogleMapsWeb
     this.maps[_args.id].map.setMapTypeId(mapType);
   }
 
-  public getRawGoogleMapInstance(id: string): google.maps.Map {
-    return this.maps[id].map;
+  public getRawGoogleMapInstance(_args: RawGoogleMapInstanceArgs): google.maps.Map {
+    return this.maps[_args.id].map;
   }
 
   async enableIndoorMaps(): Promise<void> {


### PR DESCRIPTION
This PR adds a getRawGoogleMapInstance method that exposes the underlying google.maps.Map instance when on web platforms.

This is especially useful when one wants to access specific features that are only available in the Google Map JS SDK or that haven't been implemented by this plugin. This provides an escape hatch that allows users to access all JS SDK features when those are only needed on web platforms, the only current workaround would be conditionally using this plugin to instead use the raw JS SDK on web platforms.

 

Context

We are migrating an existing app to Capacitor and are using advanced features from the JS SDK that cannot be implemented with the current interface. We don't need those advanced features in the native version of our app se we are fine to have them work only on the web.