### PR TITLE
fix(splash-screen): call clearOnExitAnimationListener on animation end

### DIFF
--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
@@ -121,6 +121,9 @@ public class SplashScreen {
                                     public void onAnimationEnd(Animator animation) {
                                         isHiding = false;
                                         windowSplashScreenView.remove();
+                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                                          activity.getSplashScreen().clearOnExitAnimationListener();
+                                        }
                                     }
                                 }
                             );

--- a/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
+++ b/splash-screen/android/src/main/java/com/capacitorjs/plugins/splashscreen/SplashScreen.java
@@ -122,7 +122,7 @@ public class SplashScreen {
                                         isHiding = false;
                                         windowSplashScreenView.remove();
                                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                                          activity.getSplashScreen().clearOnExitAnimationListener();
+                                            activity.getSplashScreen().clearOnExitAnimationListener();
                                         }
                                     }
                                 }


### PR DESCRIPTION
clear the `onExitAnimationListener` once the animation ends, otherwise it will continue to get called on app resume, preventing changes on the UI such as status bar style changes since the `exitAnimationListener` "freezes" the UI before the animation and changes done while it's "frozen" won't take any effect.