### PR TITLE
Removed direct boot awareness to fix silent crashes

### DIFF
--- a/local-notifications/android/src/main/AndroidManifest.xml
+++ b/local-notifications/android/src/main/AndroidManifest.xml
@@ -5,10 +5,8 @@
         <receiver android:name="com.capacitorjs.plugins.localnotifications.NotificationDismissReceiver" />
         <receiver
             android:name="com.capacitorjs.plugins.localnotifications.LocalNotificationRestoreReceiver"
-            android:directBootAware="true"
             android:exported="false">
             <intent-filter>
-                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
             </intent-filter>


### PR DESCRIPTION
In order to remove silent crashes during the startup of the device, this direct boot awareness was removed. 

This is the affected crash

```
Exception java.lang.IllegalStateException: SharedPreferences in credential encrypted storage are not available until after user is unlocked
  at android.app.ContextImpl.getSharedPreferences (ContextImpl.java:499)
  at android.app.ContextImpl.getSharedPreferences (ContextImpl.java:484)
  at android.content.ContextWrapper.getSharedPreferences (ContextWrapper.java:188)
  at com.google.android.gms.internal.appset.zzl.zzf (com.google.android.gms:play-services-appset@@16.0.0:1)
  at com.google.android.gms.internal.appset.zzl.zzd (com.google.android.gms:play-services-appset@@16.0.0:1)
  at com.google.android.gms.internal.appset.zzh.run
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1167)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:641)
  at java.lang.Thread.run (Thread.java:923)
```

which happens to all users that reboot their device