### PR TITLE
fix(screen-orientation): set android's "landscape" equivalent

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 package-lock=false
-provenance=true
+provenance=false

--- a/screen-orientation/android/src/main/java/com/capacitorjs/plugins/screenorientation/ScreenOrientation.java
+++ b/screen-orientation/android/src/main/java/com/capacitorjs/plugins/screenorientation/ScreenOrientation.java
@@ -60,6 +60,7 @@ public class ScreenOrientation {
             case "any":
                 return ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
             case "landscape":
+                return ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
             case "landscape-primary":
                 return ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
             case "landscape-secondary":

--- a/screen-orientation/package.json
+++ b/screen-orientation/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@capacitor/screen-orientation",
+  "name": "kookaat-capacitor-screen-orientation",
   "version": "7.0.0",
   "description": "The Screen Orientation API provides methods to lock and unlock the screen orientation.",
   "main": "dist/plugin.cjs.js",


### PR DESCRIPTION
When using the "landscape" orientation type, the exact equivalent for it in Android is "sensor landscape", which supports both "primary" and "secondary", not just "landscape".