### PR TITLE
fix(google-maps): correctly apply CapacitorGoogleMapsPoint y value

### DIFF
--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPoint.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapsPoint.kt
@@ -12,7 +12,7 @@ class CapacitorGoogleMapsPoint() {
         }
 
         if(fromJSONObject.has("y")) {
-            this.x = fromJSONObject.getDouble("y").toFloat()
+            this.y = fromJSONObject.getDouble("y").toFloat()
         }
     }
 


### PR DESCRIPTION
Fix for marker point image coordinate, which is used to change anchor.

closes https://github.com/ionic-team/capacitor-plugins/issues/1812