### PR TITLE
chore(ios): fix verify script

### DIFF
--- a/app/Package.resolved
+++ b/app/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/ionic-team/capacitor6-spm-test.git",
       "state" : {
         "branch" : "main",
-        "revision" : "b2e3d8d3ae3b421e5a0b22fd2a32347b40d1ed32"
+        "revision" : "a486602d573c65b717d0a3de0035cd879caad30d"
       }
     }
   ],

--- a/app/Package.swift
+++ b/app/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
             path: "ios/Sources/AppPlugin"),
         .testTarget(
             name: "AppPluginTests",
-            dependencies: ["AppPlugin"])
+            dependencies: ["AppPlugin"],
+            path: "ios/Tests/AppPluginTests")
     ]
 )

--- a/haptics/Package.resolved
+++ b/haptics/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/ionic-team/capacitor6-spm-test.git",
       "state" : {
         "branch" : "main",
-        "revision" : "b2e3d8d3ae3b421e5a0b22fd2a32347b40d1ed32"
+        "revision" : "a486602d573c65b717d0a3de0035cd879caad30d"
       }
     }
   ],

--- a/keyboard/Package.resolved
+++ b/keyboard/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/ionic-team/capacitor6-spm-test.git",
       "state" : {
         "branch" : "main",
-        "revision" : "b2e3d8d3ae3b421e5a0b22fd2a32347b40d1ed32"
+        "revision" : "a486602d573c65b717d0a3de0035cd879caad30d"
       }
     }
   ],

--- a/status-bar/Package.resolved
+++ b/status-bar/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/ionic-team/capacitor6-spm-test.git",
       "state" : {
         "branch" : "main",
-        "revision" : "b2e3d8d3ae3b421e5a0b22fd2a32347b40d1ed32"
+        "revision" : "a486602d573c65b717d0a3de0035cd879caad30d"
       }
     }
   ],


### PR DESCRIPTION
Update the `Package.resolved` file to use latest version of `capacitor6-spm-test`, as the one cached had a problem with the framework urls.

Also fix the app package as it didn't have the tests path configured properly.