### PR TITLE
fix(google-maps): Apply iconAnchor value to Marker anchor on Android

### DIFF
--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
@@ -772,6 +772,10 @@ class CapacitorGoogleMap(
         markerOptions.flat(marker.isFlat)
         markerOptions.draggable(marker.draggable)
         markerOptions.zIndex(marker.zIndex)
+        if (marker.iconAnchor != null) {
+            markerOptions.anchor(marker.iconAnchor!!.x, marker.iconAnchor!!.y)
+        }
+
 
         if (!marker.iconUrl.isNullOrEmpty()) {
             if (this.markerIcons.contains(marker.iconUrl)) {


### PR DESCRIPTION
While testing https://github.com/ionic-team/capacitor-plugins/pull/1800 I noticed that the fix had no effect because the iconAnchor values were not being applied to the Google Map's Marker object.