### PR TITLE
fix(browser): call notifyListeners only when browser is dismissed

### DIFF
--- a/browser/ios/Sources/BrowserPlugin/BrowserPlugin.swift
+++ b/browser/ios/Sources/BrowserPlugin/BrowserPlugin.swift
@@ -29,7 +29,13 @@ public class CAPBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
         implementation.browserEventDidOccur = { [weak self] (event) in
-            self?.notifyListeners(event.listenerEvent, data: nil)
+            if event == .finished {
+                self?.bridge?.dismissVC(animated: true, completion: {
+                    self?.notifyListeners(event.listenerEvent, data: nil)
+                })
+            } else {
+                self?.notifyListeners(event.listenerEvent, data: nil)
+            }
         }
         // display
         DispatchQueue.main.async { [weak self] in


### PR DESCRIPTION
Fixes a bug on @capacitor/browser on iOS: when trying to lock the device's orientation after the safari view controller was dismissed/closed by the user , an error occured: `None of the requested orientations are supported by the view controller. Requested: portrait; Supported: landscapeLeft`

This seemed to be happening because the view controller wasn't being properly closed/dismissed and the listeners were being incorrectly notified.

initial bug @ [here](https://github.com/ionic-team/capacitor-plugins/issues/2100)

reference: https://outsystemsrd.atlassian.net/browse/RMET-3453