### PR TITLE
fix(google-maps): Emit onMyLocationClick on iOS

### DIFF
--- a/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.swift
+++ b/google-maps/ios/Plugin/CapacitorGoogleMapsPlugin.swift
@@ -1145,7 +1145,7 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate {
 
     // onMyLocationClick
     public func mapView(_ mapView: GMSMapView, didTapMyLocation location: CLLocationCoordinate2D) {
-        self.notifyListeners("onMyLocationButtonClick", data: [
+        self.notifyListeners("onMyLocationClick", data: [
             "mapId": self.findMapIdByMapView(mapView),
             "latitude": location.latitude,
             "longitude": location.longitude


### PR DESCRIPTION
Previously, the logic was emitting `onMyLocationButtonClick` events for both the button click and an actual position click. Looking at the adjacent comment and the Android code, it appears that this is a copy-paste error, and that `onMyLocationClick` should be emitted instead.