### PR TITLE
feat(capacitor-camera): allow returning base64String when picking images from gallery

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -504,8 +504,13 @@ public class CameraPlugin extends Plugin {
             if (newUri != null) {
                 ret.put("format", "jpeg");
                 ret.put("exif", exif.toJson());
-                ret.put("path", newUri.toString());
-                ret.put("webPath", FileUtils.getPortablePath(getContext(), bridge.getLocalUrl(), newUri));
+                if (settings.getResultType() == CameraResultType.BASE64) {
+                  String encoded = this.getBase64String(bitmapOutputStream);
+                  ret.put("base64String", encoded);
+                } else {
+                  ret.put("path", newUri.toString());
+                  ret.put("webPath", FileUtils.getPortablePath(getContext(), bridge.getLocalUrl(), newUri));
+                }
             } else {
                 ret.put("error", UNABLE_TO_PROCESS_IMAGE);
             }
@@ -767,9 +772,13 @@ public class CameraPlugin extends Plugin {
         call.resolve(data);
     }
 
+    private String getBase64String(ByteArrayOutputStream bitmapOutputStream) {
+      byte[] byteArray = bitmapOutputStream.toByteArray();
+      return Base64.encodeToString(byteArray, Base64.NO_WRAP);
+    }
+
     private void returnBase64(PluginCall call, ExifWrapper exif, ByteArrayOutputStream bitmapOutputStream) {
-        byte[] byteArray = bitmapOutputStream.toByteArray();
-        String encoded = Base64.encodeToString(byteArray, Base64.NO_WRAP);
+        String encoded = this.getBase64String(bitmapOutputStream);
 
         JSObject data = new JSObject();
         data.put("format", "jpeg");

--- a/camera/ios/Sources/CameraPlugin/CameraPlugin.swift
+++ b/camera/ios/Sources/CameraPlugin/CameraPlugin.swift
@@ -373,13 +373,22 @@ private extension CameraPlugin {
                 call?.reject("Unable to get portable path to file")
                 return
             }
-
-            photos.append([
+            
+            var data = [
                 "path": fileURL.absoluteString,
                 "exif": processedImage.exifData,
                 "webPath": webURL.absoluteString,
                 "format": "jpeg"
-            ])
+            ] as [String : Any]
+            
+            if settings.resultType == CameraResultType.base64 {
+                data["base64String"] = jpeg.base64EncodedString()
+            } else {
+                data["path"] = fileURL.absoluteString
+                data["webPath"] = webURL.absoluteString
+            }
+
+            photos.append(data)
         }
         call?.resolve([
             "photos": photos


### PR DESCRIPTION
Allows returning base64 string when picking images from gallery, the same way that we return it for camera.