### PR TITLE
fix(camera): Allow cancelation of sheet in Web

### DIFF
--- a/camera/src/web.ts
+++ b/camera/src/web.ts
@@ -23,7 +23,7 @@ export class CameraWeb extends WebPlugin implements CameraPlugin {
           document.body.appendChild(actionSheet);
         }
         actionSheet.header = options.promptLabelHeader || 'Photo';
-        actionSheet.cancelable = false;
+        actionSheet.cancelable = true;
         actionSheet.options = [
           { title: options.promptLabelPhoto || 'From Photos' },
           { title: options.promptLabelPicture || 'Take Picture' },


### PR DESCRIPTION
The `actionSheet` prompt was previously not cancellable in Web, even though it is cancellable

- [on Android](https://github.com/ionic-team/capacitor-plugins/blob/main/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java#L172) -  `setCancelable(false)` not called, by default it is cancelable
- [and on iOS](https://github.com/ionic-team/capacitor-plugins/blob/main/camera/ios/Sources/CameraPlugin/CameraPlugin.swift#L417) - `UIAlertAction` with style `cancel` allows sheet to be canceled when clicking outside.

This PR fixes that.

Addresses https://github.com/ionic-team/capacitor-plugins/issues/2241 and https://github.com/ionic-team/pwa-elements/issues/134