### PR TITLE
fix(@capacitor/haptics): prevent thread overload by reusing CHHapticEngine

### DIFF
--- a/haptics/ios/Sources/HapticsPlugin/Haptics.swift
+++ b/haptics/ios/Sources/HapticsPlugin/Haptics.swift
@@ -6,6 +6,46 @@ import CoreHaptics
 
     var selectionFeedbackGenerator: UISelectionFeedbackGenerator?
 
+    private var hapticEngine: CHHapticEngine?
+    private var idleTimer: Timer?
+    private let idleInterval: TimeInterval = 5.0
+
+    private func initializeEngine() {
+        do {
+            let engine = try CHHapticEngine()
+            engine.resetHandler = { [weak self] in
+                do {
+                    try self?.hapticEngine?.start()
+                } catch {
+                    self?.hapticEngine = nil
+                }
+            }
+            engine.stoppedHandler = { [weak self] _ in
+                self?.hapticEngine = nil
+            }
+            try engine.start()
+            hapticEngine = engine
+        } catch {
+            hapticEngine = nil
+        }
+    }
+
+    private func resetIdleTimer(after duration: TimeInterval) {
+        idleTimer?.invalidate()
+        idleTimer = Timer.scheduledTimer(
+            withTimeInterval: duration + idleInterval, repeats: false
+        ) { [weak self] _ in
+            self?.shutdownEngine()
+        }
+    }
+
+    private func shutdownEngine() {
+        idleTimer?.invalidate()
+        idleTimer = nil
+        hapticEngine?.stop(completionHandler: nil)
+        hapticEngine = nil
+    }
+
     @objc public func impact(_ impactStyle: UIImpactFeedbackGenerator.FeedbackStyle) {
         let generator = UIImpactFeedbackGenerator(style: impactStyle)
         generator.impactOccurred()
@@ -38,16 +78,17 @@ import CoreHaptics
 
     @objc public func vibrate(_ duration: Double) {
         if CHHapticEngine.capabilitiesForHardware().supportsHaptics {
+            if hapticEngine == nil {
+                initializeEngine()
+            }
+            resetIdleTimer(after: duration)
+
+            guard let engine = hapticEngine else {
+                vibrate()
+                return
+            }
+
             do {
-                let engine = try CHHapticEngine()
-                try engine.start()
-                engine.resetHandler = { [] in
-                    do {
-                        try engine.start()
-                    } catch {
-                        self.vibrate()
-                    }
-                }
                 let intensity = CHHapticEventParameter(parameterID: .hapticIntensity, value: 1.0)
                 let sharpness = CHHapticEventParameter(parameterID: .hapticSharpness, value: 1.0)
 


### PR DESCRIPTION
### Fix: Prevent iOS app freeze by reusing `CHHapticEngine` instance

This PR addresses an issue where calling `Haptics.vibrate()` rapidly (e.g., from a fast-scrolling picker in my case) causes the app to hang or crash on iOS. The problem stems from creating a new `CHHapticEngine` instance on each call, which leads to excessive thread creation and eventual system overload.

#### Solution
- Reuses a single `CHHapticEngine` instance across multiple vibration calls.
- Ensures the engine is only created and started when necessary.
- Handles engine lifecycle and failure states gracefully.

This fix improves performance and stability, especially in high-frequency vibration scenarios.

#### Related Issue [#1960](https://github.com/ionic-team/capacitor-haptics/issues/7)
