### PR TITLE
feat(camera): only request permission to save to the gallery for Android <= 9

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -204,7 +204,18 @@ public class CameraPlugin extends Plugin {
         boolean hasGalleryPerms = getPermissionState(SAVE_GALLERY) == PermissionState.GRANTED;
 
         // If we want to save to the gallery, we need two permissions
-        if (settings.isSaveToGallery() && !(hasCameraPerms && hasGalleryPerms) && isFirstRequest) {
+        // actually we only need permissions to save to gallery for Android <= 9 (API 28)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // we might still need to request permission for the camera
+            if (!hasCameraPerms) {
+                requestPermissionForAlias(CAMERA, call, "cameraPermissionsCallback");
+                return false;
+            }
+            return true;
+        }
+
+        // we need to request permissions to save to gallery for Android <= 9
+        else if (settings.isSaveToGallery() && !(hasCameraPerms && hasGalleryPerms) && isFirstRequest) {
             isFirstRequest = false;
             String[] aliases;
             if (needCameraPerms) {

--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -215,7 +215,7 @@ public class CameraPlugin extends Plugin {
         }
 
         // we need to request permissions to save to gallery for Android <= 9
-        else if (settings.isSaveToGallery() && !(hasCameraPerms && hasGalleryPerms) && isFirstRequest) {
+        if (settings.isSaveToGallery() && !(hasCameraPerms && hasGalleryPerms) && isFirstRequest) {
             isFirstRequest = false;
             String[] aliases;
             if (needCameraPerms) {


### PR DESCRIPTION
Fixes a bug on @capacitor/camera on Android, where when taking a photo with `saveToGallery = true`, the camera only opened on the second attempt because of the permission to save to the gallery not being given.

This only happened for Android >= 10, and for those versions, we don't even need to request for permission to save to the gallery. More info [here](https://developer.android.com/media/camera/camera-deprecated/photobasics#TaskPath).

Closes #2210 

References: https://outsystemsrd.atlassian.net/browse/RMET-3767