### PR TITLE
fix for  RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED 

### DIFF
--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -41,7 +41,11 @@ public class SharePlugin extends Plugin {
                     }
                 }
             };
-        getActivity().registerReceiver(broadcastReceiver, new IntentFilter(Intent.EXTRA_CHOSEN_COMPONENT));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            getActivity().registerReceiver(broadcastReceiver, new IntentFilter(Intent.EXTRA_CHOSEN_COMPONENT), Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            getActivity().registerReceiver(broadcastReceiver, new IntentFilter(Intent.EXTRA_CHOSEN_COMPONENT));
+        }
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Fix for crash on Android API 34 

```
2024-03-11 00:55:48.951  6797-6797  Capacitor               myapp.com                   D  Registering plugin instance: Share
2024-03-11 00:55:48.953  6797-6797  AndroidRuntime          myapp.com                   D  Shutting down VM
2024-03-11 00:55:48.958  6797-6797  AndroidRuntime          myapp.com                   E  FATAL EXCEPTION: main
                                                                                                    Process: myapp.com, PID: 6797
                                                                                                    java.lang.RuntimeException: Unable to start activity ComponentInfo{myapp.com/myapp.com.MainActivity}: java.lang.SecurityException: myapp.com: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts
                                                                                                    	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3782)
                                                                                                    	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3922)
                                                                                                    	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:139)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:96)
                                                                                                    	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2443)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:106)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:205)
                                                                                                    	at android.os.Looper.loop(Looper.java:294)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8177)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
                                                                                                    Caused by: java.lang.SecurityException: myapp.com: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts
                                                                                                    	at android.os.Parcel.createExceptionOrNull(Parcel.java:3057)
                                                                                                    	at android.os.Parcel.createException(Parcel.java:3041)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:3024)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:2966)
                                                                                                    	at android.app.IActivityManager$Stub$Proxy.registerReceiverWithFeature(IActivityManager.java:5684)
                                                                                                    	at android.app.ContextImpl.registerReceiverInternal(ContextImpl.java:1852)
                                                                                                    	at android.app.ContextImpl.registerReceiver(ContextImpl.java:1792)
                                                                                                    	at android.app.ContextImpl.registerReceiver(ContextImpl.java:1780)
                                                                                                    	at android.content.ContextWrapper.registerReceiver(ContextWrapper.java:755)
                                                                                                    	at android.content.ContextWrapper.registerReceiver(ContextWrapper.java:755)
                                                                                                    	at com.capacitorjs.plugins.share.SharePlugin.load(SharePlugin.java:44)
                                                                                                    	at com.getcapacitor.PluginHandle.loadInstance(PluginHandle.java:115)
                                                                                                    	at com.getcapacitor.PluginHandle.load(PluginHandle.java:105)
                                                                                                    	at com.getcapacitor.PluginHandle.<init>(PluginHandle.java:65)
                                                                                                    	at com.getcapacitor.Bridge.registerPlugin(Bridge.java:664)
                                                                                                    	at com.getcapacitor.Bridge.registerAllPlugins(Bridge.java:620)
                                                                                                    	at com.getcapacitor.Bridge.<init>(Bridge.java:218)
                                                                                                    	at com.getcapacitor.Bridge.<init>(Unknown Source:0)
                                                                                                    	at com.getcapacitor.Bridge$Builder.create(Bridge.java:1539)
                                                                                                    	at com.getcapacitor.BridgeActivity.load(BridgeActivity.java:42)
                                                                                                    	at com.getcapacitor.BridgeActivity.onCreate(BridgeActivity.java:36)
                                                                                                    	at myapp.com.MainActivity.onCreate(MainActivity.java:78)
                                                                                                    	at android.app.Activity.performCreate(Activity.java:8595)
                                                                                                    	at android.app.Activity.performCreate(Activity.java:8573)
                                                                                                    	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1456)
                                                                                                    	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3764)
                                                                                                    	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3922) 
                                                                                                    	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103) 
                                                                                                    	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:139) 
                                                                                                    	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:96) 
                                                                                                    	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2443) 
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:106) 
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:205) 
                                                                                                    	at android.os.Looper.loop(Looper.java:294) 
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8177) 
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method) 
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552) 
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971) 
                                                                                                    Caused by: android.os.RemoteException: Remote stack trace:
                                                                                                    	at com.android.server.am.ActivityManagerService.registerReceiverWithFeature(ActivityManagerService.java:13927)
                                                                                                    	at android.app.IActivityManager$Stub.onTransact(IActivityManager.java:2570)
                                                                                                    	at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:2720)
                                                                                                    	at android.os.Binder.execTransactInternal(Binder.java:1339)
                                                                                                    	at android.os.Binder.execTransact(Binder.java:1275)

```