### PR TITLE
feat(browser): implement close() method for android

### DIFF
--- a/browser/android/src/main/AndroidManifest.xml
+++ b/browser/android/src/main/AndroidManifest.xml
@@ -1,5 +1,11 @@
 
   <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+      <activity android:name=".BrowserControllerActivity"
+        android:exported="false"
+          android:theme="@android:style/Theme.Translucent.NoTitleBar"
+          android:launchMode="singleTask"/>
+    </application>
     <queries>
       <intent>
         <action android:name="android.support.customtabs.action.CustomTabsService" />

--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserControllerActivity.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserControllerActivity.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-
 import androidx.annotation.Nullable;
 
 public class BrowserControllerActivity extends Activity {
@@ -24,7 +23,7 @@ public class BrowserControllerActivity extends Activity {
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
-        if(intent.hasExtra("close")) {
+        if (intent.hasExtra("close")) {
             finish();
         }
     }
@@ -32,11 +31,10 @@ public class BrowserControllerActivity extends Activity {
     @Override
     protected void onResume() {
         super.onResume();
-        if(isCustomTabsOpen) {
+        if (isCustomTabsOpen) {
             isCustomTabsOpen = false;
             finish();
-        }
-        else {
+        } else {
             isCustomTabsOpen = true;
         }
     }

--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserControllerActivity.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserControllerActivity.java
@@ -1,0 +1,54 @@
+package com.capacitorjs.plugins.browser;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+
+public class BrowserControllerActivity extends Activity {
+
+    private boolean isCustomTabsOpen = false;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        isCustomTabsOpen = false;
+
+        if (BrowserPlugin.browserControllerListener != null) {
+            BrowserPlugin.browserControllerListener.onControllerReady(this);
+        }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        if(intent.hasExtra("close")) {
+            finish();
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if(isCustomTabsOpen) {
+            isCustomTabsOpen = false;
+            finish();
+        }
+        else {
+            isCustomTabsOpen = true;
+        }
+    }
+
+    public void open(Browser implementation, Uri url, Integer toolbarColor) {
+        implementation.open(url, toolbarColor);
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        isCustomTabsOpen = false;
+        BrowserPlugin.setBrowserControllerListener(null);
+    }
+}

--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserControllerListener.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserControllerListener.java
@@ -1,0 +1,5 @@
+package com.capacitorjs.plugins.browser;
+
+public interface BrowserControllerListener {
+    void onControllerReady(BrowserControllerActivity activity);
+}

--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
@@ -1,7 +1,6 @@
 package com.capacitorjs.plugins.browser;
 
 import android.content.ActivityNotFoundException;
-import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import com.getcapacitor.Logger;

--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
@@ -21,7 +21,7 @@ public class BrowserPlugin extends Plugin {
 
     public static void setBrowserControllerListener(BrowserControllerListener listener) {
         browserControllerListener = listener;
-        if(listener == null) {
+        if (listener == null) {
             browserControllerActivityInstance = null;
         }
     }
@@ -70,11 +70,13 @@ public class BrowserPlugin extends Plugin {
             getContext().startActivity(intent);
 
             Integer finalToolbarColor = toolbarColor;
-            setBrowserControllerListener(activity -> {
-                activity.open(implementation, url, finalToolbarColor);
-                browserControllerActivityInstance = activity;
-                call.resolve();
-            });
+            setBrowserControllerListener(
+                activity -> {
+                    activity.open(implementation, url, finalToolbarColor);
+                    browserControllerActivityInstance = activity;
+                    call.resolve();
+                }
+            );
         } catch (ActivityNotFoundException ex) {
             Logger.error(getLogTag(), ex.getLocalizedMessage(), null);
             call.reject("Unable to display URL");
@@ -84,7 +86,7 @@ public class BrowserPlugin extends Plugin {
 
     @PluginMethod
     public void close(PluginCall call) {
-        if(browserControllerActivityInstance != null) {
+        if (browserControllerActivityInstance != null) {
             browserControllerActivityInstance = null;
             Intent intent = new Intent(getContext(), BrowserControllerActivity.class);
             intent.putExtra("close", true);

--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
@@ -62,8 +62,6 @@ public class BrowserPlugin extends Plugin {
 
         // open the browser and finish
         try {
-            //implementation.open(url, toolbarColor);
-
             Intent intent = new Intent(getContext(), BrowserControllerActivity.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
@@ -1,6 +1,8 @@
 package com.capacitorjs.plugins.browser;
 
 import android.content.ActivityNotFoundException;
+import android.content.Context;
+import android.content.Intent;
 import android.net.Uri;
 import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
@@ -13,6 +15,16 @@ import com.getcapacitor.util.WebColor;
 public class BrowserPlugin extends Plugin {
 
     private Browser implementation;
+
+    public static BrowserControllerListener browserControllerListener;
+    private static BrowserControllerActivity browserControllerActivityInstance;
+
+    public static void setBrowserControllerListener(BrowserControllerListener listener) {
+        browserControllerListener = listener;
+        if(listener == null) {
+            browserControllerActivityInstance = null;
+        }
+    }
 
     public void load() {
         implementation = new Browser(getContext());
@@ -50,18 +62,35 @@ public class BrowserPlugin extends Plugin {
 
         // open the browser and finish
         try {
-            implementation.open(url, toolbarColor);
+            //implementation.open(url, toolbarColor);
+
+            Intent intent = new Intent(getContext(), BrowserControllerActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            getContext().startActivity(intent);
+
+            Integer finalToolbarColor = toolbarColor;
+            setBrowserControllerListener(activity -> {
+                activity.open(implementation, url, finalToolbarColor);
+                browserControllerActivityInstance = activity;
+                call.resolve();
+            });
         } catch (ActivityNotFoundException ex) {
             Logger.error(getLogTag(), ex.getLocalizedMessage(), null);
             call.reject("Unable to display URL");
             return;
         }
-        call.resolve();
     }
 
     @PluginMethod
     public void close(PluginCall call) {
-        call.unimplemented();
+        if(browserControllerActivityInstance != null) {
+            browserControllerActivityInstance = null;
+            Intent intent = new Intent(getContext(), BrowserControllerActivity.class);
+            intent.putExtra("close", true);
+            getContext().startActivity(intent);
+        }
+        call.resolve();
     }
 
     @Override


### PR DESCRIPTION
Closes #151 

This PR adds the `close()` method to the Android Browser Plugin.
We create an "intermediate" controller activity that launches the custom tabs, and when we want to close, we launch the same activity with `FLAG_ACTIVITY_CLEAR_TOP` which triggers `onNewIntent` where we can detect to destroy the activity & custom tabs, without sacrificing the existing activity stack.