### PR TITLE
docs: Add missing latest-5 tag on install

### DIFF
--- a/action-sheet/README.md
+++ b/action-sheet/README.md
@@ -5,7 +5,7 @@ The Action Sheet API provides access to native Action Sheets, which come up from
 ## Install
 
 ```bash
-npm install @capacitor/action-sheet
+npm install @capacitor/action-sheet@latest-5
 npx cap sync
 ```
 

--- a/google-maps/README.md
+++ b/google-maps/README.md
@@ -5,7 +5,7 @@ Google maps on Capacitor
 ## Install
 
 ```bash
-npm install @capacitor/google-maps
+npm install @capacitor/google-maps@latest-5
 npx cap sync
 ```
 


### PR DESCRIPTION
the install instructions weren't updated for google maps and action-sheet plugins, so they have not been published because there were no changes.