### PR TITLE
fix(ios): iOS panorama photos selected through CameraPlugin are corrupted

### DIFF
--- a/camera/ios/Plugin/CameraExtensions.swift
+++ b/camera/ios/Plugin/CameraExtensions.swift
@@ -91,12 +91,10 @@ internal extension UIImage {
             targetHeight = maxHeight
         }
         // generate the new image and return
-        let format: UIGraphicsImageRendererFormat = UIGraphicsImageRendererFormat.default()
-        format.scale = 1.0
-        format.opaque = false
-        let renderer = UIGraphicsImageRenderer(size: CGSize(width: targetWidth, height: targetHeight), format: format)
-        return renderer.image { (_) in
-            self.draw(in: CGRect(origin: .zero, size: CGSize(width: targetWidth, height: targetHeight)))
-        }
+        UIGraphicsBeginImageContextWithOptions(.init(width: targetWidth, height: targetHeight), false, 1.0) // size, opaque and scale
+        self.draw(in: .init(origin: .zero, size: .init(width: targetWidth, height: targetHeight)))
+        let resizedImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return resizedImage ?? self
     }
 }


### PR DESCRIPTION
Closes #2046

This fixes the issue for `5.x`.

The bug was due to an out-of-memory issue. The `self.draw` call kept the image in memory after usage. When transforming the image to a jpeg data, there wasn't enough memory available to perform the operation, so a `nil` data object was being returned, resulting in an empty image. 
Using `UIGraphicsImageContext` fixes the issue.