### PR TITLE
fix(camera): Android dialog not fully showing when in landscape

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraBottomSheetDialogFragment.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraBottomSheetDialogFragment.java
@@ -113,11 +113,12 @@ public class CameraBottomSheetDialogFragment extends BottomSheetDialogFragment {
         dialog.setContentView(parentLayout.getRootView());
 
         CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) ((View) parentLayout.getParent()).getLayoutParams();
-        CoordinatorLayout.Behavior<?> behavior = params.getBehavior();
+        CoordinatorLayout.Behavior<View> behavior = params.getBehavior();
 
         if (behavior instanceof BottomSheetBehavior) {
-            ((BottomSheetBehavior<?>) behavior).addBottomSheetCallback(mBottomSheetBehaviorCallback);
-            ((BottomSheetBehavior<?>) behavior).setState(BottomSheetBehavior.STATE_EXPANDED);
+            BottomSheetBehavior<View> bottomSheetBehavior = (BottomSheetBehavior<View>) behavior;
+            bottomSheetBehavior.addBottomSheetCallback(mBottomSheetBehaviorCallback);
+            bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
         }
     }
 }

--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraBottomSheetDialogFragment.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraBottomSheetDialogFragment.java
@@ -113,10 +113,11 @@ public class CameraBottomSheetDialogFragment extends BottomSheetDialogFragment {
         dialog.setContentView(parentLayout.getRootView());
 
         CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) ((View) parentLayout.getParent()).getLayoutParams();
-        CoordinatorLayout.Behavior behavior = params.getBehavior();
+        CoordinatorLayout.Behavior<?> behavior = params.getBehavior();
 
         if (behavior != null && behavior instanceof BottomSheetBehavior) {
-            ((BottomSheetBehavior) behavior).addBottomSheetCallback(mBottomSheetBehaviorCallback);
+            ((BottomSheetBehavior<?>) behavior).addBottomSheetCallback(mBottomSheetBehaviorCallback);
+            ((BottomSheetBehavior<?>) behavior).setState(BottomSheetBehavior.STATE_EXPANDED);
         }
     }
 }

--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraBottomSheetDialogFragment.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraBottomSheetDialogFragment.java
@@ -115,7 +115,7 @@ public class CameraBottomSheetDialogFragment extends BottomSheetDialogFragment {
         CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) ((View) parentLayout.getParent()).getLayoutParams();
         CoordinatorLayout.Behavior<?> behavior = params.getBehavior();
 
-        if (behavior != null && behavior instanceof BottomSheetBehavior) {
+        if (behavior instanceof BottomSheetBehavior) {
             ((BottomSheetBehavior<?>) behavior).addBottomSheetCallback(mBottomSheetBehaviorCallback);
             ((BottomSheetBehavior<?>) behavior).setState(BottomSheetBehavior.STATE_EXPANDED);
         }


### PR DESCRIPTION
- Fixes the `CameraSheetDialogFragment` that wasn't fully showing when orientation was landscape, by explicitly setting its state to `BottomSheetBehavior.STATE_EXPANDED`.
- Also removes unnecessary null check since `instanceof` will return `false` if `behavior` is null.

Closes: https://github.com/ionic-team/capacitor-plugins/issues/2224