### PR TITLE
feat(action-sheet): Add cancelable parameter

### DIFF
--- a/action-sheet/README.md
+++ b/action-sheet/README.md
@@ -84,18 +84,20 @@ to select.
 
 #### ShowActionsResult
 
-| Prop        | Type                | Description                                  | Since |
-| ----------- | ------------------- | -------------------------------------------- | ----- |
-| **`index`** | <code>number</code> | The index of the clicked option (Zero-based) | 1.0.0 |
+| Prop           | Type                 | Description                                  | Since |
+| -------------- | -------------------- | -------------------------------------------- | ----- |
+| **`index`**    | <code>number</code>  | The index of the clicked option (Zero-based), or -1 if the sheet was canceled. On iOS, if there is a button with ActionSheetButtonStyle.Cancel, and user clicks outside the sheet, the index of the cancel option is returned | 1.0.0 |
+| **`canceled`** | <code>boolean</code> | True if sheet was canceled by user; False otherwise | 6.1.0 |
 
 
 #### ShowActionsOptions
 
-| Prop          | Type                             | Description                                                              | Since |
-| ------------- | -------------------------------- | ------------------------------------------------------------------------ | ----- |
-| **`title`**   | <code>string</code>              | The title of the Action Sheet.                                           | 1.0.0 |
-| **`message`** | <code>string</code>              | A message to show under the title. This option is only supported on iOS. | 1.0.0 |
-| **`options`** | <code>ActionSheetButton[]</code> | Options the user can choose from.                                        | 1.0.0 |
+| Prop             | Type                             | Description                                                              | Since |
+| ---------------- | -------------------------------- | ------------------------------------------------------------------------ | ----- |
+| **`title`**      | <code>string</code>              | The title of the Action Sheet.                                           | 1.0.0 |
+| **`message`**    | <code>string</code>              | A message to show under the title. This option is only supported on iOS. | 1.0.0 |
+| **`options`**    | <code>ActionSheetButton[]</code> | Options the user can choose from.                                        | 1.0.0 |
+| **`cancelable`** | <code>boolean</code>             | If true, sheet is canceled when clicked outside; If false, it is not. By default, false. On iOS, the sheet is also cancelable if a button with ActionSheetButtonStyle.Cancel is provided and cancelable is false. | 6.1.0 |
 
 
 #### ActionSheetButton

--- a/action-sheet/android/src/main/java/com/capacitorjs/plugins/actionsheet/ActionSheet.java
+++ b/action-sheet/android/src/main/java/com/capacitorjs/plugins/actionsheet/ActionSheet.java
@@ -26,7 +26,9 @@ public class ActionSheet extends BottomSheetDialogFragment {
     @Override
     public void onCancel(DialogInterface dialog) {
         super.onCancel(dialog);
-        this.cancelListener.onCancel();
+        if (this.cancelListener != null) {
+            this.cancelListener.onCancel();
+        }
     }
 
     private String title;

--- a/action-sheet/android/src/main/java/com/capacitorjs/plugins/actionsheet/ActionSheetPlugin.java
+++ b/action-sheet/android/src/main/java/com/capacitorjs/plugins/actionsheet/ActionSheetPlugin.java
@@ -43,21 +43,24 @@ public class ActionSheetPlugin extends Plugin {
             implementation.setCancelable(cancelable);
             if (cancelable) {
                 implementation.setOnCancelListener(
-                        () -> call.reject("User canceled action sheet")
+                    () -> resolve(call, -1)
                 );
             }
             implementation.setOnSelectedListener(
-                index -> {
-                    JSObject ret = new JSObject();
-                    ret.put("index", index);
-                    call.resolve(ret);
-                    implementation.dismiss();
-                }
+                index -> resolve(call, index)
             );
             implementation.show(getActivity().getSupportFragmentManager(), "capacitorModalsActionSheet");
         } catch (JSONException ex) {
             Logger.error("JSON error processing an option for showActions", ex);
             call.reject("JSON error processing an option for showActions", ex);
         }
+    }
+    
+    private void resolve(final PluginCall call, int selectedIndex) {
+        JSObject ret = new JSObject();
+        ret.put("index", selectedIndex);
+        ret.put("canceled", selectedIndex < 0);
+        call.resolve(ret);
+        implementation.dismiss();
     }
 }

--- a/action-sheet/android/src/main/java/com/capacitorjs/plugins/actionsheet/ActionSheetPlugin.java
+++ b/action-sheet/android/src/main/java/com/capacitorjs/plugins/actionsheet/ActionSheetPlugin.java
@@ -19,6 +19,7 @@ public class ActionSheetPlugin extends Plugin {
     @PluginMethod
     public void showActions(final PluginCall call) {
         String title = call.getString("title");
+        boolean cancelable = Boolean.TRUE.equals(call.getBoolean("cancelable", false));
         JSArray options = call.getArray("options");
         if (options == null) {
             call.reject("Must supply options");
@@ -39,7 +40,12 @@ public class ActionSheetPlugin extends Plugin {
             }
             implementation.setTitle(title);
             implementation.setOptions(actionOptions);
-            implementation.setCancelable(false);
+            implementation.setCancelable(cancelable);
+            if (cancelable) {
+                implementation.setOnCancelListener(
+                        () -> call.reject("User canceled action sheet")
+                );
+            }
             implementation.setOnSelectedListener(
                 index -> {
                     JSObject ret = new JSObject();

--- a/action-sheet/ios/Sources/ActionSheetPlugin/ActionSheetPlugin.swift
+++ b/action-sheet/ios/Sources/ActionSheetPlugin/ActionSheetPlugin.swift
@@ -35,7 +35,8 @@ public class ActionSheetPlugin: CAPPlugin, CAPBridgedPlugin {
             }
             let action = UIAlertAction(title: title, style: buttonStyle, handler: { (_) -> Void in
                 call.resolve([
-                    "index": index
+                    "index": index,
+                    "canceled": false
                 ])
             })
             alertActions.append(action)
@@ -48,7 +49,10 @@ public class ActionSheetPlugin: CAPPlugin, CAPBridgedPlugin {
                     if (forceCancelableOnClickOutside) {
                         let gestureRecognizer = TapGestureRecognizerWithClosure {
                             alertController.dismiss(animated: true, completion: nil)
-                            call.reject("User canceled action sheet")
+                            call.resolve([
+                                "index": -1,
+                                "canceled": true
+                            ])
                         }
                         let backroundView = alertController.view.superview?.subviews[0]
                         backroundView?.addGestureRecognizer(gestureRecognizer)

--- a/action-sheet/src/definitions.ts
+++ b/action-sheet/src/definitions.ts
@@ -16,6 +16,16 @@ export interface ShowActionsOptions {
   message?: string;
 
   /**
+   * If true, sheet is canceled when clicked outside; If false, it is not. By default, false.
+   * 
+   * On iOS, sheet is also cancelable if a button with ActionSheetButtonStyle.Cancel is provided and cancelable is false.
+   * 
+   * @since TODO provide release number
+   */
+  cancelable?: boolean;
+
+
+  /**
    * Options the user can choose from.
    *
    * @since 1.0.0

--- a/action-sheet/src/definitions.ts
+++ b/action-sheet/src/definitions.ts
@@ -20,7 +20,7 @@ export interface ShowActionsOptions {
    * 
    * On iOS, sheet is also cancelable if a button with ActionSheetButtonStyle.Cancel is provided and cancelable is false.
    * 
-   * @since TODO provide release number
+   * @since 6.1.0
    */
   cancelable?: boolean;
 
@@ -86,11 +86,19 @@ export interface ActionSheetButton {
 
 export interface ShowActionsResult {
   /**
-   * The index of the clicked option (Zero-based)
+   * The index of the clicked option (Zero-based), or -1 if the sheet was canceled.
+   * 
+   * On iOS, if there is a button with ActionSheetButtonStyle.Cancel, and user clicks outside the sheet, the index of the cancel option is returned
    *
    * @since 1.0.0
    */
   index: number;
+  /**
+   * True if sheet was canceled by user; False otherwise
+   * 
+   * @since 6.1.0
+   */
+  canceled: boolean;
 }
 
 export interface ActionSheetPlugin {

--- a/action-sheet/src/definitions.ts
+++ b/action-sheet/src/definitions.ts
@@ -16,21 +16,20 @@ export interface ShowActionsOptions {
   message?: string;
 
   /**
-   * If true, sheet is canceled when clicked outside; If false, it is not. By default, false.
-   * 
-   * On iOS, sheet is also cancelable if a button with ActionSheetButtonStyle.Cancel is provided and cancelable is false.
-   * 
-   * @since 6.1.0
-   */
-  cancelable?: boolean;
-
-
-  /**
    * Options the user can choose from.
    *
    * @since 1.0.0
    */
   options: ActionSheetButton[];
+
+  /**
+   * If true, sheet is canceled when clicked outside; If false, it is not. By default, false.
+   * 
+   * On iOS, the sheet is also cancelable if a button with ActionSheetButtonStyle.Cancel is provided and cancelable is false.
+   * 
+   * @since 6.1.0
+   */
+  cancelable?: boolean;
 }
 
 export enum ActionSheetButtonStyle {

--- a/action-sheet/src/web.ts
+++ b/action-sheet/src/web.ts
@@ -15,14 +15,23 @@ export class ActionSheetWeb extends WebPlugin implements ActionSheetPlugin {
         document.body.appendChild(actionSheet);
       }
       actionSheet.header = options.title;
-      actionSheet.cancelable = false;
+      actionSheet.cancelable = options.cancelable;
       actionSheet.options = options.options;
       actionSheet.addEventListener('onSelection', async (e: any) => {
         const selection = e.detail;
         resolve({
           index: selection,
+          canceled: false
         });
       });
+      if (options.cancelable) {
+        actionSheet.addEventListener('onCanceled', async () => {
+          resolve({
+            index: -1,
+            canceled: true
+          });
+        })
+      }
     });
   }
 }


### PR DESCRIPTION
Add parameter to allow action-sheet to be cancelable (clicking outside the sheet, and using the system back button on Android), and in case it is canceled, return it in the result.

Notes:

- There's some slight differences in behavior for iOS, because it supports the `ActionSheetButtonStyle` property that other platforms do not - explained in the doc updates that are also in this PR.
- For this to work with PWAs, it requires https://github.com/ionic-team/pwa-elements/pull/138


Fixes https://github.com/ionic-team/capacitor-plugins/issues/2154