### PR TITLE
docs(screen-reader): Use stateChange event in example code

### DIFF
--- a/screen-reader/README.md
+++ b/screen-reader/README.md
@@ -14,7 +14,7 @@ npx cap sync
 ```typescript
 import { ScreenReader } from '@capacitor/screen-reader';
 
-ScreenReader.addListener('screenReaderStateChange', ({ value }) => {
+ScreenReader.addListener('stateChange', ({ value }) => {
   console.log(`Screen reader is now ${value ? 'on' : 'off'}`);
 });
 


### PR DESCRIPTION
The example code snippet in docs for @capacitor/screen-reader does not compile. Use the `stateChange` event in example code rather than non-existent `screenReaderStateChange` event.