### PR TITLE
Proposed fix for #2072 - EventGroup count variable should allowed to be zero

### DIFF
--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/EventGroup.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/EventGroup.java
@@ -35,7 +35,7 @@ class EventGroup {
     }
 
     private void checkForCompletion() {
-        if (count <= 0) {
+        if (count < 0) {
             if (isComplete == false && completion != null) {
                 completion.onGroupCompletion();
             }


### PR DESCRIPTION
This would in turn fix:
https://github.com/ionic-team/capacitor-plugins/issues/2072

Due to the fact that TAB_HIDDEN is fired before TAB_SHOWN, the count variable would be zero and hence BROWSER_FINISHED would be fired prematurely.
