### PR TITLE
Fix Android Camera crash when opening photo gallery with limit

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -347,6 +347,15 @@ public class CameraPlugin extends Plugin {
 
     private ActivityResultContract<PickVisualMediaRequest, List<Uri>> getContractForCall(final PluginCall call) {
         int limit = call.getInt("limit", 0);
+
+        // Ensure limit does not exceed system max limit
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            int maxLimit = MediaStore.getPickImagesMaxLimit();
+            if (limit > maxLimit) {
+                limit = maxLimit; // Restrict to allowed limit
+            }
+        }
+        
         if (limit > 1) {
             return new ActivityResultContracts.PickMultipleVisualMedia(limit);
         } else {


### PR DESCRIPTION
Prevents a crash where if the user specifies a `limit` to `pickImages` that is above the system's maximum limit. Currently supplying a limit value of, say, 10,000 will result in crash with the following exception:

> Max items must be less or equals MediaStore.getPickImagesMaxLimit()

This change makes the check as suggested in the error.