### PR TITLE
refactor(ios): remove removeAllListeners methods

### DIFF
--- a/app/ios/Plugin/AppPlugin.m
+++ b/app/ios/Plugin/AppPlugin.m
@@ -9,5 +9,4 @@ CAP_PLUGIN(AppPlugin, "App",
            CAP_PLUGIN_METHOD(getLaunchUrl, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getState, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(minimizeApp, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnPromise);
 )

--- a/browser/ios/Plugin/BrowserPlugin.m
+++ b/browser/ios/Plugin/BrowserPlugin.m
@@ -4,5 +4,4 @@
 CAP_PLUGIN(CAPBrowserPlugin, "Browser",
   CAP_PLUGIN_METHOD(open, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(close, CAPPluginReturnPromise);
-  CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnPromise);
 )

--- a/keyboard/ios/Plugin/KeyboardPlugin.m
+++ b/keyboard/ios/Plugin/KeyboardPlugin.m
@@ -11,5 +11,4 @@ CAP_PLUGIN(KeyboardPlugin, "Keyboard",
            CAP_PLUGIN_METHOD(setResizeMode, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getResizeMode, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setScroll, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnPromise);
 )

--- a/local-notifications/ios/Plugin/LocalNotificationsPlugin.m
+++ b/local-notifications/ios/Plugin/LocalNotificationsPlugin.m
@@ -15,5 +15,4 @@ CAP_PLUGIN(LocalNotificationsPlugin, "LocalNotifications",
     CAP_PLUGIN_METHOD(createChannel, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(deleteChannel, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(listChannels, CAPPluginReturnPromise);
-    CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnPromise);
 )

--- a/network/ios/Plugin/NetworkPlugin.m
+++ b/network/ios/Plugin/NetworkPlugin.m
@@ -5,5 +5,4 @@
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
 CAP_PLUGIN(CAPNetworkPlugin, "Network",
   CAP_PLUGIN_METHOD(getStatus, CAPPluginReturnPromise);
-  CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnPromise);
 )

--- a/push-notifications/ios/Plugin/PushNotificationsPlugin.m
+++ b/push-notifications/ios/Plugin/PushNotificationsPlugin.m
@@ -10,7 +10,6 @@ CAP_PLUGIN(PushNotificationsPlugin, "PushNotifications",
            CAP_PLUGIN_METHOD(requestPermissions, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getDeliveredNotifications, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(removeAllDeliveredNotifications, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(removeDeliveredNotifications, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(createChannel, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(listChannels, CAPPluginReturnPromise);

--- a/screen-orientation/ios/Plugin/ScreenOrientationPlugin.m
+++ b/screen-orientation/ios/Plugin/ScreenOrientationPlugin.m
@@ -5,5 +5,4 @@ CAP_PLUGIN(ScreenOrientationPlugin, "ScreenOrientation",
   CAP_PLUGIN_METHOD(orientation, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(lock, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(unlock, CAPPluginReturnPromise);
-  CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnPromise);
 )

--- a/screen-reader/ios/Plugin/ScreenReaderPlugin.m
+++ b/screen-reader/ios/Plugin/ScreenReaderPlugin.m
@@ -6,5 +6,4 @@
 CAP_PLUGIN(ScreenReaderPlugin, "ScreenReader",
            CAP_PLUGIN_METHOD(speak, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(isEnabled, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnPromise);
 )


### PR DESCRIPTION
removeAllListeners is going to work out of the box on Capacitor 6, no need for additional declarations