### PR TITLE
docs: add apple privacy manifest code requirements

### DIFF
--- a/device/README.md
+++ b/device/README.md
@@ -68,13 +68,13 @@ const logBatteryInfo = async () => {
 
 <docgen-index>
 
-- [`getId()`](#getid)
-- [`getInfo()`](#getinfo)
-- [`getBatteryInfo()`](#getbatteryinfo)
-- [`getLanguageCode()`](#getlanguagecode)
-- [`getLanguageTag()`](#getlanguagetag)
-- [Interfaces](#interfaces)
-- [Type Aliases](#type-aliases)
+* [`getId()`](#getid)
+* [`getInfo()`](#getinfo)
+* [`getBatteryInfo()`](#getbatteryinfo)
+* [`getLanguageCode()`](#getlanguagecode)
+* [`getLanguageTag()`](#getlanguagetag)
+* [Interfaces](#interfaces)
+* [Type Aliases](#type-aliases)
 
 </docgen-index>
 
@@ -93,7 +93,8 @@ Return an unique identifier for the device.
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### getInfo()
 
@@ -107,7 +108,8 @@ Return information about the underlying device/os/platform.
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### getBatteryInfo()
 
@@ -121,7 +123,8 @@ Return information about the battery.
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### getLanguageCode()
 
@@ -135,7 +138,8 @@ Get the device's current language locale code.
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### getLanguageTag()
 
@@ -149,15 +153,18 @@ Get the device's current language locale tag.
 
 **Since:** 4.0.0
 
----
+--------------------
+
 
 ### Interfaces
+
 
 #### DeviceId
 
 | Prop             | Type                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Since |
 | ---------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| **`identifier`** | <code>string</code> | The identifier of the device as available to the app. This identifier may change on modern mobile platforms that only allow per-app install ids. On iOS, the identifier is a UUID that uniquely identifies a device to the app’s vendor ([read more](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor)). on Android 8+, **the identifier is a 64-bit number (expressed as a hexadecimal string)**, unique to each combination of app-signing key, user, and device ([read more](https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID)). On web, a random identifier is generated and stored on localStorage for subsequent calls. If localStorage is not available a new random identifier will be generated on every call. | 1.0.0 |
+| **`identifier`** | <code>string</code> | The identifier of the device as available to the app. This identifier may change on modern mobile platforms that only allow per-app install ids. On iOS, the identifier is a UUID that uniquely identifies a device to the app’s vendor ([read more](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor)). on Android 8+, __the identifier is a 64-bit number (expressed as a hexadecimal string)__, unique to each combination of app-signing key, user, and device ([read more](https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID)). On web, a random identifier is generated and stored on localStorage for subsequent calls. If localStorage is not available a new random identifier will be generated on every call. | 1.0.0 |
+
 
 #### DeviceInfo
 
@@ -179,6 +186,7 @@ Get the device's current language locale tag.
 | **`realDiskTotal`**     | <code>number</code>                                         | The total size of the normal data storage path, in bytes.                                                                                                                                                                                                                                                                                        | 1.1.0 |
 | **`webViewVersion`**    | <code>string</code>                                         | The web view browser version                                                                                                                                                                                                                                                                                                                     | 1.0.0 |
 
+
 #### BatteryInfo
 
 | Prop               | Type                 | Description                                                       | Since |
@@ -186,11 +194,13 @@ Get the device's current language locale tag.
 | **`batteryLevel`** | <code>number</code>  | A percentage (0 to 1) indicating how much the battery is charged. | 1.0.0 |
 | **`isCharging`**   | <code>boolean</code> | Whether the device is charging.                                   | 1.0.0 |
 
+
 #### GetLanguageCodeResult
 
 | Prop        | Type                | Description                  | Since |
 | ----------- | ------------------- | ---------------------------- | ----- |
 | **`value`** | <code>string</code> | Two character language code. | 1.0.0 |
+
 
 #### LanguageTag
 
@@ -198,7 +208,9 @@ Get the device's current language locale tag.
 | ----------- | ------------------- | ----------------------------------------------- | ----- |
 | **`value`** | <code>string</code> | Returns a well-formed IETF BCP 47 language tag. | 4.0.0 |
 
+
 ### Type Aliases
+
 
 #### OperatingSystem
 

--- a/device/README.md
+++ b/device/README.md
@@ -9,7 +9,44 @@ npm install @capacitor/device
 npx cap sync
 ```
 
-## Example
+## Apple Privacy Manifest Requirements
+
+Apple mandates that app developers now specify approved reasons for API usage to enhance user privacy. By May 1st, 2024, it's required to include these reasons when submitting apps to the App Store Connect.
+
+When using this specific plugin in your app, you must create a `PrivacyInfo.xcprivacy` file in `/ios/App` or use the VS Code Extension to generate it, specifying the usage reasons.
+
+### Manual Steps
+
+1. In Xcode, select File > New File.
+2. Choose App Privacy File type under the Resource section.
+3. After creation, edit `PrivacyInfo.xcprivacy` to add the necessary keys and reasons, as detailed in [Apple's documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api).
+
+### Example PrivacyInfo.xcprivacy
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <!-- Add this dict entry to the array if the PrivacyInfo file already exists -->
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>85F4.1</string> <!-- Replace with the appropriate reason code -->
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>
+```
+
+## Example Plugin Usage
 
 ```typescript
 import { Device } from '@capacitor/device';
@@ -31,13 +68,13 @@ const logBatteryInfo = async () => {
 
 <docgen-index>
 
-* [`getId()`](#getid)
-* [`getInfo()`](#getinfo)
-* [`getBatteryInfo()`](#getbatteryinfo)
-* [`getLanguageCode()`](#getlanguagecode)
-* [`getLanguageTag()`](#getlanguagetag)
-* [Interfaces](#interfaces)
-* [Type Aliases](#type-aliases)
+- [`getId()`](#getid)
+- [`getInfo()`](#getinfo)
+- [`getBatteryInfo()`](#getbatteryinfo)
+- [`getLanguageCode()`](#getlanguagecode)
+- [`getLanguageTag()`](#getlanguagetag)
+- [Interfaces](#interfaces)
+- [Type Aliases](#type-aliases)
 
 </docgen-index>
 
@@ -56,8 +93,7 @@ Return an unique identifier for the device.
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### getInfo()
 
@@ -71,8 +107,7 @@ Return information about the underlying device/os/platform.
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### getBatteryInfo()
 
@@ -86,8 +121,7 @@ Return information about the battery.
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### getLanguageCode()
 
@@ -101,8 +135,7 @@ Get the device's current language locale code.
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### getLanguageTag()
 
@@ -116,18 +149,15 @@ Get the device's current language locale tag.
 
 **Since:** 4.0.0
 
---------------------
-
+---
 
 ### Interfaces
-
 
 #### DeviceId
 
 | Prop             | Type                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Since |
 | ---------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| **`identifier`** | <code>string</code> | The identifier of the device as available to the app. This identifier may change on modern mobile platforms that only allow per-app install ids. On iOS, the identifier is a UUID that uniquely identifies a device to the app’s vendor ([read more](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor)). on Android 8+, __the identifier is a 64-bit number (expressed as a hexadecimal string)__, unique to each combination of app-signing key, user, and device ([read more](https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID)). On web, a random identifier is generated and stored on localStorage for subsequent calls. If localStorage is not available a new random identifier will be generated on every call. | 1.0.0 |
-
+| **`identifier`** | <code>string</code> | The identifier of the device as available to the app. This identifier may change on modern mobile platforms that only allow per-app install ids. On iOS, the identifier is a UUID that uniquely identifies a device to the app’s vendor ([read more](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor)). on Android 8+, **the identifier is a 64-bit number (expressed as a hexadecimal string)**, unique to each combination of app-signing key, user, and device ([read more](https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID)). On web, a random identifier is generated and stored on localStorage for subsequent calls. If localStorage is not available a new random identifier will be generated on every call. | 1.0.0 |
 
 #### DeviceInfo
 
@@ -149,7 +179,6 @@ Get the device's current language locale tag.
 | **`realDiskTotal`**     | <code>number</code>                                         | The total size of the normal data storage path, in bytes.                                                                                                                                                                                                                                                                                        | 1.1.0 |
 | **`webViewVersion`**    | <code>string</code>                                         | The web view browser version                                                                                                                                                                                                                                                                                                                     | 1.0.0 |
 
-
 #### BatteryInfo
 
 | Prop               | Type                 | Description                                                       | Since |
@@ -157,13 +186,11 @@ Get the device's current language locale tag.
 | **`batteryLevel`** | <code>number</code>  | A percentage (0 to 1) indicating how much the battery is charged. | 1.0.0 |
 | **`isCharging`**   | <code>boolean</code> | Whether the device is charging.                                   | 1.0.0 |
 
-
 #### GetLanguageCodeResult
 
 | Prop        | Type                | Description                  | Since |
 | ----------- | ------------------- | ---------------------------- | ----- |
 | **`value`** | <code>string</code> | Two character language code. | 1.0.0 |
-
 
 #### LanguageTag
 
@@ -171,9 +198,7 @@ Get the device's current language locale tag.
 | ----------- | ------------------- | ----------------------------------------------- | ----- |
 | **`value`** | <code>string</code> | Returns a well-formed IETF BCP 47 language tag. | 4.0.0 |
 
-
 ### Type Aliases
-
 
 #### OperatingSystem
 

--- a/device/README.md
+++ b/device/README.md
@@ -15,11 +15,9 @@ Apple mandates that app developers now specify approved reasons for API usage to
 
 When using this specific plugin in your app, you must create a `PrivacyInfo.xcprivacy` file in `/ios/App` or use the VS Code Extension to generate it, specifying the usage reasons.
 
-### Manual Steps
+For detailed steps on how to do this, please see the [Capacitor Docs](https://capacitorjs.com/docs/ios/privacy-manifest).
 
-1. In Xcode, select File > New File.
-2. Choose App Privacy File type under the Resource section.
-3. After creation, edit `PrivacyInfo.xcprivacy` to add the necessary keys and reasons, as detailed in [Apple's documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api).
+**For this plugin, the required dictionary key is [NSPrivacyAccessedAPICategoryDiskSpace](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278397) and the recommended reason is [85F4.1](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278397).**
 
 ### Example PrivacyInfo.xcprivacy
 

--- a/device/README.md
+++ b/device/README.md
@@ -28,8 +28,6 @@ When using this specific plugin in your app, you must create a `PrivacyInfo.xcpr
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>NSPrivacyTracking</key>
-    <false/>
     <key>NSPrivacyAccessedAPITypes</key>
     <array>
       <!-- Add this dict entry to the array if the PrivacyInfo file already exists -->
@@ -38,7 +36,7 @@ When using this specific plugin in your app, you must create a `PrivacyInfo.xcpr
         <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
         <key>NSPrivacyAccessedAPITypeReasons</key>
         <array>
-          <string>85F4.1</string> <!-- Replace with the appropriate reason code -->
+          <string>85F4.1</string>
         </array>
       </dict>
     </array>

--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -15,11 +15,9 @@ Apple mandates that app developers now specify approved reasons for API usage to
 
 When using this specific plugin in your app, you must create a `PrivacyInfo.xcprivacy` file in `/ios/App` or use the VS Code Extension to generate it, specifying the usage reasons.
 
-### Manual Steps
+For detailed steps on how to do this, please see the [Capacitor Docs](https://capacitorjs.com/docs/ios/privacy-manifest).
 
-1. In Xcode, select File > New File.
-2. Choose App Privacy File type under the Resource section.
-3. After creation, edit `PrivacyInfo.xcprivacy` to add the necessary keys and reasons, as detailed in [Apple's documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api).
+**For this plugin, the required dictionary key is [NSPrivacyAccessedAPICategoryFileTimestamp](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278393) and the recommended reason is [CA617.1](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278393).**
 
 ### Example PrivacyInfo.xcprivacy
 

--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -123,25 +123,25 @@ const readFilePath = async () => {
 
 <docgen-index>
 
-- [`readFile(...)`](#readfile)
-- [`writeFile(...)`](#writefile)
-- [`appendFile(...)`](#appendfile)
-- [`deleteFile(...)`](#deletefile)
-- [`mkdir(...)`](#mkdir)
-- [`rmdir(...)`](#rmdir)
-- [`readdir(...)`](#readdir)
-- [`getUri(...)`](#geturi)
-- [`stat(...)`](#stat)
-- [`rename(...)`](#rename)
-- [`copy(...)`](#copy)
-- [`checkPermissions()`](#checkpermissions)
-- [`requestPermissions()`](#requestpermissions)
-- [`downloadFile(...)`](#downloadfile)
-- [`addListener('progress', ...)`](#addlistenerprogress-)
-- [`removeAllListeners()`](#removealllisteners)
-- [Interfaces](#interfaces)
-- [Type Aliases](#type-aliases)
-- [Enums](#enums)
+* [`readFile(...)`](#readfile)
+* [`writeFile(...)`](#writefile)
+* [`appendFile(...)`](#appendfile)
+* [`deleteFile(...)`](#deletefile)
+* [`mkdir(...)`](#mkdir)
+* [`rmdir(...)`](#rmdir)
+* [`readdir(...)`](#readdir)
+* [`getUri(...)`](#geturi)
+* [`stat(...)`](#stat)
+* [`rename(...)`](#rename)
+* [`copy(...)`](#copy)
+* [`checkPermissions()`](#checkpermissions)
+* [`requestPermissions()`](#requestpermissions)
+* [`downloadFile(...)`](#downloadfile)
+* [`addListener('progress', ...)`](#addlistenerprogress-)
+* [`removeAllListeners()`](#removealllisteners)
+* [Interfaces](#interfaces)
+* [Type Aliases](#type-aliases)
+* [Enums](#enums)
 
 </docgen-index>
 
@@ -164,7 +164,8 @@ Read a file from disk
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### writeFile(...)
 
@@ -182,7 +183,8 @@ Write a file to disk in the specified location on device
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### appendFile(...)
 
@@ -198,7 +200,8 @@ Append to a file on disk in the specified location on device
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### deleteFile(...)
 
@@ -214,7 +217,8 @@ Delete a file from disk
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### mkdir(...)
 
@@ -230,7 +234,8 @@ Create a directory.
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### rmdir(...)
 
@@ -246,7 +251,8 @@ Remove a directory
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### readdir(...)
 
@@ -264,7 +270,8 @@ Return a list of files from the directory (not recursive)
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### getUri(...)
 
@@ -282,7 +289,8 @@ Return full File URI for a path and directory
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### stat(...)
 
@@ -300,7 +308,8 @@ Return data about a file
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### rename(...)
 
@@ -316,7 +325,8 @@ Rename a file or directory
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### copy(...)
 
@@ -334,7 +344,8 @@ Copy a file or directory
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### checkPermissions()
 
@@ -350,7 +361,8 @@ Required on Android, only when using <a href="#directory">`Directory.Documents`<
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### requestPermissions()
 
@@ -366,7 +378,8 @@ Required on Android, only when using <a href="#directory">`Directory.Documents`<
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### downloadFile(...)
 
@@ -384,7 +397,8 @@ Perform a http request to a server and download the file to the specified destin
 
 **Since:** 5.1.0
 
----
+--------------------
+
 
 ### addListener('progress', ...)
 
@@ -403,7 +417,8 @@ Add a listener to file download progress events.
 
 **Since:** 5.1.0
 
----
+--------------------
+
 
 ### removeAllListeners()
 
@@ -415,15 +430,18 @@ Remove all listeners for this plugin.
 
 **Since:** 5.2.0
 
----
+--------------------
+
 
 ### Interfaces
+
 
 #### ReadFileResult
 
 | Prop       | Type                        | Description                                                                                                                            | Since |
 | ---------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- |
 | **`data`** | <code>string \| Blob</code> | The representation of the data contained in the file Note: Blob is only available on Web. On native, the data is returned as a string. | 1.0.0 |
+
 
 #### ReadFileOptions
 
@@ -433,11 +451,13 @@ Remove all listeners for this plugin.
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to read the file from                                                                                                              | 1.0.0 |
 | **`encoding`**  | <code><a href="#encoding">Encoding</a></code>   | The encoding to read the file in, if not provided, data is read as binary and returned as base64 encoded. Pass <a href="#encoding">Encoding.UTF8</a> to read data as string | 1.0.0 |
 
+
 #### WriteFileResult
 
 | Prop      | Type                | Description                             | Since |
 | --------- | ------------------- | --------------------------------------- | ----- |
 | **`uri`** | <code>string</code> | The uri where the file was written into | 1.0.0 |
+
 
 #### WriteFileOptions
 
@@ -449,6 +469,7 @@ Remove all listeners for this plugin.
 | **`encoding`**  | <code><a href="#encoding">Encoding</a></code>   | The encoding to write the file in. If not provided, data is written as base64 encoded. Pass <a href="#encoding">Encoding.UTF8</a> to write data as string |                    | 1.0.0 |
 | **`recursive`** | <code>boolean</code>                            | Whether to create any missing parent directories.                                                                                                         | <code>false</code> | 1.0.0 |
 
+
 #### AppendFileOptions
 
 | Prop            | Type                                            | Description                                                                                                                                               | Since |
@@ -458,12 +479,14 @@ Remove all listeners for this plugin.
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to store the file in                                                                                             | 1.0.0 |
 | **`encoding`**  | <code><a href="#encoding">Encoding</a></code>   | The encoding to write the file in. If not provided, data is written as base64 encoded. Pass <a href="#encoding">Encoding.UTF8</a> to write data as string | 1.0.0 |
 
+
 #### DeleteFileOptions
 
 | Prop            | Type                                            | Description                                                      | Since |
 | --------------- | ----------------------------------------------- | ---------------------------------------------------------------- | ----- |
 | **`path`**      | <code>string</code>                             | The path of the file to delete                                   | 1.0.0 |
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to delete the file from | 1.0.0 |
+
 
 #### MkdirOptions
 
@@ -473,6 +496,7 @@ Remove all listeners for this plugin.
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to make the new directory in |                    | 1.0.0 |
 | **`recursive`** | <code>boolean</code>                            | Whether to create any missing parent directories as well.             | <code>false</code> | 1.0.0 |
 
+
 #### RmdirOptions
 
 | Prop            | Type                                            | Description                                                           | Default            | Since |
@@ -481,11 +505,13 @@ Remove all listeners for this plugin.
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to remove the directory from |                    | 1.0.0 |
 | **`recursive`** | <code>boolean</code>                            | Whether to recursively remove the contents of the directory           | <code>false</code> | 1.0.0 |
 
+
 #### ReaddirResult
 
 | Prop        | Type                    | Description                                        | Since |
 | ----------- | ----------------------- | -------------------------------------------------- | ----- |
 | **`files`** | <code>FileInfo[]</code> | List of files and directories inside the directory | 1.0.0 |
+
 
 #### FileInfo
 
@@ -498,6 +524,7 @@ Remove all listeners for this plugin.
 | **`mtime`** | <code>number</code>                | Time of last modification in milliseconds.                                           | 4.0.0 |
 | **`uri`**   | <code>string</code>                | The uri of the file.                                                                 | 4.0.0 |
 
+
 #### ReaddirOptions
 
 | Prop            | Type                                            | Description                                                 | Since |
@@ -505,11 +532,13 @@ Remove all listeners for this plugin.
 | **`path`**      | <code>string</code>                             | The path of the directory to read                           | 1.0.0 |
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to list files from | 1.0.0 |
 
+
 #### GetUriResult
 
 | Prop      | Type                | Description         | Since |
 | --------- | ------------------- | ------------------- | ----- |
 | **`uri`** | <code>string</code> | The uri of the file | 1.0.0 |
+
 
 #### GetUriOptions
 
@@ -517,6 +546,7 @@ Remove all listeners for this plugin.
 | --------------- | ----------------------------------------------- | -------------------------------------------------------------- | ----- |
 | **`path`**      | <code>string</code>                             | The path of the file to get the URI for                        | 1.0.0 |
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to get the file under | 1.0.0 |
+
 
 #### StatResult
 
@@ -528,12 +558,14 @@ Remove all listeners for this plugin.
 | **`mtime`** | <code>number</code>                | Time of last modification in milliseconds.                                           | 1.0.0 |
 | **`uri`**   | <code>string</code>                | The uri of the file                                                                  | 1.0.0 |
 
+
 #### StatOptions
 
 | Prop            | Type                                            | Description                                                    | Since |
 | --------------- | ----------------------------------------------- | -------------------------------------------------------------- | ----- |
 | **`path`**      | <code>string</code>                             | The path of the file to get data about                         | 1.0.0 |
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to get the file under | 1.0.0 |
+
 
 #### CopyOptions
 
@@ -544,11 +576,13 @@ Remove all listeners for this plugin.
 | **`directory`**   | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> containing the existing file or directory                                                                           | 1.0.0 |
 | **`toDirectory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> containing the destination file or directory. If not supplied will use the 'directory' parameter as the destination | 1.0.0 |
 
+
 #### CopyResult
 
 | Prop      | Type                | Description                            | Since |
 | --------- | ------------------- | -------------------------------------- | ----- |
 | **`uri`** | <code>string</code> | The uri where the file was copied into | 4.0.0 |
+
 
 #### PermissionStatus
 
@@ -556,12 +590,14 @@ Remove all listeners for this plugin.
 | ------------------- | ----------------------------------------------------------- |
 | **`publicStorage`** | <code><a href="#permissionstate">PermissionState</a></code> |
 
+
 #### DownloadFileResult
 
 | Prop       | Type                | Description                                                          | Since |
 | ---------- | ------------------- | -------------------------------------------------------------------- | ----- |
 | **`path`** | <code>string</code> | The path the file was downloaded to.                                 | 5.1.0 |
 | **`blob`** | <code>Blob</code>   | The blob data of the downloaded file. This is only available on web. | 5.1.0 |
+
 
 #### DownloadFileOptions
 
@@ -572,11 +608,13 @@ Remove all listeners for this plugin.
 | **`progress`**  | <code>boolean</code>                            | An optional listener function to receive downloaded progress events. If this option is used, progress event should be dispatched on every chunk received. Chunks are throttled to every 100ms on Android/iOS to avoid slowdowns. |                    | 5.1.0 |
 | **`recursive`** | <code>boolean</code>                            | Whether to create any missing parent directories.                                                                                                                                                                                | <code>false</code> | 5.1.2 |
 
+
 #### PluginListenerHandle
 
 | Prop         | Type                                      |
 | ------------ | ----------------------------------------- |
 | **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
+
 
 #### ProgressStatus
 
@@ -586,15 +624,19 @@ Remove all listeners for this plugin.
 | **`bytes`**         | <code>number</code> | The number of bytes downloaded so far.               | 5.1.0 |
 | **`contentLength`** | <code>number</code> | The total number of bytes to download for this file. | 5.1.0 |
 
+
 ### Type Aliases
+
 
 #### RenameOptions
 
 <code><a href="#copyoptions">CopyOptions</a></code>
 
+
 #### PermissionState
 
 <code>'prompt' | 'prompt-with-rationale' | 'granted' | 'denied'</code>
+
 
 #### ProgressListener
 
@@ -602,7 +644,9 @@ A listener function that receives progress events.
 
 <code>(progress: <a href="#progressstatus">ProgressStatus</a>): void</code>
 
+
 ### Enums
+
 
 #### Directory
 
@@ -614,6 +658,7 @@ A listener function that receives progress events.
 | **`Cache`**           | <code>'CACHE'</code>            | The Cache directory. Can be deleted in cases of low memory, so use this directory to write app-specific files. that your app can re-create easily.                                                                                                                                                                                                                                                                                                                                        | 1.0.0 |
 | **`External`**        | <code>'EXTERNAL'</code>         | The external directory. On iOS it will use the Documents directory. On Android it's the directory on the primary shared/external storage device where the application can place persistent files it owns. These files are internal to the applications, and not typically visible to the user as media. Files will be deleted when the application is uninstalled.                                                                                                                        | 1.0.0 |
 | **`ExternalStorage`** | <code>'EXTERNAL_STORAGE'</code> | The external storage directory. On iOS it will use the Documents directory. On Android it's the primary shared/external storage directory. It's not accesible on Android 10 unless the app enables legacy External Storage by adding `android:requestLegacyExternalStorage="true"` in the `application` tag in the `AndroidManifest.xml`. It's not accesible on Android 11 or newer.                                                                                                      | 1.0.0 |
+
 
 #### Encoding
 

--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -9,9 +9,46 @@ npm install @capacitor/filesystem
 npx cap sync
 ```
 
+## Apple Privacy Manifest Requirements
+
+Apple mandates that app developers now specify approved reasons for API usage to enhance user privacy. By May 1st, 2024, it's required to include these reasons when submitting apps to the App Store Connect.
+
+When using this specific plugin in your app, you must create a `PrivacyInfo.xcprivacy` file in `/ios/App` or use the VS Code Extension to generate it, specifying the usage reasons.
+
+### Manual Steps
+
+1. In Xcode, select File > New File.
+2. Choose App Privacy File type under the Resource section.
+3. After creation, edit `PrivacyInfo.xcprivacy` to add the necessary keys and reasons, as detailed in [Apple's documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api).
+
+### Example PrivacyInfo.xcprivacy
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <!-- Add this dict entry to the array if the PrivacyInfo file already exists -->
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>C617.1</string> <!-- Replace with the appropriate reason code -->
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>
+```
+
 ## iOS
 
-To have files appear in the Files app, you must set the following keys to `YES` in `Info.plist`:
+To have files appear in the Files app, you must also set the following keys to `YES` in `Info.plist`:
 
 - `UIFileSharingEnabled` (`Application supports iTunes file sharing`)
 - `LSSupportsOpeningDocumentsInPlace` (`Supports opening documents in place`)
@@ -86,25 +123,25 @@ const readFilePath = async () => {
 
 <docgen-index>
 
-* [`readFile(...)`](#readfile)
-* [`writeFile(...)`](#writefile)
-* [`appendFile(...)`](#appendfile)
-* [`deleteFile(...)`](#deletefile)
-* [`mkdir(...)`](#mkdir)
-* [`rmdir(...)`](#rmdir)
-* [`readdir(...)`](#readdir)
-* [`getUri(...)`](#geturi)
-* [`stat(...)`](#stat)
-* [`rename(...)`](#rename)
-* [`copy(...)`](#copy)
-* [`checkPermissions()`](#checkpermissions)
-* [`requestPermissions()`](#requestpermissions)
-* [`downloadFile(...)`](#downloadfile)
-* [`addListener('progress', ...)`](#addlistenerprogress-)
-* [`removeAllListeners()`](#removealllisteners)
-* [Interfaces](#interfaces)
-* [Type Aliases](#type-aliases)
-* [Enums](#enums)
+- [`readFile(...)`](#readfile)
+- [`writeFile(...)`](#writefile)
+- [`appendFile(...)`](#appendfile)
+- [`deleteFile(...)`](#deletefile)
+- [`mkdir(...)`](#mkdir)
+- [`rmdir(...)`](#rmdir)
+- [`readdir(...)`](#readdir)
+- [`getUri(...)`](#geturi)
+- [`stat(...)`](#stat)
+- [`rename(...)`](#rename)
+- [`copy(...)`](#copy)
+- [`checkPermissions()`](#checkpermissions)
+- [`requestPermissions()`](#requestpermissions)
+- [`downloadFile(...)`](#downloadfile)
+- [`addListener('progress', ...)`](#addlistenerprogress-)
+- [`removeAllListeners()`](#removealllisteners)
+- [Interfaces](#interfaces)
+- [Type Aliases](#type-aliases)
+- [Enums](#enums)
 
 </docgen-index>
 
@@ -127,8 +164,7 @@ Read a file from disk
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### writeFile(...)
 
@@ -146,8 +182,7 @@ Write a file to disk in the specified location on device
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### appendFile(...)
 
@@ -163,8 +198,7 @@ Append to a file on disk in the specified location on device
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### deleteFile(...)
 
@@ -180,8 +214,7 @@ Delete a file from disk
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### mkdir(...)
 
@@ -197,8 +230,7 @@ Create a directory.
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### rmdir(...)
 
@@ -214,8 +246,7 @@ Remove a directory
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### readdir(...)
 
@@ -233,8 +264,7 @@ Return a list of files from the directory (not recursive)
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### getUri(...)
 
@@ -252,8 +282,7 @@ Return full File URI for a path and directory
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### stat(...)
 
@@ -271,8 +300,7 @@ Return data about a file
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### rename(...)
 
@@ -288,8 +316,7 @@ Rename a file or directory
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### copy(...)
 
@@ -307,8 +334,7 @@ Copy a file or directory
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### checkPermissions()
 
@@ -324,8 +350,7 @@ Required on Android, only when using <a href="#directory">`Directory.Documents`<
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### requestPermissions()
 
@@ -341,8 +366,7 @@ Required on Android, only when using <a href="#directory">`Directory.Documents`<
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### downloadFile(...)
 
@@ -360,8 +384,7 @@ Perform a http request to a server and download the file to the specified destin
 
 **Since:** 5.1.0
 
---------------------
-
+---
 
 ### addListener('progress', ...)
 
@@ -380,8 +403,7 @@ Add a listener to file download progress events.
 
 **Since:** 5.1.0
 
---------------------
-
+---
 
 ### removeAllListeners()
 
@@ -393,18 +415,15 @@ Remove all listeners for this plugin.
 
 **Since:** 5.2.0
 
---------------------
-
+---
 
 ### Interfaces
-
 
 #### ReadFileResult
 
 | Prop       | Type                        | Description                                                                                                                            | Since |
 | ---------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- |
 | **`data`** | <code>string \| Blob</code> | The representation of the data contained in the file Note: Blob is only available on Web. On native, the data is returned as a string. | 1.0.0 |
-
 
 #### ReadFileOptions
 
@@ -414,13 +433,11 @@ Remove all listeners for this plugin.
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to read the file from                                                                                                              | 1.0.0 |
 | **`encoding`**  | <code><a href="#encoding">Encoding</a></code>   | The encoding to read the file in, if not provided, data is read as binary and returned as base64 encoded. Pass <a href="#encoding">Encoding.UTF8</a> to read data as string | 1.0.0 |
 
-
 #### WriteFileResult
 
 | Prop      | Type                | Description                             | Since |
 | --------- | ------------------- | --------------------------------------- | ----- |
 | **`uri`** | <code>string</code> | The uri where the file was written into | 1.0.0 |
-
 
 #### WriteFileOptions
 
@@ -432,7 +449,6 @@ Remove all listeners for this plugin.
 | **`encoding`**  | <code><a href="#encoding">Encoding</a></code>   | The encoding to write the file in. If not provided, data is written as base64 encoded. Pass <a href="#encoding">Encoding.UTF8</a> to write data as string |                    | 1.0.0 |
 | **`recursive`** | <code>boolean</code>                            | Whether to create any missing parent directories.                                                                                                         | <code>false</code> | 1.0.0 |
 
-
 #### AppendFileOptions
 
 | Prop            | Type                                            | Description                                                                                                                                               | Since |
@@ -442,14 +458,12 @@ Remove all listeners for this plugin.
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to store the file in                                                                                             | 1.0.0 |
 | **`encoding`**  | <code><a href="#encoding">Encoding</a></code>   | The encoding to write the file in. If not provided, data is written as base64 encoded. Pass <a href="#encoding">Encoding.UTF8</a> to write data as string | 1.0.0 |
 
-
 #### DeleteFileOptions
 
 | Prop            | Type                                            | Description                                                      | Since |
 | --------------- | ----------------------------------------------- | ---------------------------------------------------------------- | ----- |
 | **`path`**      | <code>string</code>                             | The path of the file to delete                                   | 1.0.0 |
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to delete the file from | 1.0.0 |
-
 
 #### MkdirOptions
 
@@ -459,7 +473,6 @@ Remove all listeners for this plugin.
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to make the new directory in |                    | 1.0.0 |
 | **`recursive`** | <code>boolean</code>                            | Whether to create any missing parent directories as well.             | <code>false</code> | 1.0.0 |
 
-
 #### RmdirOptions
 
 | Prop            | Type                                            | Description                                                           | Default            | Since |
@@ -468,13 +481,11 @@ Remove all listeners for this plugin.
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to remove the directory from |                    | 1.0.0 |
 | **`recursive`** | <code>boolean</code>                            | Whether to recursively remove the contents of the directory           | <code>false</code> | 1.0.0 |
 
-
 #### ReaddirResult
 
 | Prop        | Type                    | Description                                        | Since |
 | ----------- | ----------------------- | -------------------------------------------------- | ----- |
 | **`files`** | <code>FileInfo[]</code> | List of files and directories inside the directory | 1.0.0 |
-
 
 #### FileInfo
 
@@ -487,7 +498,6 @@ Remove all listeners for this plugin.
 | **`mtime`** | <code>number</code>                | Time of last modification in milliseconds.                                           | 4.0.0 |
 | **`uri`**   | <code>string</code>                | The uri of the file.                                                                 | 4.0.0 |
 
-
 #### ReaddirOptions
 
 | Prop            | Type                                            | Description                                                 | Since |
@@ -495,13 +505,11 @@ Remove all listeners for this plugin.
 | **`path`**      | <code>string</code>                             | The path of the directory to read                           | 1.0.0 |
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to list files from | 1.0.0 |
 
-
 #### GetUriResult
 
 | Prop      | Type                | Description         | Since |
 | --------- | ------------------- | ------------------- | ----- |
 | **`uri`** | <code>string</code> | The uri of the file | 1.0.0 |
-
 
 #### GetUriOptions
 
@@ -509,7 +517,6 @@ Remove all listeners for this plugin.
 | --------------- | ----------------------------------------------- | -------------------------------------------------------------- | ----- |
 | **`path`**      | <code>string</code>                             | The path of the file to get the URI for                        | 1.0.0 |
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to get the file under | 1.0.0 |
-
 
 #### StatResult
 
@@ -521,14 +528,12 @@ Remove all listeners for this plugin.
 | **`mtime`** | <code>number</code>                | Time of last modification in milliseconds.                                           | 1.0.0 |
 | **`uri`**   | <code>string</code>                | The uri of the file                                                                  | 1.0.0 |
 
-
 #### StatOptions
 
 | Prop            | Type                                            | Description                                                    | Since |
 | --------------- | ----------------------------------------------- | -------------------------------------------------------------- | ----- |
 | **`path`**      | <code>string</code>                             | The path of the file to get data about                         | 1.0.0 |
 | **`directory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> to get the file under | 1.0.0 |
-
 
 #### CopyOptions
 
@@ -539,13 +544,11 @@ Remove all listeners for this plugin.
 | **`directory`**   | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> containing the existing file or directory                                                                           | 1.0.0 |
 | **`toDirectory`** | <code><a href="#directory">Directory</a></code> | The <a href="#directory">`Directory`</a> containing the destination file or directory. If not supplied will use the 'directory' parameter as the destination | 1.0.0 |
 
-
 #### CopyResult
 
 | Prop      | Type                | Description                            | Since |
 | --------- | ------------------- | -------------------------------------- | ----- |
 | **`uri`** | <code>string</code> | The uri where the file was copied into | 4.0.0 |
-
 
 #### PermissionStatus
 
@@ -553,14 +556,12 @@ Remove all listeners for this plugin.
 | ------------------- | ----------------------------------------------------------- |
 | **`publicStorage`** | <code><a href="#permissionstate">PermissionState</a></code> |
 
-
 #### DownloadFileResult
 
 | Prop       | Type                | Description                                                          | Since |
 | ---------- | ------------------- | -------------------------------------------------------------------- | ----- |
 | **`path`** | <code>string</code> | The path the file was downloaded to.                                 | 5.1.0 |
 | **`blob`** | <code>Blob</code>   | The blob data of the downloaded file. This is only available on web. | 5.1.0 |
-
 
 #### DownloadFileOptions
 
@@ -571,13 +572,11 @@ Remove all listeners for this plugin.
 | **`progress`**  | <code>boolean</code>                            | An optional listener function to receive downloaded progress events. If this option is used, progress event should be dispatched on every chunk received. Chunks are throttled to every 100ms on Android/iOS to avoid slowdowns. |                    | 5.1.0 |
 | **`recursive`** | <code>boolean</code>                            | Whether to create any missing parent directories.                                                                                                                                                                                | <code>false</code> | 5.1.2 |
 
-
 #### PluginListenerHandle
 
 | Prop         | Type                                      |
 | ------------ | ----------------------------------------- |
 | **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
-
 
 #### ProgressStatus
 
@@ -587,19 +586,15 @@ Remove all listeners for this plugin.
 | **`bytes`**         | <code>number</code> | The number of bytes downloaded so far.               | 5.1.0 |
 | **`contentLength`** | <code>number</code> | The total number of bytes to download for this file. | 5.1.0 |
 
-
 ### Type Aliases
-
 
 #### RenameOptions
 
 <code><a href="#copyoptions">CopyOptions</a></code>
 
-
 #### PermissionState
 
 <code>'prompt' | 'prompt-with-rationale' | 'granted' | 'denied'</code>
-
 
 #### ProgressListener
 
@@ -607,9 +602,7 @@ A listener function that receives progress events.
 
 <code>(progress: <a href="#progressstatus">ProgressStatus</a>): void</code>
 
-
 ### Enums
-
 
 #### Directory
 
@@ -621,7 +614,6 @@ A listener function that receives progress events.
 | **`Cache`**           | <code>'CACHE'</code>            | The Cache directory. Can be deleted in cases of low memory, so use this directory to write app-specific files. that your app can re-create easily.                                                                                                                                                                                                                                                                                                                                        | 1.0.0 |
 | **`External`**        | <code>'EXTERNAL'</code>         | The external directory. On iOS it will use the Documents directory. On Android it's the directory on the primary shared/external storage device where the application can place persistent files it owns. These files are internal to the applications, and not typically visible to the user as media. Files will be deleted when the application is uninstalled.                                                                                                                        | 1.0.0 |
 | **`ExternalStorage`** | <code>'EXTERNAL_STORAGE'</code> | The external storage directory. On iOS it will use the Documents directory. On Android it's the primary shared/external storage directory. It's not accesible on Android 10 unless the app enables legacy External Storage by adding `android:requestLegacyExternalStorage="true"` in the `application` tag in the `AndroidManifest.xml`. It's not accesible on Android 11 or newer.                                                                                                      | 1.0.0 |
-
 
 #### Encoding
 

--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -17,7 +17,7 @@ When using this specific plugin in your app, you must create a `PrivacyInfo.xcpr
 
 For detailed steps on how to do this, please see the [Capacitor Docs](https://capacitorjs.com/docs/ios/privacy-manifest).
 
-**For this plugin, the required dictionary key is [NSPrivacyAccessedAPICategoryFileTimestamp](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278393) and the recommended reason is [CA617.1](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278393).**
+**For this plugin, the required dictionary key is [NSPrivacyAccessedAPICategoryFileTimestamp](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278393) and the recommended reason is [C617.1](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278393).**
 
 ### Example PrivacyInfo.xcprivacy
 

--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -28,8 +28,6 @@ When using this specific plugin in your app, you must create a `PrivacyInfo.xcpr
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>NSPrivacyTracking</key>
-    <false/>
     <key>NSPrivacyAccessedAPITypes</key>
     <array>
       <!-- Add this dict entry to the array if the PrivacyInfo file already exists -->
@@ -38,7 +36,7 @@ When using this specific plugin in your app, you must create a `PrivacyInfo.xcpr
         <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
         <key>NSPrivacyAccessedAPITypeReasons</key>
         <array>
-          <string>C617.1</string> <!-- Replace with the appropriate reason code -->
+          <string>C617.1</string>
         </array>
       </dict>
     </array>

--- a/preferences/README.md
+++ b/preferences/README.md
@@ -29,11 +29,9 @@ Apple mandates that app developers now specify approved reasons for API usage to
 
 When using this specific plugin in your app, you must create a `PrivacyInfo.xcprivacy` file in `/ios/App` or use the VS Code Extension to generate it, specifying the usage reasons.
 
-### Manual Steps
+For detailed steps on how to do this, please see the [Capacitor Docs](https://capacitorjs.com/docs/ios/privacy-manifest).
 
-1. In Xcode, select File > New File.
-2. Choose App Privacy File type under the Resource section.
-3. After creation, edit `PrivacyInfo.xcprivacy` to add the necessary keys and reasons, as detailed in [Apple's documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api).
+**For this plugin, the required dictionary key is [NSPrivacyAccessedAPICategoryUserDefaults](hhttps://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401) and the recommended reason is [CA92.1](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401).**
 
 ### Example PrivacyInfo.xcprivacy
 

--- a/preferences/README.md
+++ b/preferences/README.md
@@ -93,15 +93,15 @@ This method can also be used to store non-string values, such as numbers and boo
 
 <docgen-index>
 
-- [`configure(...)`](#configure)
-- [`get(...)`](#get)
-- [`set(...)`](#set)
-- [`remove(...)`](#remove)
-- [`clear()`](#clear)
-- [`keys()`](#keys)
-- [`migrate()`](#migrate)
-- [`removeOld()`](#removeold)
-- [Interfaces](#interfaces)
+* [`configure(...)`](#configure)
+* [`get(...)`](#get)
+* [`set(...)`](#set)
+* [`remove(...)`](#remove)
+* [`clear()`](#clear)
+* [`keys()`](#keys)
+* [`migrate()`](#migrate)
+* [`removeOld()`](#removeold)
+* [Interfaces](#interfaces)
 
 </docgen-index>
 
@@ -124,7 +124,8 @@ Options that are `undefined` will not be used.
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### get(...)
 
@@ -142,7 +143,8 @@ Get the value from preferences of a given key.
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### set(...)
 
@@ -158,7 +160,8 @@ Set the value in preferences for a given key.
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### remove(...)
 
@@ -174,7 +177,8 @@ Remove the value from preferences for a given key, if any.
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### clear()
 
@@ -186,7 +190,8 @@ Clear keys and values from preferences.
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### keys()
 
@@ -200,7 +205,8 @@ Return the list of known keys in preferences.
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### migrate()
 
@@ -218,7 +224,8 @@ To remove the old data after being migrated, call removeOld().
 
 **Since:** 1.0.0
 
----
+--------------------
+
 
 ### removeOld()
 
@@ -230,9 +237,11 @@ Removes old data with `_cap_` prefix from the Capacitor 2 Storage plugin.
 
 **Since:** 1.1.0
 
----
+--------------------
+
 
 ### Interfaces
+
 
 #### ConfigureOptions
 
@@ -240,17 +249,20 @@ Removes old data with `_cap_` prefix from the Capacitor 2 Storage plugin.
 | ----------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ----- |
 | **`group`** | <code>string</code> | Set the preferences group. Preferences groups are used to organize key/value pairs. Using the value 'NativeStorage' provides backwards-compatibility with [`cordova-plugin-nativestorage`](https://www.npmjs.com/package/cordova-plugin-nativestorage). WARNING: The `clear()` method can delete unintended values when using the 'NativeStorage' group. | <code>CapacitorStorage</code> | 1.0.0 |
 
+
 #### GetResult
 
 | Prop        | Type                        | Description                                                                                                                       | Since |
 | ----------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----- |
 | **`value`** | <code>string \| null</code> | The value from preferences associated with the given key. If a value was not previously set or was removed, value will be `null`. | 1.0.0 |
 
+
 #### GetOptions
 
 | Prop      | Type                | Description                                       | Since |
 | --------- | ------------------- | ------------------------------------------------- | ----- |
 | **`key`** | <code>string</code> | The key whose value to retrieve from preferences. | 1.0.0 |
+
 
 #### SetOptions
 
@@ -259,17 +271,20 @@ Removes old data with `_cap_` prefix from the Capacitor 2 Storage plugin.
 | **`key`**   | <code>string</code> | The key to associate with the value being set in preferences. | 1.0.0 |
 | **`value`** | <code>string</code> | The value to set in preferences with the associated key.      | 1.0.0 |
 
+
 #### RemoveOptions
 
 | Prop      | Type                | Description                                     | Since |
 | --------- | ------------------- | ----------------------------------------------- | ----- |
 | **`key`** | <code>string</code> | The key whose value to remove from preferences. | 1.0.0 |
 
+
 #### KeysResult
 
 | Prop       | Type                  | Description                    | Since |
 | ---------- | --------------------- | ------------------------------ | ----- |
 | **`keys`** | <code>string[]</code> | The known keys in preferences. | 1.0.0 |
+
 
 #### MigrateResult
 

--- a/preferences/README.md
+++ b/preferences/README.md
@@ -31,7 +31,7 @@ When using this specific plugin in your app, you must create a `PrivacyInfo.xcpr
 
 For detailed steps on how to do this, please see the [Capacitor Docs](https://capacitorjs.com/docs/ios/privacy-manifest).
 
-**For this plugin, the required dictionary key is [NSPrivacyAccessedAPICategoryUserDefaults](hhttps://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401) and the recommended reason is [CA92.1](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401).**
+**For this plugin, the required dictionary key is [NSPrivacyAccessedAPICategoryUserDefaults](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401) and the recommended reason is [CA92.1](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401).**
 
 ### Example PrivacyInfo.xcprivacy
 

--- a/preferences/README.md
+++ b/preferences/README.md
@@ -23,7 +23,44 @@ npm install @capacitor/preferences
 npx cap sync
 ```
 
-## Example
+## Apple Privacy Manifest Requirements
+
+Apple mandates that app developers now specify approved reasons for API usage to enhance user privacy. By May 1st, 2024, it's required to include these reasons when submitting apps to the App Store Connect.
+
+When using this specific plugin in your app, you must create a `PrivacyInfo.xcprivacy` file in `/ios/App` or use the VS Code Extension to generate it, specifying the usage reasons.
+
+### Manual Steps
+
+1. In Xcode, select File > New File.
+2. Choose App Privacy File type under the Resource section.
+3. After creation, edit `PrivacyInfo.xcprivacy` to add the necessary keys and reasons, as detailed in [Apple's documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api).
+
+### Example PrivacyInfo.xcprivacy
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <!-- Add this dict entry to the array if the PrivacyInfo file already exists -->
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>CA92.1</string> <!-- Replace with the appropriate reason code -->
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>
+```
+
+## Example Plugin Usage
 
 ```typescript
 import { Preferences } from '@capacitor/preferences';
@@ -56,15 +93,15 @@ This method can also be used to store non-string values, such as numbers and boo
 
 <docgen-index>
 
-* [`configure(...)`](#configure)
-* [`get(...)`](#get)
-* [`set(...)`](#set)
-* [`remove(...)`](#remove)
-* [`clear()`](#clear)
-* [`keys()`](#keys)
-* [`migrate()`](#migrate)
-* [`removeOld()`](#removeold)
-* [Interfaces](#interfaces)
+- [`configure(...)`](#configure)
+- [`get(...)`](#get)
+- [`set(...)`](#set)
+- [`remove(...)`](#remove)
+- [`clear()`](#clear)
+- [`keys()`](#keys)
+- [`migrate()`](#migrate)
+- [`removeOld()`](#removeold)
+- [Interfaces](#interfaces)
 
 </docgen-index>
 
@@ -87,8 +124,7 @@ Options that are `undefined` will not be used.
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### get(...)
 
@@ -106,8 +142,7 @@ Get the value from preferences of a given key.
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### set(...)
 
@@ -123,8 +158,7 @@ Set the value in preferences for a given key.
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### remove(...)
 
@@ -140,8 +174,7 @@ Remove the value from preferences for a given key, if any.
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### clear()
 
@@ -153,8 +186,7 @@ Clear keys and values from preferences.
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### keys()
 
@@ -168,8 +200,7 @@ Return the list of known keys in preferences.
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### migrate()
 
@@ -187,8 +218,7 @@ To remove the old data after being migrated, call removeOld().
 
 **Since:** 1.0.0
 
---------------------
-
+---
 
 ### removeOld()
 
@@ -200,11 +230,9 @@ Removes old data with `_cap_` prefix from the Capacitor 2 Storage plugin.
 
 **Since:** 1.1.0
 
---------------------
-
+---
 
 ### Interfaces
-
 
 #### ConfigureOptions
 
@@ -212,20 +240,17 @@ Removes old data with `_cap_` prefix from the Capacitor 2 Storage plugin.
 | ----------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ----- |
 | **`group`** | <code>string</code> | Set the preferences group. Preferences groups are used to organize key/value pairs. Using the value 'NativeStorage' provides backwards-compatibility with [`cordova-plugin-nativestorage`](https://www.npmjs.com/package/cordova-plugin-nativestorage). WARNING: The `clear()` method can delete unintended values when using the 'NativeStorage' group. | <code>CapacitorStorage</code> | 1.0.0 |
 
-
 #### GetResult
 
 | Prop        | Type                        | Description                                                                                                                       | Since |
 | ----------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----- |
 | **`value`** | <code>string \| null</code> | The value from preferences associated with the given key. If a value was not previously set or was removed, value will be `null`. | 1.0.0 |
 
-
 #### GetOptions
 
 | Prop      | Type                | Description                                       | Since |
 | --------- | ------------------- | ------------------------------------------------- | ----- |
 | **`key`** | <code>string</code> | The key whose value to retrieve from preferences. | 1.0.0 |
-
 
 #### SetOptions
 
@@ -234,20 +259,17 @@ Removes old data with `_cap_` prefix from the Capacitor 2 Storage plugin.
 | **`key`**   | <code>string</code> | The key to associate with the value being set in preferences. | 1.0.0 |
 | **`value`** | <code>string</code> | The value to set in preferences with the associated key.      | 1.0.0 |
 
-
 #### RemoveOptions
 
 | Prop      | Type                | Description                                     | Since |
 | --------- | ------------------- | ----------------------------------------------- | ----- |
 | **`key`** | <code>string</code> | The key whose value to remove from preferences. | 1.0.0 |
 
-
 #### KeysResult
 
 | Prop       | Type                  | Description                    | Since |
 | ---------- | --------------------- | ------------------------------ | ----- |
 | **`keys`** | <code>string[]</code> | The known keys in preferences. | 1.0.0 |
-
 
 #### MigrateResult
 

--- a/preferences/README.md
+++ b/preferences/README.md
@@ -42,8 +42,6 @@ When using this specific plugin in your app, you must create a `PrivacyInfo.xcpr
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>NSPrivacyTracking</key>
-    <false/>
     <key>NSPrivacyAccessedAPITypes</key>
     <array>
       <!-- Add this dict entry to the array if the PrivacyInfo file already exists -->
@@ -52,7 +50,7 @@ When using this specific plugin in your app, you must create a `PrivacyInfo.xcpr
         <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
         <key>NSPrivacyAccessedAPITypeReasons</key>
         <array>
-          <string>CA92.1</string> <!-- Replace with the appropriate reason code -->
+          <string>CA92.1</string>
         </array>
       </dict>
     </array>


### PR DESCRIPTION
This PR adds the [Apple Privacy Manifest Requirements](https://ionic.zendesk.com/hc/en-us/articles/22242418163735-Privacy-Manifest-Requirements) to the relevant plugins.

Addresses #2060 