### PR TITLE
Fix java.lang.NullPointerException bug on Android

### DIFF
--- a/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/Filesystem.java
+++ b/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/Filesystem.java
@@ -153,7 +153,7 @@ public class Filesystem {
     public InputStream getInputStream(String path, String directory) throws IOException {
         if (directory == null) {
             Uri u = Uri.parse(path);
-            if (u.getScheme().equals("content")) {
+            if (u.getScheme() != null && u.getScheme().equals("content")) {
                 return this.context.getContentResolver().openInputStream(u);
             } else {
                 return new FileInputStream(new File(u.getPath()));


### PR DESCRIPTION
### Fixes "java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.equals(java.lang.Object)' on a null object reference"

Within `getInputStream()`, there is a conditional in which `.equals()` is invoked on `u.getScheme()`.

If `u.getScheme()` is `null` as can sometimes be the case, this will break functions such as `Filesystem.readFile()` by breaking the `getInputStream()` function.

This fix involves first checking that `u.getScheme() != null` within the conditional.