### PR TITLE
chore(dev-deps): Use latest instead of next

### DIFF
--- a/action-sheet/package.json
+++ b/action-sheet/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorActionSheet.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/app-launcher/package.json
+++ b/app-launcher/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorAppLauncher.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/app/package.json
+++ b/app/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorApp.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/browser/package.json
+++ b/browser/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorBrowser.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/camera/package.json
+++ b/camera/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorCamera.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/clipboard/package.json
+++ b/clipboard/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorClipboard.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/device/package.json
+++ b/device/package.json
@@ -48,10 +48,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorDevice.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/dialog/package.json
+++ b/dialog/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorDialog.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/filesystem/package.json
+++ b/filesystem/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorFilesystem.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/geolocation/package.json
+++ b/geolocation/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorGeolocation.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/haptics/package.json
+++ b/haptics/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorHaptics.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/keyboard/package.json
+++ b/keyboard/package.json
@@ -47,11 +47,11 @@
     "publish:cocoapod": "pod trunk push ./CapacitorKeyboard.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
+    "@capacitor/android": "^7.0.0",
     "@capacitor/cli": "^6.0.0",
-    "@capacitor/core": "next",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/local-notifications/package.json
+++ b/local-notifications/package.json
@@ -47,11 +47,11 @@
     "publish:cocoapod": "pod trunk push ./CapacitorLocalNotifications.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
+    "@capacitor/android": "^7.0.0",
     "@capacitor/cli": "^6.0.0",
-    "@capacitor/core": "next",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/motion/package.json
+++ b/motion/package.json
@@ -39,10 +39,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "eslint": "^8.57.0",

--- a/network/package.json
+++ b/network/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorNetwork.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/preferences/package.json
+++ b/preferences/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorPreferences.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/push-notifications/package.json
+++ b/push-notifications/package.json
@@ -47,11 +47,11 @@
     "publish:cocoapod": "pod trunk push ./CapacitorPushNotifications.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
+    "@capacitor/android": "^7.0.0",
     "@capacitor/cli": "^6.0.0",
-    "@capacitor/core": "next",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/screen-orientation/package.json
+++ b/screen-orientation/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorScreenOrientation.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/screen-reader/package.json
+++ b/screen-reader/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorScreenReader.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/share/package.json
+++ b/share/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorShare.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/splash-screen/package.json
+++ b/splash-screen/package.json
@@ -47,11 +47,11 @@
     "publish:cocoapod": "pod trunk push ./CapacitorSplashScreen.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
+    "@capacitor/android": "^7.0.0",
     "@capacitor/cli": "^6.0.0",
-    "@capacitor/core": "next",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/status-bar/package.json
+++ b/status-bar/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorStatusBar.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/text-zoom/package.json
+++ b/text-zoom/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorTextZoom.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",

--- a/toast/package.json
+++ b/toast/package.json
@@ -47,10 +47,10 @@
     "publish:cocoapod": "pod trunk push ./CapacitorToast.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "next",
-    "@capacitor/core": "next",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
-    "@capacitor/ios": "next",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "~1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",


### PR DESCRIPTION
Dev dependencies are still pointing to `next` version, make them use `^7.0.0`