### PR TITLE
chore: updated publishing version dependency for capacitor 6

### DIFF
--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # The default Capacitor version(s) the plugin should depend on. Latest published in a range will be pulled by the user
-DEFAULT_CAPACITOR_VERSION="[5.0,6.0)"
+DEFAULT_CAPACITOR_VERSION="[6.0,7.0)"
 
 publish_plugin () {
     PLUGIN_PATH=$1


### PR DESCRIPTION
This needs to be updated before publishing to native so main publishes a dependency on v6