### PR TITLE
Add check for invalid use of multiple scheduler types

### DIFF
--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
@@ -332,8 +332,15 @@ public class LocalNotificationManager {
         }
         PendingIntent pendingIntent = PendingIntent.getBroadcast(context, request.getId(), notificationIntent, flags);
 
-        // Schedule at specific time (with repeating support)
         Date at = schedule.getAt();
+        String every = schedule.getEvery();
+        DateMatch on = schedule.getOn();
+        if ((at != null ? 0 : 1) + (every != null ? 0 : 1) + (on != null ? 0 : 1) <= 1) {
+            Logger.error(Logger.tags("LN"), "You cannot use multiple scheduler types. Use either 'at', 'every' or 'on' in the schedule object.", null);
+            return;
+        }
+
+        // Schedule at specific time (with repeating support)
         if (at != null) {
             if (at.getTime() < new Date().getTime()) {
                 Logger.error(Logger.tags("LN"), "Scheduled time must be *after* current time", null);
@@ -349,7 +356,6 @@ public class LocalNotificationManager {
         }
 
         // Schedule at specific intervals
-        String every = schedule.getEvery();
         if (every != null) {
             Long everyInterval = schedule.getEveryInterval();
             if (everyInterval != null) {
@@ -360,7 +366,6 @@ public class LocalNotificationManager {
         }
 
         // Cron like scheduler
-        DateMatch on = schedule.getOn();
         if (on != null) {
             long trigger = on.nextTrigger(new Date());
             notificationIntent.putExtra(TimedNotificationPublisher.CRON_KEY, on.toMatchString());

--- a/local-notifications/ios/Sources/LocalNotificationsPlugin/LocalNotificationsPlugin.swift
+++ b/local-notifications/ios/Sources/LocalNotificationsPlugin/LocalNotificationsPlugin.swift
@@ -284,6 +284,11 @@ public class LocalNotificationsPlugin: CAPPlugin, CAPBridgedPlugin {
         let on = schedule["on"] as? JSObject
         let repeats = schedule["repeats"] as? Bool ?? false
 
+        if (at != nil ? 1 : 0) + (on != nil ? 1 : 0) + (every != nil ? 1 : 0) <= 1 {
+            call.reject("You cannot use multiple scheduler types. Use either 'at', 'every' or 'on' in the schedule object.")
+            return nil
+        }
+
         // If there's a specific date for this notificiation
         if let at = at {
             let dateInfo = Calendar.current.dateComponents(in: TimeZone.current, from: at)


### PR DESCRIPTION
Added a check for invalid use of multiple scheduler types in the capacitor-local-notifications plugin. I think this is a good idea as the scheduler types are checked in an arbitrary order and it might not be clear from a developers side what would happen. I decided to handle the error in similar style as the rest of the function for the respective platform.

I also noticed the handling of the scheduled time being after current time check is handled with an exception on ios, but on android it is handled by exiting out of the function and logging an error, which seems inconsistent.