### PR TITLE
Added note on mobile-web-app-capable mete tag

### DIFF
--- a/text-zoom/README.md
+++ b/text-zoom/README.md
@@ -12,6 +12,12 @@ The Text Zoom API provides the ability to change Web View text size for visual a
 }
 ```
 
+**Note:** text-zoom plugin won't work unless your index.html contains this metadata tag.
+
+```html
+<meta name="mobile-web-app-capable" content="yes" />
+```
+
 ## Install
 
 ```bash


### PR DESCRIPTION
The text-zoom plugin would not work unless the following meta tag was added to index.html

<meta name="mobile-web-app-capable" content="yes" />