### PR TITLE
chore(ci): Pin @actions/http-client version to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,17 +23,18 @@
     "ci:publish:dev": "lerna publish prerelease --conventional-commits --conventional-prerelease --preid dev-$(date +\"%Y%m%dT%H%M%S\") --force-publish --no-changelog --no-git-tag-version --dist-tag dev --no-push --yes"
   },
   "devDependencies": {
-    "@types/node": "~18.11.19",
     "@actions/core": "^1.9.1",
+    "@actions/http-client": "2.1.1",
     "@ionic/prettier-config": "^1.0.1",
+    "@types/node": "~18.11.19",
     "@types/prompts": "^2.0.8",
     "cross-spawn": "^7.0.3",
     "esm": "^3.2.25",
+    "glob": "^10.3.3",
     "lerna": "^7.1.3",
     "nx": "^16.3.1",
     "prettier": "~2.3.0",
     "prompts": "^2.3.2",
-    "glob": "^10.3.3",
     "typescript": "~4.1.5"
   },
   "prettier": "@ionic/prettier-config",


### PR DESCRIPTION
An update on `@actions/http-client` that was released last week broke our CI, pinning the previous version for now.