### PR TITLE
Add handling of content URIs in Filesystem.stat() and Filesystem.readdir()

### DIFF
--- a/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/Filesystem.java
+++ b/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/Filesystem.java
@@ -222,6 +222,7 @@ public class Filesystem {
             if (u.getScheme() == null || u.getScheme().equals("file")) {
                 return new File(u.getPath());
             }
+            return null;
         }
 
         File androidDirectory = this.getDirectory(directory);


### PR DESCRIPTION
closes #308

This PR and #1301 should contribute to expand the support of the SAF, but there are unfortunately some limitations that are inherent to the API exposed in this capacitor plugin that prevent most of the other functions from being implemented, since content URLs do not work like paths.

First issue is that content URIs are not required to be hierarchical, which is a problem for functions like `deleteFile` or `rmdir` that need to know the parent directory of a document to delete it since it might be shared between multiple directories.

Second is that content URIs are not named based and thus cannot encode files that do not exist by just appending the name of the file to a directory path. A possible solution would be to expand the use of the directory parameter to any directory when it comes to content URIs but this requires special handling on the application side.

Overall, these URIs do not encode enough information for this plugin to rely exclusively on them and treat them as regular paths, which is sadly a major drawback for many applications. Special URIs / paths that encode more information could be used both as input and output of the filesystem functions to add a layer of abstraction over the SAF but then this would no longer be handling content URIs. This could however be a practical solution if support for these special paths is implemented alongside of support for content URIs in such a way that functions could handle content URIs but would then return the context-rich special paths, with the host application being totally oblivious to it. `getUri` could then be used if the application needs to turn back one of these rich paths into a content URI / file path to use it somewhere else.

Anyway, this is just my point of view on the situation as both a novice and an outsider, so I hope you (the maintainers) might have a better insight. Also regarding the PR I have tested it in integration with an application using this plugin while developing it, if it matters.