### PR TITLE
fix(camera): now we honor users selection order

### DIFF
--- a/camera/ios/Plugin/CameraPlugin.swift
+++ b/camera/ios/Plugin/CameraPlugin.swift
@@ -251,9 +251,12 @@ extension CameraPlugin: PHPickerViewControllerDelegate {
             return
         }
         if multiple {
-            var images: [ProcessedImage] = []
+            var images: [ProcessedImage?] = Array(repeating: nil, count: results.count)
             var processedCount = 0
-            for img in results {
+
+            for index in results.indices {
+                let img = results[index]
+
                 guard img.itemProvider.canLoadObject(ofClass: UIImage.self) else {
                     self.call?.reject("Error loading image")
                     return
@@ -266,11 +269,11 @@ extension CameraPlugin: PHPickerViewControllerDelegate {
                             asset = PHAsset.fetchAssets(withLocalIdentifiers: [assetId], options: nil).firstObject
                         }
                         if let processedImage = self?.processedImage(from: image, with: asset?.imageData) {
-                            images.append(processedImage)
+                            images[index] = processedImage
                         }
                         processedCount += 1
                         if processedCount == results.count {
-                            self?.returnImages(images)
+                            self?.returnImages(images.compactMap({ $0 }))
                         }
                     } else {
                         self?.call?.reject("Error loading image")


### PR DESCRIPTION
Fixed the issue described in #1950 that, due to a race condition, lead the underlying iOS implementation of the `Camera.pickImages` method to not honor the order in which users selected images. 

Fixes: #1950
