### PR TITLE
fix(camera): reject promise on web input cancel event

### DIFF
--- a/camera/src/web.ts
+++ b/camera/src/web.ts
@@ -88,7 +88,11 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
     }
   }
 
-  private fileInputExperience(options: ImageOptions, resolve: any, reject: any) {
+  private fileInputExperience(
+    options: ImageOptions,
+    resolve: any,
+    reject: any,
+  ) {
     let input = document.querySelector(
       '#_capacitor-camera-input',
     ) as HTMLInputElement;
@@ -148,7 +152,7 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
       input.addEventListener('cancel', (_e: any) => {
         reject(new CapacitorException('User cancelled photos app'));
         cleanup();
-      })
+      });
     }
 
     input.accept = 'image/*';
@@ -207,7 +211,7 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
       input.addEventListener('cancel', (_e: any) => {
         reject(new CapacitorException('User cancelled photos app'));
         cleanup();
-      })
+      });
     }
 
     input.accept = 'image/*';

--- a/camera/src/web.ts
+++ b/camera/src/web.ts
@@ -15,7 +15,7 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
     // eslint-disable-next-line no-async-promise-executor
     return new Promise<Photo>(async (resolve, reject) => {
       if (options.webUseInput || options.source === CameraSource.Photos) {
-        this.fileInputExperience(options, resolve);
+        this.fileInputExperience(options, resolve, reject);
       } else if (options.source === CameraSource.Prompt) {
         let actionSheet: any = document.querySelector('pwa-action-sheet');
         if (!actionSheet) {
@@ -31,7 +31,7 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
         actionSheet.addEventListener('onSelection', async (e: any) => {
           const selection = e.detail;
           if (selection === 0) {
-            this.fileInputExperience(options, resolve);
+            this.fileInputExperience(options, resolve, reject);
           } else {
             this.cameraExperience(options, resolve, reject);
           }
@@ -44,8 +44,8 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
 
   async pickImages(_options: GalleryImageOptions): Promise<GalleryPhotos> {
     // eslint-disable-next-line no-async-promise-executor
-    return new Promise<GalleryPhotos>(async resolve => {
-      this.multipleFileInputExperience(resolve);
+    return new Promise<GalleryPhotos>(async (resolve, reject) => {
+      this.multipleFileInputExperience(resolve, reject);
     });
   }
 
@@ -78,17 +78,17 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
 
         cameraModal.present();
       } catch (e) {
-        this.fileInputExperience(options, resolve);
+        this.fileInputExperience(options, resolve, reject);
       }
     } else {
       console.error(
         `Unable to load PWA Element 'pwa-camera-modal'. See the docs: https://capacitorjs.com/docs/web/pwa-elements.`,
       );
-      this.fileInputExperience(options, resolve);
+      this.fileInputExperience(options, resolve, reject);
     }
   }
 
-  private fileInputExperience(options: ImageOptions, resolve: any) {
+  private fileInputExperience(options: ImageOptions, resolve: any, reject: any) {
     let input = document.querySelector(
       '#_capacitor-camera-input',
     ) as HTMLInputElement;
@@ -145,6 +145,10 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
           cleanup();
         }
       });
+      input.addEventListener('cancel', (_e: any) => {
+        reject(new CapacitorException('User cancelled photos app'));
+        cleanup();
+      })
     }
 
     input.accept = 'image/*';
@@ -164,7 +168,7 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
     input.click();
   }
 
-  private multipleFileInputExperience(resolve: any) {
+  private multipleFileInputExperience(resolve: any, reject: any) {
     let input = document.querySelector(
       '#_capacitor-camera-input-multiple',
     ) as HTMLInputElement;
@@ -200,6 +204,10 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
         resolve({ photos });
         cleanup();
       });
+      input.addEventListener('cancel', (_e: any) => {
+        reject(new CapacitorException('User cancelled photos app'));
+        cleanup();
+      })
     }
 
     input.accept = 'image/*';


### PR DESCRIPTION
This PR adds promise rejections for the pwa camera plugin upon cancelation of the input element.

Previously, in the web implementation of the PWA camera plugin, the promise would remain unresolved if the user cancelled the input, as it was solely reliant on the 'change' event. This behaviour differed from the iOS/Android implementation, where the promise is rejected under similar circumstances.

closes https://github.com/ionic-team/capacitor-plugins/issues/1050
