### PR TITLE
chore: Update install instructions with latest-5 tag

### DIFF
--- a/app-launcher/README.md
+++ b/app-launcher/README.md
@@ -18,7 +18,7 @@ Example:
 ## Install
 
 ```bash
-npm install @capacitor/app-launcher
+npm install @capacitor/app-launcher@latest-5
 npx cap sync
 ```
 

--- a/app/README.md
+++ b/app/README.md
@@ -5,7 +5,7 @@ The App API handles high level App state and events. For example, this API emits
 ## Install
 
 ```bash
-npm install @capacitor/app
+npm install @capacitor/app@latest-5
 npx cap sync
 ```
 

--- a/browser/README.md
+++ b/browser/README.md
@@ -7,7 +7,7 @@ On iOS, this uses `SFSafariViewController` and is compliant with leading OAuth s
 ## Install
 
 ```bash
-npm install @capacitor/browser
+npm install @capacitor/browser@latest-5
 npx cap sync
 ```
 

--- a/camera/README.md
+++ b/camera/README.md
@@ -5,7 +5,7 @@ The Camera API provides the ability to take a photo with the camera or choose an
 ## Install
 
 ```bash
-npm install @capacitor/camera
+npm install @capacitor/camera@latest-5
 npx cap sync
 ```
 

--- a/clipboard/README.md
+++ b/clipboard/README.md
@@ -5,7 +5,7 @@ The Clipboard API enables copy and pasting to/from the system clipboard.
 ## Install
 
 ```bash
-npm install @capacitor/clipboard
+npm install @capacitor/clipboard@latest-5
 npx cap sync
 ```
 

--- a/device/README.md
+++ b/device/README.md
@@ -5,7 +5,7 @@ The Device API exposes internal information about the device, such as the model 
 ## Install
 
 ```bash
-npm install @capacitor/device
+npm install @capacitor/device@latest-5
 npx cap sync
 ```
 

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -5,7 +5,7 @@ The Dialog API provides methods for triggering native dialog windows for alerts,
 ## Install
 
 ```bash
-npm install @capacitor/dialog
+npm install @capacitor/dialog@latest-5
 npx cap sync
 ```
 

--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -5,7 +5,7 @@ The Filesystem API provides a NodeJS-like API for working with files on the devi
 ## Install
 
 ```bash
-npm install @capacitor/filesystem
+npm install @capacitor/filesystem@latest-5
 npx cap sync
 ```
 

--- a/geolocation/README.md
+++ b/geolocation/README.md
@@ -5,7 +5,7 @@ The Geolocation API provides simple methods for getting and tracking the current
 ## Install
 
 ```bash
-npm install @capacitor/geolocation
+npm install @capacitor/geolocation@latest-5
 npx cap sync
 ```
 

--- a/haptics/README.md
+++ b/haptics/README.md
@@ -7,7 +7,7 @@ On devices that don't have Taptic Engine or Vibrator, the API calls will resolve
 ## Install
 
 ```bash
-npm install @capacitor/haptics
+npm install @capacitor/haptics@latest-5
 npx cap sync
 ```
 

--- a/keyboard/README.md
+++ b/keyboard/README.md
@@ -5,7 +5,7 @@ The Keyboard API provides keyboard display and visibility control, along with ev
 ## Install
 
 ```bash
-npm install @capacitor/keyboard
+npm install @capacitor/keyboard@latest-5
 npx cap sync
 ```
 

--- a/local-notifications/README.md
+++ b/local-notifications/README.md
@@ -5,7 +5,7 @@ The Local Notifications API provides a way to schedule device notifications loca
 ## Install
 
 ```bash
-npm install @capacitor/local-notifications
+npm install @capacitor/local-notifications@latest-5
 npx cap sync
 ```
 

--- a/motion/README.md
+++ b/motion/README.md
@@ -5,7 +5,7 @@ The Motion API tracks accelerometer and device orientation (compass heading, etc
 ## Install
 
 ```bash
-npm install @capacitor/motion
+npm install @capacitor/motion@latest-5
 npx cap sync
 ```
 

--- a/network/README.md
+++ b/network/README.md
@@ -5,7 +5,7 @@ The Network API provides network and connectivity information.
 ## Install
 
 ```bash
-npm install @capacitor/network
+npm install @capacitor/network@latest-5
 npx cap sync
 ```
 

--- a/preferences/README.md
+++ b/preferences/README.md
@@ -19,7 +19,7 @@ we recommend taking a look at a SQLite-based solution. One such solution is [Ion
 ## Install
 
 ```bash
-npm install @capacitor/preferences
+npm install @capacitor/preferences@latest-5
 npx cap sync
 ```
 

--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -5,7 +5,7 @@ The Push Notifications API provides access to native push notifications.
 ## Install
 
 ```bash
-npm install @capacitor/push-notifications
+npm install @capacitor/push-notifications@latest-5
 npx cap sync
 ```
 

--- a/screen-orientation/README.md
+++ b/screen-orientation/README.md
@@ -5,7 +5,7 @@ The Screen Orientation API provides information and functionality related to the
 ## Install
 
 ```bash
-npm install @capacitor/screen-orientation
+npm install @capacitor/screen-orientation@latest-5
 npx cap sync
 ```
 

--- a/screen-reader/README.md
+++ b/screen-reader/README.md
@@ -5,7 +5,7 @@ The Screen Reader API provides access to TalkBack/VoiceOver/etc. and provides si
 ## Install
 
 ```bash
-npm install @capacitor/screen-reader
+npm install @capacitor/screen-reader@latest-5
 npx cap sync
 ```
 

--- a/share/README.md
+++ b/share/README.md
@@ -8,7 +8,7 @@ API](https://web.dev/web-share/)), though web support is currently spotty.
 ## Install
 
 ```bash
-npm install @capacitor/share
+npm install @capacitor/share@latest-5
 npx cap sync
 ```
 ## Android

--- a/splash-screen/README.md
+++ b/splash-screen/README.md
@@ -5,7 +5,7 @@ The Splash Screen API provides methods for showing or hiding a Splash image.
 ## Install
 
 ```bash
-npm install @capacitor/splash-screen
+npm install @capacitor/splash-screen@latest-5
 npx cap sync
 ```
 

--- a/status-bar/README.md
+++ b/status-bar/README.md
@@ -5,7 +5,7 @@ The StatusBar API Provides methods for configuring the style of the Status Bar, 
 ## Install
 
 ```bash
-npm install @capacitor/status-bar
+npm install @capacitor/status-bar@latest-5
 npx cap sync
 ```
 

--- a/text-zoom/README.md
+++ b/text-zoom/README.md
@@ -15,7 +15,7 @@ The Text Zoom API provides the ability to change Web View text size for visual a
 ## Install
 
 ```bash
-npm install @capacitor/text-zoom
+npm install @capacitor/text-zoom@latest-5
 npx cap sync
 ```
 

--- a/toast/README.md
+++ b/toast/README.md
@@ -5,7 +5,7 @@ The Toast API provides a notification pop up for displaying important informatio
 ## Install
 
 ```bash
-npm install @capacitor/toast
+npm install @capacitor/toast@latest-5
 npx cap sync
 ```
 


### PR DESCRIPTION
For Capacitor 5 plugins use `latest-5` tag, except for google-maps as it doesn't have `latest-5` tag yet