### PR TITLE
chore(ci): create dev releases for non-draft PRs

### DIFF
--- a/.github/workflows/dev-releases-for-pr.yml
+++ b/.github/workflows/dev-releases-for-pr.yml
@@ -1,0 +1,76 @@
+name: Release Dev Build for PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  setup:
+    if: github.event.pull_request.draft == false
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-12]
+    timeout-minutes: 30
+    outputs:
+      plugins: ${{ steps.packages.outputs.paths }}
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@ce177499ccf9fd2aded3b0426c97e5434c2e8a73
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Latest
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.18.0
+      - uses: actions/checkout@v3
+      - name: Restore Dependency Cache
+        id: cache-modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            */node_modules
+          key: ${{ runner.os }}-dependency-caching-${{ hashFiles('package.json', '*/package.json') }}
+      - run: npm install
+      - id: files
+        uses: tj-actions/changed-files@v37
+        with:
+          json: true
+          write_output_files: true
+      - id: catjson
+        run: |
+          echo "FILES_JSON=$(cat .github/outputs/all_changed_files.json)" >> $GITHUB_OUTPUT
+      - id: packages
+        uses: ./.github/actions/changed-packages
+        with:
+         files: ${{ steps.catjson.outputs.FILES_JSON }}
+
+  release-dev-of-plugins:
+    runs-on: macos-12
+    timeout-minutes: 30
+    needs:
+      - setup
+    strategy:
+      matrix:
+        plugin: ${{ fromJson(needs.setup.outputs.plugins) }}
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.18.0
+      - uses: actions/checkout@v3
+      - name: Restore Dependency Cache
+        id: cache-modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            */node_modules
+          key: ${{ runner.os }}-dependency-caching-${{ hashFiles('package.json', '*/package.json') }}
+      - run: npm install
+      - run: | 
+          npm version prerelease --no-git-tag-version -f --preid dev-$()-$(date +\"%Y%m%dT%H%M%S\")
+          npm publish --tag dev --dry-run
+        working-directory: ${{ matrix.plugin }}

--- a/.github/workflows/dev-releases-for-pr.yml
+++ b/.github/workflows/dev-releases-for-pr.yml
@@ -72,8 +72,10 @@ jobs:
             */node_modules
           key: ${{ runner.os }}-dependency-caching-${{ hashFiles('package.json', '*/package.json') }}
       - run: npm install
-      - run: | 
-          npm version prerelease --no-git-tag-version -f --preid dev-$(${{ github.event.pull_request.number }})-$(date +\"%Y%m%dT%H%M%S\")
+      - env: 
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: | 
+          npm version prerelease --no-git-tag-version -f --preid dev-$PR_NUMBER-$(date +\"%Y%m%dT%H%M%S\")
           npm publish --tag dev --dry-run
         working-directory: ${{ matrix.plugin }}
       - name: get-npm-version

--- a/.github/workflows/dev-releases-for-pr.yml
+++ b/.github/workflows/dev-releases-for-pr.yml
@@ -73,7 +73,7 @@ jobs:
           key: ${{ runner.os }}-dependency-caching-${{ hashFiles('package.json', '*/package.json') }}
       - run: npm install
       - run: | 
-          npm version prerelease --no-git-tag-version -f --preid dev-$()-$(date +\"%Y%m%dT%H%M%S\")
+          npm version prerelease --no-git-tag-version -f --preid dev-$(${{ github.event.pull_request.number }})-$(date +\"%Y%m%dT%H%M%S\")
           npm publish --tag dev --dry-run
         working-directory: ${{ matrix.plugin }}
       - name: get-npm-version

--- a/.github/workflows/dev-releases-for-pr.yml
+++ b/.github/workflows/dev-releases-for-pr.yml
@@ -51,6 +51,8 @@ jobs:
   release-dev-of-plugins:
     runs-on: macos-12
     timeout-minutes: 30
+    permissions:
+      pull-requests: write
     needs:
       - setup
     strategy:
@@ -74,3 +76,12 @@ jobs:
           npm version prerelease --no-git-tag-version -f --preid dev-$()-$(date +\"%Y%m%dT%H%M%S\")
           npm publish --tag dev --dry-run
         working-directory: ${{ matrix.plugin }}
+      - name: get-npm-version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
+        with:
+          path: ${{ matrix.plugin }}
+      - uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            Released dev build of ${{ matrix.plugin }} with dev version: ${{ steps.package-version.outputs.current-version }}


### PR DESCRIPTION
Going to leave `--dry-run` on for now to make sure its behaving correctly on Github Actions, this did work fine using `act` locally.