### PR TITLE
Performance improvement for Camera plugin.

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -746,13 +746,14 @@ public class CameraPlugin extends Plugin {
      * @return
      */
     private Bitmap prepareBitmap(Bitmap bitmap, Uri imageUri, ExifWrapper exif) throws IOException {
-        if (settings.isShouldCorrectOrientation()) {
-            final Bitmap newBitmap = ImageUtils.correctOrientation(getContext(), bitmap, imageUri, exif);
-            bitmap = replaceBitmap(bitmap, newBitmap);
-        }
 
         if (settings.isShouldResize()) {
             final Bitmap newBitmap = ImageUtils.resize(bitmap, settings.getWidth(), settings.getHeight());
+            bitmap = replaceBitmap(bitmap, newBitmap);
+        }
+
+        if (settings.isShouldCorrectOrientation()) {
+            final Bitmap newBitmap = ImageUtils.correctOrientation(getContext(), bitmap, imageUri, exif);
             bitmap = replaceBitmap(bitmap, newBitmap);
         }
 


### PR DESCRIPTION
Rotating the bitmap is expensive on some devices. Doing the resize before the rotation reduces notably the delay on these devices.