### PR TITLE
chore: force typescript 4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "nx": "^16.3.1",
     "prettier": "~2.3.0",
     "prompts": "^2.3.2",
-    "glob": "^10.3.3"
+    "glob": "^10.3.3",
+    "typescript": "~4.1.5"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": {


### PR DESCRIPTION
Despite we have `"typescript": "~4.1.5"` in all plugin's package.json, 5.2.2 is being installed in the root and causing lint issues because typescript 5.2 removed something that we don't use but something we use might be using.

This PR adds `"typescript": "~4.1.5"` entry in the root package.json so it uses that version for all packages and lint gets fixed.