### PR TITLE
docs(filesystem): Plugin migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ This repository contains the official Capacitor plugins maintained by the Capaci
 | [`@capacitor/clipboard`](https://capacitorjs.com/docs/apis/clipboard) | [`./clipboard`](./clipboard) | [![npm badge](https://img.shields.io/npm/v/@capacitor/clipboard?style=flat-square)](https://www.npmjs.com/package/@capacitor/clipboard)
 | [`@capacitor/device`](https://capacitorjs.com/docs/apis/device) | [`./device`](./device) | [![npm badge](https://img.shields.io/npm/v/@capacitor/device?style=flat-square)](https://www.npmjs.com/package/@capacitor/device)
 | [`@capacitor/dialog`](https://capacitorjs.com/docs/apis/dialog) | [`./dialog`](./dialog) | [![npm badge](https://img.shields.io/npm/v/@capacitor/dialog?style=flat-square)](https://www.npmjs.com/package/@capacitor/dialog)
-| [`@capacitor/filesystem`](https://capacitorjs.com/docs/apis/filesystem) | [`./filesystem`](./filesystem) | [![npm badge](https://img.shields.io/npm/v/@capacitor/filesystem?style=flat-square)](https://www.npmjs.com/package/@capacitor/filesystem)
-| [`@capacitor/geolocation`](https://capacitorjs.com/docs/apis/geolocation) | [Migrated](https://github.com/ionic-team/capacitor-geolocation) | [![npm badge](https://img.shields.io/npm/v/@capacitor/geolocation?style=flat-square)](https://www.npmjs.com/package/@capacitor/geolocation)
 | [`@capacitor/haptics`](https://capacitorjs.com/docs/apis/haptics) | [`./haptics`](./haptics) | [![npm badge](https://img.shields.io/npm/v/@capacitor/haptics?style=flat-square)](https://www.npmjs.com/package/@capacitor/haptics)
 | [`@capacitor/keyboard`](https://capacitorjs.com/docs/apis/keyboard) | [`./keyboard`](./keyboard) | [![npm badge](https://img.shields.io/npm/v/@capacitor/keyboard?style=flat-square)](https://www.npmjs.com/package/@capacitor/keyboard)
 | [`@capacitor/local-notifications`](https://capacitorjs.com/docs/apis/local-notifications) | [`./local-notifications`](./local-notifications) | [![npm badge](https://img.shields.io/npm/v/@capacitor/local-notifications?style=flat-square)](https://www.npmjs.com/package/@capacitor/local-notifications)
@@ -47,7 +45,13 @@ These are official Capacitor plugins that are not contained in this repository.
 | --- | --- | --- |
 | [Background Runner](https://github.com/ionic-team/capacitor-background-runner) | [`@capacitor/background-runner`](https://capacitorjs.com/docs/apis/background-runner) | [![npm badge](https://img.shields.io/npm/v/@capacitor/background-runner?style=flat-square)](https://www.npmjs.com/package/@capacitor/background-runner) |
 | [Barcode Scanner](https://github.com/ionic-team/capacitor-barcode-scanner) | [`@capacitor/barcode-scanner`](https://capacitorjs.com/docs/apis/barcode-scanner) | [![npm badge](https://img.shields.io/npm/v/@capacitor/barcode-scanner?style=flat-square)](https://www.npmjs.com/package/@capacitor/barcode-scanner) |
+| [Filesystem](https://github.com/ionic-team/capacitor-filesystem) (*) | [`@capacitor/geolocation`](https://capacitorjs.com/docs/apis/filesystem) | [![npm badge](https://img.shields.io/npm/v/@capacitor/filesystem?style=flat-square)](https://www.npmjs.com/package/@capacitor/filesystem) |
+| [File Transfer](https://github.com/ionic-team/capacitor-file-transfer) | [`@capacitor/geolocation`](https://capacitorjs.com/docs/apis/file-transfer) | [![npm badge](https://img.shields.io/npm/v/@capacitor/file-transfer?style=flat-square)](https://www.npmjs.com/package/@capacitor/file-transfer) |
+| [File Viewer](https://github.com/ionic-team/capacitor-file-viewer) | [`@capacitor/geolocation`](https://capacitorjs.com/docs/apis/file-viewer) | [![npm badge](https://img.shields.io/npm/v/@capacitor/file-viewer?style=flat-square)](https://www.npmjs.com/package/@capacitor/file-viewer) |
+| [Geolocation](https://github.com/ionic-team/capacitor-geolocation) (*) | [`@capacitor/geolocation`](https://capacitorjs.com/docs/apis/geolocation) | [![npm badge](https://img.shields.io/npm/v/@capacitor/geolocation?style=flat-square)](https://www.npmjs.com/package/@capacitor/geolocation) |
 | [Google Maps](https://github.com/ionic-team/capacitor-google-maps) | [`@capacitor/google-maps`](https://capacitorjs.com/docs/apis/google-maps) | [![npm badge](https://img.shields.io/npm/v/@capacitor/google-maps?style=flat-square)](https://www.npmjs.com/package/@capacitor/google-maps) |
+
+(*) These plugins were once part of this repository, but have been since been revamped and migrated to a separate repository. The code pre-migration still remains in this repository for historic purposes.
 
 ## Capacitor Labs
 

--- a/filesystem/CHANGELOG.md
+++ b/filesystem/CHANGELOG.md
@@ -1,3 +1,7 @@
+# ⓘ Plugin migrated
+
+**From version 7.1.0 onwards, this plugin is now hosted in a separate repository. Refer to the [updated CHANGELOG](https://github.com/ionic-team/capacitor-filesystem/blob/main/CHANGELOG.md).**
+
 # Change Log
 
 All notable changes to this project will be documented in this file.

--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -1,6 +1,6 @@
 # ⓘ Plugin migrated
 
-**From version 7.1.0 onwards, this plugin is now housed in a separate repository. Refer to [capacitor-filesystem repository](https://github.com/ionic-team/capacitor-filesystem).**
+**From version 7.1.0 onwards, this plugin is now hosted in a separate repository. Refer to [capacitor-filesystem repository](https://github.com/ionic-team/capacitor-filesystem).**
 
 This file remains here to serve as documentation for version 7.0.1.
 

--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -1,3 +1,9 @@
+# ⓘ Plugin migrated
+
+**From version 7.1.0 onwards, this plugin is now housed in a separate repository. Refer to [capacitor-filesystem repository](https://github.com/ionic-team/capacitor-filesystem).**
+
+This file remains here to serve as documentation for version 7.0.1.
+
 # @capacitor/filesystem
 
 The Filesystem API provides a NodeJS-like API for working with files on the device.

--- a/geolocation/CHANGELOG.md
+++ b/geolocation/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ⓘ Plugin migrated
 
-**From version 7.1.0 onwards, this plugin is now housed in a separate repository. Refer to the [updated CHANGELOG](https://github.com/ionic-team/capacitor-geolocation/blob/main/CHANGELOG.md).**
+**From version 7.1.0 onwards, this plugin is now hosted in a separate repository. Refer to the [updated CHANGELOG](https://github.com/ionic-team/capacitor-geolocation/blob/main/CHANGELOG.md).**
 
 This file remains here as a record of the plugin's history for versions older than 7.1.0.
 

--- a/geolocation/README.md
+++ b/geolocation/README.md
@@ -1,6 +1,6 @@
 # ⓘ Plugin migrated
 
-**From version 7.1.0 onwards, this plugin is now housed in a separate repository. Refer to [capacitor-geolocation repository](https://github.com/ionic-team/capacitor-geolocation).**
+**From version 7.1.0 onwards, this plugin is now hosted in a separate repository. Refer to [capacitor-geolocation repository](https://github.com/ionic-team/capacitor-geolocation).**
 
 This file remains here to serve as documentation for version 7.0.0.
 

--- a/nx.json
+++ b/nx.json
@@ -20,7 +20,6 @@
         "{projectRoot}/clipboard/dist",
         "{projectRoot}/device/dist",
         "{projectRoot}/dialog/dist",
-        "{projectRoot}/filesystem/dist",
         "{projectRoot}/haptics/dist",
         "{projectRoot}/keyboard/dist",
         "{projectRoot}/local-notifications/dist",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "clipboard",
     "device",
     "dialog",
-    "filesystem",
     "haptics",
     "keyboard",
     "local-notifications",


### PR DESCRIPTION
Inform of `@capacitor/filesystem` migration to new GitHub repository - To me merged when a future version of the filesystem plugin is released

Also includes updates for a few other capacitor plugins that are housed in separate repositories.