### PR TITLE
docs(google-maps/geolocation)!: Removing deprecated usage descriptions for iOS

### DIFF
--- a/geolocation/README.md
+++ b/geolocation/README.md
@@ -13,8 +13,10 @@ npx cap sync
 
 Apple requires privacy descriptions to be specified in `Info.plist` for location information:
 
-- `NSLocationAlwaysUsageDescription` (`Privacy - Location Always Usage Description`)
+- `NSLocationAlwaysAndWhenInUseUsageDescription` (`Privacy - Location Always and When In Use Usage Description`)
 - `NSLocationWhenInUseUsageDescription` (`Privacy - Location When In Use Usage Description`)
+
+> `NSLocationAlwaysUsageDescription` is deprecated on iOS 11+.
 
 Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode
 

--- a/geolocation/README.md
+++ b/geolocation/README.md
@@ -13,10 +13,7 @@ npx cap sync
 
 Apple requires privacy descriptions to be specified in `Info.plist` for location information:
 
-- `NSLocationAlwaysAndWhenInUseUsageDescription` (`Privacy - Location Always and When In Use Usage Description`)
 - `NSLocationWhenInUseUsageDescription` (`Privacy - Location When In Use Usage Description`)
-
-> `NSLocationAlwaysUsageDescription` is deprecated on iOS 11+.
 
 Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode
 

--- a/google-maps/README.md
+++ b/google-maps/README.md
@@ -17,8 +17,10 @@ To use the Google Maps SDK on any platform, API keys associated with an account 
 
 The Google Maps SDK supports the use of showing the users current location via `enableCurrentLocation(bool)`. To use this, Apple requires privacy descriptions to be specified in `Info.plist`:
 
-- `NSLocationAlwaysUsageDescription` (`Privacy - Location Always Usage Description`)
+- `NSLocationAlwaysAndWhenInUseUsageDescription` (`Privacy - Location Always and When In Use Usage Description`)
 - `NSLocationWhenInUseUsageDescription` (`Privacy - Location When In Use Usage Description`)
+
+> `NSLocationAlwaysUsageDescription` is deprecated on iOS 11+.
 
 Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode.
 

--- a/google-maps/README.md
+++ b/google-maps/README.md
@@ -17,10 +17,7 @@ To use the Google Maps SDK on any platform, API keys associated with an account 
 
 The Google Maps SDK supports the use of showing the users current location via `enableCurrentLocation(bool)`. To use this, Apple requires privacy descriptions to be specified in `Info.plist`:
 
-- `NSLocationAlwaysAndWhenInUseUsageDescription` (`Privacy - Location Always and When In Use Usage Description`)
 - `NSLocationWhenInUseUsageDescription` (`Privacy - Location When In Use Usage Description`)
-
-> `NSLocationAlwaysUsageDescription` is deprecated on iOS 11+.
 
 Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode.
 


### PR DESCRIPTION
Removing `NSLocationAlwaysUsageDescription` in exchange for `NSLocationAlwaysAndWhenInUseUsageDescription` as its now [deprecated](https://developer.apple.com/documentation/bundleresources/information_property_list/nslocationalwaysusagedescription).