### PR TITLE
feat(google-maps): Support marker rotation

### DIFF
--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMap.kt
@@ -769,6 +769,7 @@ class CapacitorGoogleMap(
         markerOptions.title(marker.title)
         markerOptions.snippet(marker.snippet)
         markerOptions.alpha(marker.opacity)
+        markerOptions.rotation(marker.rotation)
         markerOptions.flat(marker.isFlat)
         markerOptions.draggable(marker.draggable)
         markerOptions.zIndex(marker.zIndex)

--- a/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapMarker.kt
+++ b/google-maps/android/src/main/java/com/capacitorjs/plugins/googlemaps/CapacitorGoogleMapMarker.kt
@@ -11,6 +11,7 @@ import org.json.JSONObject
 class CapacitorGoogleMapMarker(fromJSONObject: JSONObject): ClusterItem {
     var coordinate: LatLng = LatLng(0.0, 0.0)
     var opacity: Float = 1.0f
+    var rotation: Float = 1.0f
     private var title: String
     private var snippet: String
     private var zIndex: Float = 0.0f
@@ -36,6 +37,7 @@ class CapacitorGoogleMapMarker(fromJSONObject: JSONObject): ClusterItem {
         coordinate = LatLng(latLngObj.getDouble("lat"), latLngObj.getDouble("lng"))
         title = fromJSONObject.optString("title")
         opacity = fromJSONObject.optDouble("opacity", 1.0).toFloat()
+        rotation = fromJSONObject.optDouble("rotation", 0.0).toFloat()
         snippet = fromJSONObject.optString("snippet")
         isFlat = fromJSONObject.optBoolean("isFlat", false)
         iconUrl = fromJSONObject.optString("iconUrl")

--- a/google-maps/ios/Plugin/Marker.swift
+++ b/google-maps/ios/Plugin/Marker.swift
@@ -4,6 +4,7 @@ import Capacitor
 public struct Marker {
     let coordinate: LatLng
     let opacity: Float?
+    let rotation: Float?
     let title: String?
     let snippet: String?
     let isFlat: Bool?
@@ -55,6 +56,7 @@ public struct Marker {
 
         self.coordinate = LatLng(lat: lat, lng: lng)
         self.opacity = fromJSObject["opacity"] as? Float
+        self.rotation = fromJSObject["rotation"] as? Float
         self.title = fromJSObject["title"] as? String
         self.snippet = fromJSObject["snippet"] as? String
         self.isFlat = fromJSObject["isFlat"] as? Bool

--- a/google-maps/src/definitions.ts
+++ b/google-maps/src/definitions.ts
@@ -280,6 +280,12 @@ export interface Marker {
    */
   opacity?: number;
   /**
+   * The angle by which to rotate the marker, expressed clockwise in degrees
+   *
+   * @default 0
+   */
+  rotation?: number;
+  /**
    * Title, a short description of the overlay.
    */
   title?: string;


### PR DESCRIPTION
Add marker missing property "rotation", which has been stated in issue #1428