### PR TITLE
feat(toast): Add durationMilliseconds option for iOS and Web

### DIFF
--- a/toast/README.md
+++ b/toast/README.md
@@ -59,10 +59,11 @@ Shows a Toast on the screen
 
 #### ShowOptions
 
-| Prop           | Type                                       | Description                                                                        | Default               | Since |
-| -------------- | ------------------------------------------ | ---------------------------------------------------------------------------------- | --------------------- | ----- |
-| **`text`**     | <code>string</code>                        | Text to display on the Toast                                                       |                       | 1.0.0 |
-| **`duration`** | <code>'short' \| 'long'</code>             | Duration of the Toast, either 'short' (2000ms) or 'long' (3500ms)                  | <code>'short'</code>  | 1.0.0 |
-| **`position`** | <code>'top' \| 'center' \| 'bottom'</code> | Position of the Toast. On Android 12 and newer all toasts are shown at the bottom. | <code>'bottom'</code> | 1.0.0 |
+| Prop                       | Type                                       | Description                                                                          | Default               | Since |
+| -------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------ | --------------------- | ----- |
+| **`text`**                 | <code>string</code>                        | Text to display on the Toast                                                         |                       | 1.0.0 |
+| **`duration`**             | <code>'short' \| 'long'</code>             | Duration of the Toast, either 'short' (2000ms) or 'long' (3500ms)                    | <code>'short'</code>  | 1.0.0 |
+| **`durationMilliseconds`** | <code>number</code>                        | Duration of the Toast in milliseconds. This option is only supported on iOS and Web. |                       | 6.0.0 |
+| **`position`**             | <code>'top' \| 'center' \| 'bottom'</code> | Position of the Toast. On Android 12 and newer all toasts are shown at the bottom.   | <code>'bottom'</code> | 1.0.0 |
 
 </docgen-api>

--- a/toast/ios/Sources/ToastPlugin/ToastPlugin.swift
+++ b/toast/ios/Sources/ToastPlugin/ToastPlugin.swift
@@ -14,8 +14,11 @@ public class ToastPlugin: CAPPlugin, CAPBridgedPlugin {
             call.reject("text must be provided and must be a string.")
             return
         }
-        let durationType = call.getString("duration", "short")
-        let duration = durationType == "long" ? 3500 : 2000
+        var duration = call.getInt("durationMilliseconds", 0)
+        if(duration <= 0) {
+            let durationType = call.getString("duration", "short")
+            duration = durationType == "long" ? 3500 : 2000
+        }
         let position = call.getString("position", "bottom")
 
         guard let viewController = bridge?.viewController else {

--- a/toast/src/definitions.ts
+++ b/toast/src/definitions.ts
@@ -24,6 +24,15 @@ export interface ShowOptions {
   duration?: 'short' | 'long';
 
   /**
+   * Duration of the Toast in milliseconds.
+   *
+   * This option is only supported on iOS and Web.
+   * 
+   * @since 6.0.0
+   */
+  durationMilliseconds?: number;
+
+  /**
    * Position of the Toast.
    *
    * On Android 12 and newer all toasts are shown at the bottom.

--- a/toast/src/web.ts
+++ b/toast/src/web.ts
@@ -6,7 +6,9 @@ export class ToastWeb extends WebPlugin implements ToastPlugin {
   async show(options: ShowOptions): Promise<void> {
     if (typeof document !== 'undefined') {
       let duration = 2000;
-      if (options.duration) {
+      if (options.durationMilliseconds) {
+        duration = options.durationMilliseconds;
+      } else if (options.duration) {
         duration = options.duration === 'long' ? 3500 : 2000;
       }
       const toast = document.createElement('pwa-toast') as any;


### PR DESCRIPTION
Implement 'durationMilliseconds' option for iOS and Web platforms in toast plugin.
This option enables setting the toast display duration in milliseconds for iOS and Web platforms.