### PR TITLE
docs(google-maps): adjust since for mapId properties

### DIFF
--- a/google-maps/README.md
+++ b/google-maps/README.md
@@ -899,9 +899,9 @@ For iOS and Android only the config options declared on <a href="#googlemapconfi
 | **`androidLiteMode`**  | <code>boolean</code>                      | Enables image-based lite mode on Android.                                                                                                                 | <code>false</code> |       |
 | **`devicePixelRatio`** | <code>number</code>                       | Override pixel ratio for native map.                                                                                                                      |                    |       |
 | **`styles`**           | <code>MapTypeStyle[] \| null</code>       | Styles to apply to each of the default map types. Note that for satellite, hybrid and terrain modes, these styles will only apply to labels and geometry. |                    | 4.3.0 |
-| **`mapId`**            | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for Web.        |                    | 6.0.0 |
-| **`androidMapId`**     | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for Android.    |                    | 6.0.0 |
-| **`iOSMapId`**         | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for iOS.        |                    | 6.0.0 |
+| **`mapId`**            | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for Web.        |                    | 5.4.0 |
+| **`androidMapId`**     | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for Android.    |                    | 5.4.0 |
+| **`iOSMapId`**         | <code>string</code>                       | A map id associated with a specific map style or feature. [Use Map IDs](https://developers.google.com/maps/documentation/get-map-id) Only for iOS.        |                    | 5.4.0 |
 
 
 #### LatLng

--- a/google-maps/src/definitions.ts
+++ b/google-maps/src/definitions.ts
@@ -198,7 +198,7 @@ export interface GoogleMapConfig extends google.maps.MapOptions {
    *
    * Only for Web.
    *
-   * @since 6.0.0
+   * @since 5.4.0
    */
   mapId?: string;
   /**
@@ -208,7 +208,7 @@ export interface GoogleMapConfig extends google.maps.MapOptions {
    *
    * Only for Android.
    *
-   * @since 6.0.0
+   * @since 5.4.0
    */
   androidMapId?: string;
   /**
@@ -218,7 +218,7 @@ export interface GoogleMapConfig extends google.maps.MapOptions {
    *
    * Only for iOS.
    *
-   * @since 6.0.0
+   * @since 5.4.0
    */
   iOSMapId?: string;
 }


### PR DESCRIPTION
mapId, androidMapId and iOSMapId are going to be available on next google-maps release (5.4.0), so adjust the `@since` for them.