### PR TITLE
Check if a browser supports Custom Tabs before trying to open an URL

### DIFF
--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/Browser.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/Browser.java
@@ -5,11 +5,17 @@ import static androidx.browser.customtabs.CustomTabsIntent.SHARE_STATE_ON;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.browser.customtabs.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The Browser class implements Custom Chrome Tabs. See
@@ -79,6 +85,24 @@ public class Browser {
     @Nullable
     public BrowserEventListener getBrowserEventListenerListener() {
         return browserEventListener;
+    }
+
+    /**
+     * Check if custom tabs are supported.
+     * @return boolean
+     */
+    public boolean areCustomTabsSupported() {
+        PackageManager packageManager = context.getPackageManager();
+        Intent activityIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"));
+        List<ResolveInfo> resolveInfos = packageManager.queryIntentActivities(activityIntent, PackageManager.MATCH_ALL);
+
+        List<String> packageNames = new ArrayList<>();
+        for (ResolveInfo info : resolveInfos) {
+            packageNames.add(info.activityInfo.packageName);
+        }
+
+        String packageName = CustomTabsClient.getPackageName(context, packageNames, true);
+        return packageName != null;
     }
 
     /**

--- a/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
+++ b/browser/android/src/main/java/com/capacitorjs/plugins/browser/BrowserPlugin.java
@@ -59,25 +59,36 @@ public class BrowserPlugin extends Plugin {
             Logger.error(getLogTag(), "Invalid color provided for toolbarColor. Using default", null);
         }
 
-        // open the browser and finish
-        try {
-            Intent intent = new Intent(getContext(), BrowserControllerActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            getContext().startActivity(intent);
+        if (implementation.areCustomTabsSupported()) {
+            // open the browser and finish
+            try {
+                Intent intent = new Intent(getContext(), BrowserControllerActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                getContext().startActivity(intent);
 
-            Integer finalToolbarColor = toolbarColor;
-            setBrowserControllerListener(
-                activity -> {
-                    activity.open(implementation, url, finalToolbarColor);
-                    browserControllerActivityInstance = activity;
-                    call.resolve();
-                }
-            );
-        } catch (ActivityNotFoundException ex) {
-            Logger.error(getLogTag(), ex.getLocalizedMessage(), null);
-            call.reject("Unable to display URL");
-            return;
+                Integer finalToolbarColor = toolbarColor;
+                setBrowserControllerListener(
+                    activity -> {
+                        activity.open(implementation, url, finalToolbarColor);
+                        browserControllerActivityInstance = activity;
+                        call.resolve();
+                    }
+                );
+            } catch (ActivityNotFoundException ex) {
+                Logger.error(getLogTag(), ex.getLocalizedMessage(), null);
+                call.reject("Unable to display URL");
+            }
+        } else {
+            // fallback to opening the URL in the default browser
+            Intent browserIntent = new Intent(Intent.ACTION_VIEW, url);
+            browserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            if (browserIntent.resolveActivity(getContext().getPackageManager()) != null) {
+                getContext().startActivity(browserIntent);
+                call.resolve();
+            } else {
+                call.reject("No application can handle the URL");
+            }
         }
     }
 


### PR DESCRIPTION
Adds a new method `areCustomTabsSupported` to the `Browser` class and uses the method in the `BrowserPlugin`class to check if any browser on the device can handle opening an URL via Custom Tabs. If no browser can handle it, fallback to opening the URL in the default browser.

I used the exact method suggested in the [official documentation](https://developer.chrome.com/docs/android/custom-tabs/howto-custom-tab-check#check_if_any_browser_on_the_device_supports_custom_tabs). The documentation also suggests to do this check to avoid `ActivityNotFoundException` exceptions:

> If no browser supporting Custom Tabs is available in the device and you launch a URL using customTabsIntent.launchUrl(context, url), the intent might fail, leading to an ActivityNotFoundException.

> Always perform a compatibility check to ensure a better user experience.

> You can fallback to a standard ACTION_VIEW Intent to open the URL in any available browser.

This will probably fix some of the exceptions mentioned in this issue: https://github.com/ionic-team/capacitor-plugins/issues/2036