### PR TITLE
Update @capacitor/browser README.md to reflect change for Browser.close()

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -68,7 +68,7 @@ Open a page with the specified options.
 close() => Promise<void>
 ```
 
-Web & iOS only: Close an open browser window.
+Web & iOS & Android only: Close an open browser window.
 
 No-op on other platforms.
 


### PR DESCRIPTION
Android is supported as of 6.0.0-rc.0 (2024-02-07)

https://github.com/ionic-team/capacitor-plugins/blob/main/browser/CHANGELOG.md#600-rc0-2024-02-07