### PR TITLE
refactor(text-zoom): don't use deprecated Plugins object

### DIFF
--- a/text-zoom/src/ios.ts
+++ b/text-zoom/src/ios.ts
@@ -1,8 +1,4 @@
-import type {
-  GetResult,
-  SetOptions,
-  TextZoomPlugin,
-} from './definitions';
+import type { GetResult, SetOptions, TextZoomPlugin } from './definitions';
 
 export class TextZoomIOS implements TextZoomPlugin {
   static readonly TEXT_SIZE_REGEX = /(\d+)%/;

--- a/text-zoom/src/ios.ts
+++ b/text-zoom/src/ios.ts
@@ -1,7 +1,4 @@
-import { Plugins } from '@capacitor/core';
-
 import type {
-  GetPreferredResult,
   GetResult,
   SetOptions,
   TextZoomPlugin,
@@ -17,8 +14,8 @@ export class TextZoomIOS implements TextZoomPlugin {
     return { value };
   }
 
-  async getPreferred(): Promise<GetPreferredResult> {
-    return Plugins.TextZoom.getPreferred();
+  async getPreferred(): Promise<never> {
+    throw 'Native implementation will be used';
   }
 
   async set(options: SetOptions): Promise<void> {


### PR DESCRIPTION
Plugins object is being removed in Capacitor 7

`getPreferred()` method is not really called, as there is a `getPreferred()` native iOS method, the Capacitor internal code will use the native method when available instead of the one in the typescript code. But needs to be declared since it implements `TextZoomPlugin` and typescript will complain if not present, so change it to just "throw".