### PR TITLE
feat(device)!: remove disk size related information

### DIFF
--- a/device/README.md
+++ b/device/README.md
@@ -9,39 +9,6 @@ npm install @capacitor/device
 npx cap sync
 ```
 
-## Apple Privacy Manifest Requirements
-
-Apple mandates that app developers now specify approved reasons for API usage to enhance user privacy. By May 1st, 2024, it's required to include these reasons when submitting apps to the App Store Connect.
-
-When using this specific plugin in your app, you must create a `PrivacyInfo.xcprivacy` file in `/ios/App` or use the VS Code Extension to generate it, specifying the usage reasons.
-
-For detailed steps on how to do this, please see the [Capacitor Docs](https://capacitorjs.com/docs/ios/privacy-manifest).
-
-**For this plugin, the required dictionary key is [NSPrivacyAccessedAPICategoryDiskSpace](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278397) and the recommended reason is [85F4.1](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278397).**
-
-### Example PrivacyInfo.xcprivacy
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>NSPrivacyAccessedAPITypes</key>
-    <array>
-      <!-- Add this dict entry to the array if the PrivacyInfo file already exists -->
-      <dict>
-        <key>NSPrivacyAccessedAPIType</key>
-        <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
-        <key>NSPrivacyAccessedAPITypeReasons</key>
-        <array>
-          <string>85F4.1</string>
-        </array>
-      </dict>
-    </array>
-  </dict>
-</plist>
-```
-
 ## Example Plugin Usage
 
 ```typescript
@@ -176,10 +143,6 @@ Get the device's current language locale tag.
 | **`manufacturer`**      | <code>string</code>                                         | The manufacturer of the device.                                                                                                                                                                                                                                                                                                                  | 1.0.0 |
 | **`isVirtual`**         | <code>boolean</code>                                        | Whether the app is running in a simulator/emulator.                                                                                                                                                                                                                                                                                              | 1.0.0 |
 | **`memUsed`**           | <code>number</code>                                         | Approximate memory used by the current app, in bytes. Divide by 1048576 to get the number of MBs used.                                                                                                                                                                                                                                           | 1.0.0 |
-| **`diskFree`**          | <code>number</code>                                         | How much free disk space is available on the normal data storage path for the os, in bytes. On Android it returns the free disk space on the "system" partition holding the core Android OS. On iOS this value is not accurate.                                                                                                                  | 1.0.0 |
-| **`diskTotal`**         | <code>number</code>                                         | The total size of the normal data storage path for the OS, in bytes. On Android it returns the disk space on the "system" partition holding the core Android OS.                                                                                                                                                                                 | 1.0.0 |
-| **`realDiskFree`**      | <code>number</code>                                         | How much free disk space is available on the normal data storage, in bytes.                                                                                                                                                                                                                                                                      | 1.1.0 |
-| **`realDiskTotal`**     | <code>number</code>                                         | The total size of the normal data storage path, in bytes.                                                                                                                                                                                                                                                                                        | 1.1.0 |
 | **`webViewVersion`**    | <code>string</code>                                         | The web view browser version                                                                                                                                                                                                                                                                                                                     | 1.0.0 |
 
 

--- a/device/android/src/main/java/com/capacitorjs/plugins/device/Device.java
+++ b/device/android/src/main/java/com/capacitorjs/plugins/device/Device.java
@@ -7,8 +7,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.BatteryManager;
 import android.os.Build;
-import android.os.Environment;
-import android.os.StatFs;
 import android.provider.Settings;
 import android.webkit.WebView;
 
@@ -24,26 +22,6 @@ public class Device {
         final Runtime runtime = Runtime.getRuntime();
         final long usedMem = (runtime.totalMemory() - runtime.freeMemory());
         return usedMem;
-    }
-
-    public long getDiskFree() {
-        StatFs statFs = new StatFs(Environment.getRootDirectory().getAbsolutePath());
-        return statFs.getAvailableBlocksLong() * statFs.getBlockSizeLong();
-    }
-
-    public long getDiskTotal() {
-        StatFs statFs = new StatFs(Environment.getRootDirectory().getAbsolutePath());
-        return statFs.getBlockCountLong() * statFs.getBlockSizeLong();
-    }
-
-    public long getRealDiskFree() {
-        StatFs statFs = new StatFs(Environment.getDataDirectory().getAbsolutePath());
-        return statFs.getAvailableBlocksLong() * statFs.getBlockSizeLong();
-    }
-
-    public long getRealDiskTotal() {
-        StatFs statFs = new StatFs(Environment.getDataDirectory().getAbsolutePath());
-        return statFs.getBlockCountLong() * statFs.getBlockSizeLong();
     }
 
     public String getPlatform() {

--- a/device/android/src/main/java/com/capacitorjs/plugins/device/DevicePlugin.java
+++ b/device/android/src/main/java/com/capacitorjs/plugins/device/DevicePlugin.java
@@ -32,10 +32,6 @@ public class DevicePlugin extends Plugin {
         JSObject r = new JSObject();
 
         r.put("memUsed", implementation.getMemUsed());
-        r.put("diskFree", implementation.getDiskFree());
-        r.put("diskTotal", implementation.getDiskTotal());
-        r.put("realDiskFree", implementation.getRealDiskFree());
-        r.put("realDiskTotal", implementation.getRealDiskTotal());
         r.put("model", android.os.Build.MODEL);
         r.put("operatingSystem", "android");
         r.put("osVersion", android.os.Build.VERSION.RELEASE);

--- a/device/ios/Sources/DevicePlugin/Device.swift
+++ b/device/ios/Sources/DevicePlugin/Device.swift
@@ -21,48 +21,6 @@ import UIKit
         }
     }
 
-    /**
-     * Get free disk space
-     */
-    public func getFreeDiskSize() -> Int64? {
-        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
-        if let dictionary = try? FileManager.default.attributesOfFileSystem(forPath: paths.last!) {
-            if let freeSize = dictionary[FileAttributeKey.systemFreeSize] as? NSNumber {
-                return freeSize.int64Value
-            }
-        }
-        return nil
-    }
-
-    /**
-     * Get real free disk space
-     */
-    public func getRealFreeDiskSize() -> Int64? {
-        do {
-            let values = try URL(fileURLWithPath: NSHomeDirectory() as String).resourceValues(forKeys: [URLResourceKey.volumeAvailableCapacityForImportantUsageKey])
-            if let available = values.volumeAvailableCapacityForImportantUsage {
-                return available
-            } else {
-                return nil
-            }
-        } catch {
-            return nil
-        }
-    }
-
-    /**
-     * Get total disk size
-     */
-    public func getTotalDiskSize() -> Int64? {
-        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
-        if let dictionary = try? FileManager.default.attributesOfFileSystem(forPath: paths.last!) {
-            if let freeSize = dictionary[FileAttributeKey.systemSize] as? NSNumber {
-                return freeSize.int64Value
-            }
-        }
-        return nil
-    }
-
     public func getLanguageCode() -> String {
         return String(Locale.preferredLanguages[0].prefix(2))
     }

--- a/device/ios/Sources/DevicePlugin/DevicePlugin.swift
+++ b/device/ios/Sources/DevicePlugin/DevicePlugin.swift
@@ -34,17 +34,10 @@ public class DevicePlugin: CAPPlugin, CAPBridgedPlugin {
         #endif
 
         let memUsed = implementation.getMemoryUsage()
-        let diskFree = implementation.getFreeDiskSize() ?? 0
-        let realDiskFree = implementation.getRealFreeDiskSize() ?? 0
-        let diskTotal = implementation.getTotalDiskSize() ?? 0
         let systemVersionNum = implementation.getSystemVersionInt() ?? 0
 
         call.resolve([
             "memUsed": memUsed,
-            "diskFree": diskFree,
-            "diskTotal": diskTotal,
-            "realDiskFree": realDiskFree,
-            "realDiskTotal": diskTotal,
             "name": UIDevice.current.name,
             "model": modelName,
             "operatingSystem": "ios",

--- a/device/src/__tests__/useragent.spec.ts
+++ b/device/src/__tests__/useragent.spec.ts
@@ -1,11 +1,9 @@
-import type { WebPluginConfig } from '@capacitor/core';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 
 import { DeviceWeb } from '../web';
 
-const config: WebPluginConfig = { name: 'DevicePlugin' };
-const web = new DeviceWeb(config);
+const web = new DeviceWeb();
 
 test('Chrome', () => {
   // Mock empty navigator/window objects

--- a/device/src/definitions.ts
+++ b/device/src/definitions.ts
@@ -100,44 +100,6 @@ export interface DeviceInfo {
   memUsed?: number;
 
   /**
-   * How much free disk space is available on the normal data storage
-   * path for the os, in bytes.
-   *
-   * On Android it returns the free disk space on the "system"
-   * partition holding the core Android OS.
-   * On iOS this value is not accurate.
-   *
-   * @deprecated Use `realDiskFree`.
-   * @since 1.0.0
-   */
-  diskFree?: number;
-
-  /**
-   * The total size of the normal data storage path for the OS, in bytes.
-   *
-   * On Android it returns the disk space on the "system"
-   * partition holding the core Android OS.
-   *
-   * @deprecated Use `realDiskTotal`.
-   * @since 1.0.0
-   */
-  diskTotal?: number;
-
-  /**
-   * How much free disk space is available on the normal data storage, in bytes.
-   *
-   * @since 1.1.0
-   */
-  realDiskFree?: number;
-
-  /**
-   * The total size of the normal data storage path, in bytes.
-   *
-   * @since 1.1.0
-   */
-  realDiskTotal?: number;
-
-  /**
    * The web view browser version
    *
    * @since 1.0.0


### PR DESCRIPTION
Remove the disk (total/available) size information from Device plugin as it's sensitive on iOS and requires a privacy manifest

closes https://github.com/ionic-team/capacitor-plugins/issues/2071