### PR TITLE
fix(share): Address Android 14 changes

### DIFF
--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -42,7 +42,12 @@ public class SharePlugin extends Plugin {
                     }
                 }
             };
-        ContextCompat.registerReceiver(getContext(), broadcastReceiver, new IntentFilter(Intent.EXTRA_CHOSEN_COMPONENT), ContextCompat.RECEIVER_EXPORTED);
+        ContextCompat.registerReceiver(
+            getContext(),
+            broadcastReceiver,
+            new IntentFilter(Intent.EXTRA_CHOSEN_COMPONENT),
+            ContextCompat.RECEIVER_EXPORTED
+        );
     }
 
     @SuppressWarnings("deprecation")

--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.webkit.MimeTypeMap;
 import androidx.activity.result.ActivityResult;
+import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
@@ -41,7 +42,7 @@ public class SharePlugin extends Plugin {
                     }
                 }
             };
-        getActivity().registerReceiver(broadcastReceiver, new IntentFilter(Intent.EXTRA_CHOSEN_COMPONENT));
+        ContextCompat.registerReceiver(getContext(), broadcastReceiver, new IntentFilter(Intent.EXTRA_CHOSEN_COMPONENT), ContextCompat.RECEIVER_EXPORTED);
     }
 
     @SuppressWarnings("deprecation")
@@ -113,8 +114,11 @@ public class SharePlugin extends Plugin {
                 shareFiles(files, intent, call);
             }
             int flags = PendingIntent.FLAG_UPDATE_CURRENT;
-            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 flags = flags | PendingIntent.FLAG_MUTABLE;
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                flags = flags | PendingIntent.FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT;
             }
 
             // requestCode parameter is not used. Providing 0


### PR DESCRIPTION
This is the simpler solution I've found for addressing Android 14 changes.
I think `FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT` is safe to use because we only use the pending intent for getting the package of the app the user selected to share, we null the value right before the share starts so if somebody managed to get our `BroadcastReceived` it will have no effect.
But if somebody thinks this is unsafe I can try some different approach that doesn't use `FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT`.