### PR TITLE
fix(filesystem): respect downloadFile recursive option on Android and iOS

### DIFF
--- a/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/Filesystem.java
+++ b/filesystem/android/src/main/java/com/capacitorjs/plugins/filesystem/Filesystem.java
@@ -340,6 +340,7 @@ public class Filesystem {
         Boolean disableRedirects = call.getBoolean("disableRedirects");
         Boolean shouldEncode = call.getBoolean("shouldEncodeUrlParams", true);
         Boolean progress = call.getBoolean("progress", false);
+        Boolean recursive = call.getBoolean("recursive", false);
 
         String method = call.getString("method", "GET").toUpperCase(Locale.ROOT);
         String path = call.getString("path");
@@ -347,6 +348,10 @@ public class Filesystem {
 
         final URL url = new URL(urlString);
         final File file = getFileObject(path, directory);
+
+        if(recursive) {
+            file.getParentFile().mkdirs();
+        }
 
         HttpRequestHandler.HttpURLConnectionBuilder connectionBuilder = new HttpRequestHandler.HttpURLConnectionBuilder()
             .setUrl(url)

--- a/filesystem/ios/Sources/FilesystemPlugin/Filesystem.swift
+++ b/filesystem/ios/Sources/FilesystemPlugin/Filesystem.swift
@@ -186,6 +186,7 @@ import Capacitor
     // swiftlint:disable function_body_length
     @objc public func downloadFile(call: CAPPluginCall, emitter: @escaping ProgressEmitter, config: InstanceConfiguration?) throws {
         let directory = call.getString("directory", "DOCUMENTS")
+        let recursive = call.getBool("recursive", false)
         guard let path = call.getString("path") else {
             call.reject("Invalid file path")
             return
@@ -222,7 +223,7 @@ import Capacitor
                     let dest = dir!.appendingPathComponent(path)
                     CAPLog.print("Attempting to write to file destination: \(dest.absoluteString)")
 
-                    if !FileManager.default.fileExists(atPath: dest.deletingLastPathComponent().absoluteString) {
+                    if recursive && !FileManager.default.fileExists(atPath: dest.deletingLastPathComponent().absoluteString) {
                         try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
                     }
 


### PR DESCRIPTION
Resolution for https://github.com/ionic-team/capacitor-plugins/issues/1835

While on Android an error is thrown because missing directories are never created, the iOS implementation ignores the recursive option by always creating directories if they don't exist.

Both implementations updated to respect the recursive parameter.