### PR TITLE
bug(camera): pickImages() doesn't work first time on safari #1314

### DIFF
--- a/camera/src/index.ts
+++ b/camera/src/index.ts
@@ -1,9 +1,11 @@
 import { registerPlugin } from '@capacitor/core';
 
 import type { CameraPlugin } from './definitions';
+// See https://github.com/ionic-team/capacitor-plugins/issues/1314
+import * as web from './web';
 
 const Camera = registerPlugin<CameraPlugin>('Camera', {
-  web: () => import('./web').then(m => new m.CameraWeb()),
+  web: () => new web.CameraWeb(),
 });
 
 export * from './definitions';


### PR DESCRIPTION
Solution is, to early import the web package. Safari tracks time differences between click and code execution to open the input file picker.