### PR TITLE
feat: Implement exitApp in iOS

### DIFF
--- a/app/ios/Sources/AppPlugin/AppPlugin.swift
+++ b/app/ios/Sources/AppPlugin/AppPlugin.swift
@@ -75,7 +75,12 @@ public class AppPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc func exitApp(_ call: CAPPluginCall) {
-        call.unimplemented()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            UIApplication.shared.perform(#selector(NSXPCConnection.suspend))
+             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+              exit(0)
+            }
+        }
     }
 
     @objc func getInfo(_ call: CAPPluginCall) {


### PR DESCRIPTION
This pull request introduces a change in the Ionic Capacitor plugin for iOS to ensure a smoother and more reliable app termination process. The updated implementation delays the suspension and exit calls, reducing the risk of premature termination issues.

### Changes Introduced

- Added a delay of 0.2 seconds using DispatchQueue.main.asyncAfter before calling UIApplication.shared.perform(#selector(NSXPCConnection.suspend)).
- Introduced an additional 0.2-second delay before executing exit(0) to ensure proper app suspension prior to termination.

**Reason for the Change**

- This change addresses potential issues with abrupt app termination on iOS devices, ensuring:
- All necessary background operations or state-saving mechanisms have sufficient time to complete before suspension.
- A smoother user experience during app closure.

**Code Change**

```swift
DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
    UIApplication.shared.perform(#selector(NSXPCConnection.suspend))
    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
        exit(0)
    }
}

```

**Testing**

- Verified the app termination process on multiple iOS devices to confirm:
- The app suspends and exits gracefully.
- No crashes or unexpected behavior during termination.

**Impacts**

- This change affects the app termination process in iOS only.
- No impact on Android or other platforms.