### PR TITLE
Do not throw an error when haptics is not supported by a browser

### DIFF
--- a/haptics/src/web.ts
+++ b/haptics/src/web.ts
@@ -64,7 +64,7 @@ export class HapticsWeb extends WebPlugin implements HapticsPlugin {
     if (navigator.vibrate) {
       navigator.vibrate(pattern);
     } else {
-      throw this.unavailable('Browser does not support the vibrate API');
+      console.error('Browser does not support the vibrate API');
     }
   }
 }


### PR DESCRIPTION
Haptics should not throw an error when the platform doesn't support haptics.