### PR TITLE
fix(keyboard): Remove iOS keyboard delay (#1904)

### DIFF
--- a/keyboard/ios/Sources/KeyboardPlugin/Keyboard.m
+++ b/keyboard/ios/Sources/KeyboardPlugin/Keyboard.m
@@ -110,7 +110,7 @@ double stageManagerOffset;
 
 - (void)onKeyboardWillHide:(NSNotification *)notification
 {
-  [self setKeyboardHeight:0 delay:0.01];
+  [self setKeyboardHeight:0 delay:0];
   [self resetScrollView];
   hideTimer = [NSTimer scheduledTimerWithTimeInterval:0 repeats:NO block:^(NSTimer * _Nonnull timer) {
     [self.bridge triggerWindowJSEventWithEventName:@"keyboardWillHide"];
@@ -142,8 +142,7 @@ double stageManagerOffset;
     }
   }
 
-  double duration = [[notification.userInfo valueForKey:UIKeyboardAnimationDurationUserInfoKey] doubleValue]+0.2;
-  [self setKeyboardHeight:height delay:duration];
+  [self setKeyboardHeight:height delay:0];
   [self resetScrollView];
 
   NSString * data = [NSString stringWithFormat:@"{ 'keyboardHeight': %d }", (int)height];
@@ -199,7 +198,7 @@ double stageManagerOffset;
         height = screenHeight - paddingBottom;
     }
     
-    [self.bridge evalWithJs: [NSString stringWithFormat:@"(function() { var el = %@; var height = %d; if (el) { el.style.height = height > -1 ? height + 'px' : null; } })()", element, height]];
+    [self.bridge evalWithJs: [NSString stringWithFormat:@"requestAnimationFrame(() => { var el = %@; var height = %d; if (el) { el.style.height = height > -1 ? height + 'px' : null; } })", element, height]];
 }
 
 - (void)_updateFrame


### PR DESCRIPTION
This fix aligns with the Android implementation of no delay.

This fix removes all keyboard delay, including the 0.01 second delay for hiding. I believe this delay existed due to a slight flicker observed when setting delay to 0. However, by wrapping the height javascript logic in
`requestAnimationFrame()` the flicker is no longer present.

I believe this is a better solution than #2230 because it avoids adding animations. (Users can do this themselves by disabling resizing and hooking into keyboardWillShow, didShow, willHide, and didHide events in javascript.)

It also avoids magic/arbitrary delay amounts, like 0.01.