### PR TITLE
bug(@capacitor/screen-orientation): iOS landscape lock using incorrect mappings

### DIFF
--- a/screen-orientation/ios/Plugin/ScreenOrientation.swift
+++ b/screen-orientation/ios/Plugin/ScreenOrientation.swift
@@ -85,9 +85,11 @@ public class ScreenOrientation: NSObject {
         case "any":
             return UIInterfaceOrientationMask.all
         case "landscape", "landscape-primary":
-            return UIInterfaceOrientationMask.landscapeLeft
-        case "landscape-secondary":
+            // UIInterfaceOrientationMask.landscapeRight is the same as UIDeviceOrientation.landscapeLeft
             return UIInterfaceOrientationMask.landscapeRight
+        case "landscape-secondary":
+            // UIInterfaceOrientationMask.landscapeLeft is the same as UIDeviceOrientation.landscapeRight
+            return UIInterfaceOrientationMask.landscapeLeft
         case "portrait-secondary":
             return UIInterfaceOrientationMask.portraitUpsideDown
         default:
@@ -101,9 +103,15 @@ public class ScreenOrientation: NSObject {
         case "any":
             return UIInterfaceOrientation.unknown.rawValue
         case "landscape", "landscape-primary":
-            return UIInterfaceOrientation.landscapeLeft.rawValue
-        case "landscape-secondary":
+            // UIInterfaceOrientation.landscapeRight is the same as UIDeviceOrientation.landscapeLeft
+            // @see https://developer.apple.com/documentation/uikit/uiinterfaceorientation/landscaperight
+            // @see https://developer.apple.com/documentation/uikit/uideviceorientation/landscapeleft
             return UIInterfaceOrientation.landscapeRight.rawValue
+        case "landscape-secondary":
+            // UIInterfaceOrientation.landscapeLeft is the same as UIDeviceOrientation.landscapeRight
+            // @see https://developer.apple.com/documentation/uikit/uiinterfaceorientation/landscapeleft
+            // @see https://developer.apple.com/documentation/uikit/uideviceorientation/landscaperight
+            return UIInterfaceOrientation.landscapeLeft.rawValue
         case "portrait-secondary":
             return UIInterfaceOrientation.portraitUpsideDown.rawValue
         default:


### PR DESCRIPTION
Fixes #2022