### PR TITLE
Make Geolocation plugin work if Google Play Services are not enabled

### DIFF
--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
@@ -1,4 +1,4 @@
-package org.mapcomplete;
+package com.capacitorjs.plugins.geolocation;
 
 import android.content.Context;
 import android.location.Location;
@@ -6,7 +6,6 @@ import android.location.LocationListener;
 import android.location.LocationManager;
 import android.os.Bundle;
 import android.os.SystemClock;
-import android.util.Log;
 
 import androidx.core.location.LocationManagerCompat;
 

--- a/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
+++ b/geolocation/android/src/main/java/com/capacitorjs/plugins/geolocation/Geolocation.java
@@ -1,10 +1,15 @@
-package com.capacitorjs.plugins.geolocation;
+package org.mapcomplete;
 
 import android.content.Context;
 import android.location.Location;
+import android.location.LocationListener;
 import android.location.LocationManager;
+import android.os.Bundle;
 import android.os.SystemClock;
+import android.util.Log;
+
 import androidx.core.location.LocationManagerCompat;
+
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.location.FusedLocationProviderClient;
@@ -13,6 +18,33 @@ import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationResult;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.location.Priority;
+
+class LocationUpdateListener implements LocationListener {
+
+    private final LocationResultCallback callback;
+
+    public LocationUpdateListener(LocationResultCallback callback) {
+
+        this.callback = callback;
+    }
+
+    @Override
+    public void onLocationChanged(Location location) {
+        this.callback.success(location);
+    }
+
+    @Override
+    public void onStatusChanged(String provider, int status, Bundle extras) {
+    }
+
+    @Override
+    public void onProviderEnabled(String provider) {
+    }
+
+    @Override
+    public void onProviderDisabled(String provider) {
+    }
+}
 
 public class Geolocation {
 
@@ -30,68 +62,117 @@ public class Geolocation {
         return LocationManagerCompat.isLocationEnabled(lm);
     }
 
+    private int getPriority(boolean enableHighAccuracy) {
+        boolean networkEnabled = false;
+        if (enableHighAccuracy) {
+            return Priority.PRIORITY_HIGH_ACCURACY;
+        }
+        LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+        try {
+            networkEnabled = lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+        } catch (Exception ex) {
+        }
+        return networkEnabled ? Priority.PRIORITY_BALANCED_POWER_ACCURACY : Priority.PRIORITY_LOW_POWER;
+    }
+
+    private boolean hasPlayServices() {
+        return GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS;
+    }
+
+    /**
+     * If the play services are disabled, the location manager will be queryied to indicate what providers are available.
+     * Typical providers are `passive`, `network`, `fused` and `gps`
+     *
+     * This method selects the best appropriate
+     */
+    private String getPreferredProvider(boolean enableHighAccuracy) {
+        LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+        var providers = lm.getProviders(true);
+        if(enableHighAccuracy) {
+            if(providers.contains("gps")){
+                return "gps";
+            }
+            if(providers.contains("fused")){
+                return "fused";
+            }
+            if(providers.contains("network")){
+                return "network";
+            }
+        }else{
+            if(providers.contains("network")){
+                return "network";
+            }
+            if(providers.contains("fused")){
+                return "fused";
+            }
+            if(providers.contains("gps")){
+                return "gps";
+            }
+        }
+        if(providers.contains("passive")){
+            return "passive";
+        }
+
+        return null;
+    }
     @SuppressWarnings("MissingPermission")
     public void sendLocation(boolean enableHighAccuracy, final LocationResultCallback resultCallback) {
-        int resultCode = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context);
-        if (resultCode == ConnectionResult.SUCCESS) {
-            LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+        if (!this.isLocationServicesEnabled()) {
+            resultCallback.error("location disabled");
+            return;
+        }
 
-            if (this.isLocationServicesEnabled()) {
-                boolean networkEnabled = false;
+        if (hasPlayServices()) {
 
-                try {
-                    networkEnabled = lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
-                } catch (Exception ex) {}
-
-                int lowPriority = networkEnabled ? Priority.PRIORITY_BALANCED_POWER_ACCURACY : Priority.PRIORITY_LOW_POWER;
-                int priority = enableHighAccuracy ? Priority.PRIORITY_HIGH_ACCURACY : lowPriority;
-
-                LocationServices
+            LocationServices
                     .getFusedLocationProviderClient(context)
-                    .getCurrentLocation(priority, null)
+                    .getCurrentLocation(getPriority(enableHighAccuracy), null)
                     .addOnFailureListener(e -> resultCallback.error(e.getMessage()))
                     .addOnSuccessListener(
-                        location -> {
-                            if (location == null) {
-                                resultCallback.error("location unavailable");
-                            } else {
-                                resultCallback.success(location);
+                            location -> {
+                                if (location == null) {
+                                    resultCallback.error("location unavailable");
+                                } else {
+                                    resultCallback.success(location);
+                                }
                             }
-                        }
                     );
-            } else {
-                resultCallback.error("location disabled");
-            }
         } else {
-            resultCallback.error("Google Play Services not available");
+            LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+
+            var provider = getPreferredProvider(enableHighAccuracy);
+            if (provider == null) {
+                resultCallback.error("Location unavaible: no providers defined. Note: Google Play Services are not available as well");
+                return;
+            }
+            lm.requestLocationUpdates(provider, 1000, 10, new LocationUpdateListener(resultCallback));
         }
+
+
     }
 
     @SuppressWarnings("MissingPermission")
     public void requestLocationUpdates(boolean enableHighAccuracy, int timeout, final LocationResultCallback resultCallback) {
-        int resultCode = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context);
-        if (resultCode == ConnectionResult.SUCCESS) {
+
+
+        if (!this.isLocationServicesEnabled()) {
+            resultCallback.error("location disabled");
+            return;
+        }
+
+        LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+
+        if (hasPlayServices()) {
             clearLocationUpdates();
             fusedLocationClient = LocationServices.getFusedLocationProviderClient(context);
 
-            LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-            if (this.isLocationServicesEnabled()) {
-                boolean networkEnabled = false;
-
-                try {
-                    networkEnabled = lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
-                } catch (Exception ex) {}
-
-                int lowPriority = networkEnabled ? Priority.PRIORITY_BALANCED_POWER_ACCURACY : Priority.PRIORITY_LOW_POWER;
-                int priority = enableHighAccuracy ? Priority.PRIORITY_HIGH_ACCURACY : lowPriority;
-
-                LocationRequest locationRequest = new LocationRequest.Builder(10000)
+            LocationRequest locationRequest = new LocationRequest.Builder(10000)
                     .setMaxUpdateDelayMillis(timeout)
                     .setMinUpdateIntervalMillis(5000)
-                    .setPriority(priority)
+                    .setPriority(getPriority(enableHighAccuracy))
                     .build();
 
-                locationCallback =
+            locationCallback =
                     new LocationCallback() {
                         @Override
                         public void onLocationResult(LocationResult locationResult) {
@@ -104,12 +185,15 @@ public class Geolocation {
                         }
                     };
 
-                fusedLocationClient.requestLocationUpdates(locationRequest, locationCallback, null);
-            } else {
-                resultCallback.error("location disabled");
-            }
+            fusedLocationClient.requestLocationUpdates(locationRequest, locationCallback, null);
         } else {
-            resultCallback.error("Google Play Services not available");
+            var provider = getPreferredProvider(enableHighAccuracy);
+            if (provider == null) {
+                resultCallback.error("Location unavaible: no providers defined. Note: Google Play Services are not available as well");
+                return;
+            }
+            lm.requestLocationUpdates(provider, 1000, 10, new LocationUpdateListener(resultCallback));
+
         }
     }
 
@@ -130,8 +214,8 @@ public class Geolocation {
                 long locationAge = SystemClock.elapsedRealtimeNanos() - tmpLoc.getElapsedRealtimeNanos();
                 long maximumAgeNanoSec = maximumAge * 1000000L;
                 if (
-                    locationAge <= maximumAgeNanoSec &&
-                    (lastLoc == null || lastLoc.getElapsedRealtimeNanos() > tmpLoc.getElapsedRealtimeNanos())
+                        locationAge <= maximumAgeNanoSec &&
+                                (lastLoc == null || lastLoc.getElapsedRealtimeNanos() > tmpLoc.getElapsedRealtimeNanos())
                 ) {
                     lastLoc = tmpLoc;
                 }


### PR DESCRIPTION
Hi,

I'm currently in [the process of packaging](https://github.com/pietervdvn/MapComplete/issues/2112) [MapComplete](https://mapcomplete.org) into an Android app, with capacitor.

However, many of my users (including myselfs) are a bit paranoia and disable the Google Play Services or run custom ROMS without them. However, the geolocation plugin would refuse to work if those are not available.

As such, I have modified the geolocation-plugin to work with the google play services if they are available and to fallback to the stock Android API's if the Play Services are not available.

I've also moved some duplicated code into methods, in order to maintain some readability. 