### PR TITLE
feat(@capacitor/bowser) Add option to clear all website data while closing iOS browser window

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -34,7 +34,7 @@ const openCapacitorSite = async () => {
 <docgen-index>
 
 * [`open(...)`](#open)
-* [`close()`](#close)
+* [`close(...)`](#close)
 * [`addListener('browserFinished', ...)`](#addlistenerbrowserfinished-)
 * [`addListener('browserPageLoaded', ...)`](#addlistenerbrowserpageloaded-)
 * [`removeAllListeners()`](#removealllisteners)
@@ -62,15 +62,19 @@ Open a page with the specified options.
 --------------------
 
 
-### close()
+### close(...)
 
 ```typescript
-close() => Promise<void>
+close(options?: CloseOptions | undefined) => Promise<void>
 ```
 
 Web & iOS only: Close an open browser window.
 
 No-op on other platforms.
+
+| Param         | Type                                                  |
+| ------------- | ----------------------------------------------------- |
+| **`options`** | <code><a href="#closeoptions">CloseOptions</a></code> |
 
 **Since:** 1.0.0
 
@@ -148,6 +152,13 @@ Represents the options passed to `open`.
 | **`presentationStyle`** | <code>'fullscreen' \| 'popover'</code> | iOS only: The presentation style of the browser. Defaults to fullscreen. Ignored on other platforms.                                       | 1.0.0 |
 | **`width`**             | <code>number</code>                    | iOS only: The width the browser when using presentationStyle 'popover' on iPads. Ignored on other platforms.                               | 4.0.0 |
 | **`height`**            | <code>number</code>                    | iOS only: The height the browser when using presentationStyle 'popover' on iPads. Ignored on other platforms.                              | 4.0.0 |
+
+
+#### CloseOptions
+
+| Prop                   | Type                 | Description                                                         |
+| ---------------------- | -------------------- | ------------------------------------------------------------------- |
+| **`clearWebsiteData`** | <code>boolean</code> | iOS only: clear all website data before close default: null / false |
 
 
 #### PluginListenerHandle

--- a/browser/ios/Sources/BrowserPlugin/Browser.swift
+++ b/browser/ios/Sources/BrowserPlugin/Browser.swift
@@ -34,7 +34,12 @@ import SafariServices
         return false
     }
 
-    @objc public func cleanup() {
+    @objc public func cleanup(clearWebsiteData: Bool) {
+       if clearWebsiteData {
+           if #available(iOS 16.0, *) {
+              SFSafariViewController.DataStore.default.clearWebsiteData(completionHandler: {})
+           }
+        }
         safariViewController = nil
     }
 

--- a/browser/ios/Sources/BrowserPlugin/BrowserPlugin.swift
+++ b/browser/ios/Sources/BrowserPlugin/BrowserPlugin.swift
@@ -55,9 +55,11 @@ public class CAPBrowserPlugin: CAPPlugin, CAPBridgedPlugin {
     @objc func close(_ call: CAPPluginCall) {
         DispatchQueue.main.async { [weak self] in
             if self?.implementation.viewController != nil {
+
                 self?.bridge?.dismissVC(animated: true) {
                     call.resolve()
-                    self?.implementation.cleanup()
+                    let clearWebsiteData = call.getBool("clearWebsiteData") ?? false
+                    self?.implementation.cleanup(clearWebsiteData: clearWebsiteData)
                 }
             } else {
                 call.reject("No active window to close!")

--- a/browser/src/definitions.ts
+++ b/browser/src/definitions.ts
@@ -15,7 +15,7 @@ export interface BrowserPlugin {
    *
    * @since 1.0.0
    */
-  close(): Promise<void>;
+  close(options?: CloseOptions): Promise<void>;
 
   /**
    * Android & iOS only: Listen for the browser finished event.
@@ -105,6 +105,15 @@ export interface OpenOptions {
    * @since 4.0.0
    */
   height?: number;
+}
+
+export interface CloseOptions {
+    /**
+     * iOS only: clear all website data before close
+     *
+     * default: null / false
+     */
+    clearWebsiteData?: boolean;
 }
 
 /**


### PR DESCRIPTION
User Story:

After using the browser window for e.g. oauth login,  I would like to have the possibility to clear all website data to ensure that a new login is not using any cookie data and logging me in again.

Description:

Optional config to clear all website data during browser.close.