### PR TITLE
Enable immersive mode on status bar hide

### DIFF
--- a/status-bar/android/src/main/java/com/capacitorjs/plugins/statusbar/StatusBar.java
+++ b/status-bar/android/src/main/java/com/capacitorjs/plugins/statusbar/StatusBar.java
@@ -47,14 +47,32 @@ public class StatusBar {
 
     public void hide() {
         View decorView = activity.getWindow().getDecorView();
-        WindowInsetsControllerCompat windowInsetsControllerCompat = WindowCompat.getInsetsController(activity.getWindow(), decorView);
-        windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.statusBars());
+        WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(activity.getWindow(), decorView);
+
+        // Hide the status bar and navigation bar
+        if (windowInsetsController != null) {
+            windowInsetsController.hide(WindowInsetsCompat.Type.systemBars());
+
+            // Enable immersive mode
+            windowInsetsController.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
+        }
     }
 
     public void show() {
         View decorView = activity.getWindow().getDecorView();
-        WindowInsetsControllerCompat windowInsetsControllerCompat = WindowCompat.getInsetsController(activity.getWindow(), decorView);
-        windowInsetsControllerCompat.show(WindowInsetsCompat.Type.statusBars());
+        WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(activity.getWindow(), decorView);
+
+        // Hide the status bar and navigation bar
+        if (windowInsetsController != null) {
+            windowInsetsController.show(WindowInsetsCompat.Type.systemBars());
+
+            // Enable immersive mode
+            windowInsetsController.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_TOUCH
+            );
+        }
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Enable immersive mode on status bar hide to prevent opening of the status bar on user interaction. Fixes #79 