### PR TITLE
fix: iOS push notifications alert --> banner

### DIFF
--- a/push-notifications/ios/Sources/PushNotificationsPlugin/PushNotificationsHandler.swift
+++ b/push-notifications/ios/Sources/PushNotificationsPlugin/PushNotificationsHandler.swift
@@ -35,10 +35,11 @@ public class PushNotificationsHandler: NSObject, NotificationHandlerProtocol {
             optionsArray.forEach { option in
                 switch option {
                 case "alert":
-                    presentationOptions.insert(.alert)
+                    presentationOptions.insert(.banner)
+                case "banner":
+                    presentationOptions.insert(.banner)
                 case "badge":
                     presentationOptions.insert(.badge)
-
                 case "sound":
                     presentationOptions.insert(.sound)
                 default:


### PR DESCRIPTION
The `alert` notification type has been deprecated since iOS 14, and should now be replaced by `banner`.