### PR TITLE
fix(filesystem): progress notification for the last chunk

### DIFF
--- a/filesystem/ios/Sources/FilesystemPlugin/Filesystem.swift
+++ b/filesystem/ios/Sources/FilesystemPlugin/Filesystem.swift
@@ -309,7 +309,9 @@ import Capacitor
                     let timeElapsed = currentTimestamp - lastEmitTimestamp
 
                     if totalBytesExpectedToWrite > 0 {
-                        if timeElapsed >= 0.1 {
+                        let isTimeToEmit = timeElapsed >= 0.1
+                        let isLastChunk = totalBytesWritten == totalBytesExpectedToWrite
+                        if isTimeToEmit || isLastChunk {
                             emitter(totalBytesWritten, totalBytesExpectedToWrite)
                             lastEmitTimestamp = currentTimestamp
                         }


### PR DESCRIPTION
The progress notification might not be triggered when a file finishes downloading if it completes too quickly due to the time-based threshold logic. As a result, the client may never receive a progress update showing 100% completion (it often stops at something like 98.1234%).

This PR ensures that the progress notification is sent when the file has fully downloaded, guaranteeing the client receives an update with 100% progress.

### Improvements to progress update logic:
* [`filesystem/ios/Sources/FilesystemPlugin/Filesystem.swift`](diffhunk://#diff-8864871a9496f81093f0dd9f562a4932d5c6c0005267b79a02c645ca1452a650L312-R314): Added `isTimeToEmit` and `isLastChunk` variables to clarify the conditions for emitting progress updates. This ensures that progress is emitted either when the time threshold (`0.1` seconds) is reached or when the operation is complete (`totalBytesWritten == totalBytesExpectedToWrite`).