### PR TITLE
chore: make SPM use version 7 instead of main

### DIFF
--- a/action-sheet/Package.swift
+++ b/action-sheet/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["ActionSheetPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/app-launcher/Package.swift
+++ b/app-launcher/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["AppLauncherPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/app/Package.swift
+++ b/app/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["AppPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/browser/Package.swift
+++ b/browser/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["BrowserPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/camera/Package.swift
+++ b/camera/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["CameraPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/clipboard/Package.swift
+++ b/clipboard/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["ClipboardPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/device/Package.swift
+++ b/device/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["DevicePlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/dialog/Package.swift
+++ b/dialog/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["DialogPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/filesystem/Package.swift
+++ b/filesystem/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["FilesystemPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/geolocation/Package.swift
+++ b/geolocation/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["GeolocationPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/haptics/Package.swift
+++ b/haptics/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["HapticsPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/keyboard/Package.swift
+++ b/keyboard/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["KeyboardPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/local-notifications/Package.swift
+++ b/local-notifications/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["LocalNotificationsPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/network/Package.swift
+++ b/network/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["CAPNetworkPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/preferences/Package.swift
+++ b/preferences/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["PreferencesPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/push-notifications/Package.swift
+++ b/push-notifications/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["PushNotificationsPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/screen-orientation/Package.swift
+++ b/screen-orientation/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["ScreenOrientationPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/screen-reader/Package.swift
+++ b/screen-reader/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["ScreenReaderPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/share/Package.swift
+++ b/share/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["SharePlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/splash-screen/Package.swift
+++ b/splash-screen/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["SplashScreenPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/status-bar/Package.swift
+++ b/status-bar/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["StatusBarPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/text-zoom/Package.swift
+++ b/text-zoom/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["TextZoomPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(

--- a/toast/Package.swift
+++ b/toast/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["ToastPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Configure plugins `Package.swift` to use version 7.0.0 instead of main branch as main branch could have 6.x versions some times.