### PR TITLE
fix(ios): apply filter to fetch correct scene object

### DIFF
--- a/keyboard/ios/Plugin/Keyboard.m
+++ b/keyboard/ios/Plugin/Keyboard.m
@@ -213,7 +213,8 @@ double stageManagerOffset;
   
   if (!window) {
     if (@available(iOS 13.0, *)) {
-      UIScene *scene = [UIApplication sharedApplication].connectedScenes.allObjects.firstObject;
+      NSPredicate *predicate = [NSPredicate predicateWithFormat:@"self isKindOfClass: %@", UIWindowScene.class];
+      UIScene *scene = [UIApplication.sharedApplication.connectedScenes.allObjects filteredArrayUsingPredicate:predicate].firstObject;
       window = [[(UIWindowScene*)scene windows] filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"isKeyWindow == YES"]].firstObject;
     }
   }


### PR DESCRIPTION
(`5.x` cherry-pick).

Avoids breaking apps that use Apple CarPlay.

References: https://outsystemsrd.atlassian.net/browse/RMET-3229