### PR TITLE
chore(ci): Remove assign-to-project task

### DIFF
--- a/.github/bot.yml
+++ b/.github/bot.yml
@@ -32,16 +32,3 @@ tasks:
     on:
       issues:
         types: [opened, edited]
-  - name: assign-to-project
-    on:
-      issues:
-        types: [opened]
-      pull_request:
-        types: [opened]
-    condition: |-
-      (await getTeamMembers('capacitor')).includes(payload.sender.login)
-    config:
-      columns:
-        issue: 10495656
-        pr: 10495659
-        draft-pr: 10495658


### PR DESCRIPTION
GitHub projects are deprecated and causes errors on the task