### PR TITLE
refactor(haptics)!: remove unused and deprecated code

### DIFF
--- a/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/Haptics.java
+++ b/haptics/android/src/main/java/com/capacitorjs/plugins/haptics/Haptics.java
@@ -10,12 +10,10 @@ import com.capacitorjs.plugins.haptics.arguments.HapticsVibrationType;
 
 public class Haptics {
 
-    private Context context;
     private boolean selectionStarted = false;
     private final Vibrator vibrator;
 
     Haptics(Context context) {
-        this.context = context;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             VibratorManager vibratorManager = (VibratorManager) context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
             this.vibrator = vibratorManager.getDefaultVibrator();
@@ -43,8 +41,8 @@ public class Haptics {
     }
 
     @SuppressWarnings({ "deprecation" })
-    private void vibratePre26(long[] pattern, int repeat) {
-        vibrator.vibrate(pattern, repeat);
+    private void vibratePre26(long[] pattern) {
+        vibrator.vibrate(pattern, -1);
     }
 
     public void selectionStart() {
@@ -65,7 +63,7 @@ public class Haptics {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             vibrator.vibrate(VibrationEffect.createWaveform(type.getTimings(), type.getAmplitudes(), -1));
         } else {
-            vibratePre26(type.getOldSDKPattern(), -1);
+            vibratePre26(type.getOldSDKPattern());
         }
     }
 }

--- a/haptics/src/definitions.ts
+++ b/haptics/src/definitions.ts
@@ -124,27 +124,3 @@ export interface VibrateOptions {
    */
   duration: number;
 }
-
-/**
- * @deprecated Use `ImpactOptions`.
- * @since 1.0.0
- */
-export type HapticsImpactOptions = ImpactOptions;
-
-/**
- * @deprecated Use `NotificationOptions`.
- * @since 1.0.0
- */
-export type HapticsNotificationOptions = NotificationOptions;
-
-/**
- * @deprecated Use `NotificationType`.
- * @since 1.0.0
- */
-export const HapticsNotificationType = NotificationType;
-
-/**
- * @deprecated Use `ImpactStyle`.
- * @since 1.0.0
- */
-export const HapticsImpactStyle = ImpactStyle;


### PR DESCRIPTION
Removed some Android code that was causing warning on Android Studio and also deprecated types