### PR TITLE
fix: test for Linux, FreeBSD, and OpenBSD in device plugin

### DIFF
--- a/device/README.md
+++ b/device/README.md
@@ -173,6 +173,6 @@ Get the device's current language locale tag.
 
 #### OperatingSystem
 
-<code>'ios' | 'android' | 'windows' | 'mac' | 'unknown'</code>
+<code>'ios' | 'android' | 'windows' | 'mac' | 'linux' | 'freebsd' | 'openbsd' | 'unknown'</code>
 
 </docgen-api>

--- a/device/src/definitions.ts
+++ b/device/src/definitions.ts
@@ -1,4 +1,4 @@
-export type OperatingSystem = 'ios' | 'android' | 'windows' | 'mac' | 'unknown';
+export type OperatingSystem = 'ios' | 'android' | 'windows' | 'mac' | 'linux' | 'freebsd' | 'openbsd' | 'unknown';
 
 export interface DeviceId {
   /**

--- a/device/src/web.ts
+++ b/device/src/web.ts
@@ -122,6 +122,12 @@ export class DeviceWeb extends WebPlugin implements DevicePlugin {
       uaFields.operatingSystem = 'windows';
     } else if (/Mac/i.test(ua)) {
       uaFields.operatingSystem = 'mac';
+    } else if (/Linux/i.test(ua)) {
+      uaFields.operatingSystem = 'linux';
+    } else if (/FreeBSD/i.test(ua)) {
+      uaFields.operatingSystem = 'freebsd';
+    } else if (/OpenBSD/i.test(ua)) {
+      uaFields.operatingSystem = 'openbsd';
     } else {
       uaFields.operatingSystem = 'unknown';
     }


### PR DESCRIPTION
Right now, anything that isn't macOS or Windows is considered "unknown" when running `await Device.getInfo();` on the web. This PR fixes that issue for Linux, FreeBSD, and OpenBSD by testing the UserAgent against those operating systems' common identifiers.

https://explore.whatismybrowser.com/useragents/explore/operating_system_name/linux/
https://explore.whatismybrowser.com/useragents/explore/operating_system_name/freebsd/
https://explore.whatismybrowser.com/useragents/explore/operating_system_name/openbsd/