### PR TITLE
fix(android): crash when trying to open blob urls

### DIFF
--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
@@ -60,25 +60,25 @@ public class BrowserPlugin extends Plugin {
         }
 
         // open the browser and finish
-        try {
-            Intent intent = new Intent(getContext(), BrowserControllerActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            getContext().startActivity(intent);
 
-            Integer finalToolbarColor = toolbarColor;
-            setBrowserControllerListener(
-                activity -> {
+        Intent intent = new Intent(getContext(), BrowserControllerActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        getContext().startActivity(intent);
+
+        Integer finalToolbarColor = toolbarColor;
+        setBrowserControllerListener(
+            activity -> {
+                try {
                     activity.open(implementation, url, finalToolbarColor);
                     browserControllerActivityInstance = activity;
                     call.resolve();
+                } catch (ActivityNotFoundException ex) {
+                    Logger.error(getLogTag(), ex.getLocalizedMessage(), null);
+                    call.reject("Unable to display URL");
                 }
-            );
-        } catch (ActivityNotFoundException ex) {
-            Logger.error(getLogTag(), ex.getLocalizedMessage(), null);
-            call.reject("Unable to display URL");
-            return;
-        }
+            }
+        );
     }
 
     @PluginMethod


### PR DESCRIPTION
### Description
- when trying to open blob urls, an app using the @capacitor/browser plugin would just crash, with an `ActivityNotFoundException`
- the try/catch block wasn't placed properly

references: https://outsystemsrd.atlassian.net/browse/RMET-3912