### PR TITLE
chore(android): Publishing migration to Central Portal

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -3,9 +3,9 @@ name: Publish Native Android Libraries
 on:
   workflow_call:
     secrets:
-      ANDROID_OSSRH_USERNAME:
+      ANDROID_CENTRAL_USERNAME:
         required: true
-      ANDROID_OSSRH_PASSWORD:
+      ANDROID_CENTRAL_PASSWORD:
         required: true
       ANDROID_SIGNING_KEY_ID:
         required: true
@@ -62,8 +62,8 @@ jobs:
       env:
         GITHUB_PLUGINS: ${{ github.event.inputs.plugins }}
         GITHUB_CAPACITOR_VERSION: ${{ github.event.inputs.capacitor-version }}
-        ANDROID_OSSRH_USERNAME: ${{ secrets.ANDROID_OSSRH_USERNAME }}
-        ANDROID_OSSRH_PASSWORD: ${{ secrets.ANDROID_OSSRH_PASSWORD }}
+        ANDROID_CENTRAL_USERNAME: ${{ secrets.ANDROID_CENTRAL_USERNAME }}
+        ANDROID_CENTRAL_PASSWORD: ${{ secrets.ANDROID_CENTRAL_PASSWORD }}
         ANDROID_SIGNING_KEY_ID: ${{ secrets.ANDROID_SIGNING_KEY_ID }}
         ANDROID_SIGNING_PASSWORD: ${{ secrets.ANDROID_SIGNING_PASSWORD }}
         ANDROID_SIGNING_KEY: ${{ secrets.ANDROID_SIGNING_KEY }}

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -17,8 +17,8 @@ jobs:
     needs: publish-npm-latest
     uses: ./.github/workflows/publish-android.yml
     secrets:
-      ANDROID_OSSRH_USERNAME: ${{ secrets.ANDROID_OSSRH_USERNAME }}
-      ANDROID_OSSRH_PASSWORD: ${{ secrets.ANDROID_OSSRH_PASSWORD }}
+      ANDROID_CENTRAL_USERNAME: ${{ secrets.ANDROID_CENTRAL_USERNAME }}
+      ANDROID_CENTRAL_PASSWORD: ${{ secrets.ANDROID_CENTRAL_PASSWORD }}
       ANDROID_SIGNING_KEY_ID: ${{ secrets.ANDROID_SIGNING_KEY_ID }}
       ANDROID_SIGNING_PASSWORD: ${{ secrets.ANDROID_SIGNING_PASSWORD }}
       ANDROID_SIGNING_KEY: ${{ secrets.ANDROID_SIGNING_KEY }}

--- a/scripts/android/publish-root.gradle
+++ b/scripts/android/publish-root.gradle
@@ -2,8 +2,8 @@
 ext["signing.keyId"] = ''
 ext["signing.key"] = ''
 ext["signing.password"] = ''
-ext["ossrhUsername"] = ''
-ext["ossrhPassword"] = ''
+ext["centralTokenUsername"] = ''
+ext["centralTokenPassword"] = ''
 ext["sonatypeStagingProfileId"] = ''
 
 File globalSecretPropsFile = file('../../scripts/android/local.properties')
@@ -20,8 +20,8 @@ if (globalSecretPropsFile.exists()) {
     p.each { name, value -> ext[name] = value }
 } else {
     // Use system environment variables
-    ext["ossrhUsername"] = System.getenv('ANDROID_OSSRH_USERNAME')
-    ext["ossrhPassword"] = System.getenv('ANDROID_OSSRH_PASSWORD')
+    ext["centralTokenUsername"] = System.getenv('ANDROID_CENTRAL_USERNAME')
+    ext["centralTokenPassword"] = System.getenv('ANDROID_CENTRAL_PASSWORD')
     ext["sonatypeStagingProfileId"] = System.getenv('ANDROID_SONATYPE_STAGING_PROFILE_ID')
     ext["signing.keyId"] = System.getenv('ANDROID_SIGNING_KEY_ID')
     ext["signing.key"] = System.getenv('ANDROID_SIGNING_KEY')
@@ -33,10 +33,10 @@ nexusPublishing {
     repositories {
         sonatype {
             stagingProfileId = sonatypeStagingProfileId
-            username = ossrhUsername
-            password = ossrhPassword
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            username = centralTokenUsername
+            password = centralTokenPassword
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
     repositoryDescription = 'Capacitor Android ' + System.getenv('PLUGIN_NAME') + ' plugin v' + System.getenv('PLUGIN_VERSION')

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -42,7 +42,7 @@ publish_plugin () {
                 if grep --quiet "BUILD SUCCESSFUL" $LOG_OUTPUT; then
                     printf %"s\n\n" "Success: $PLUGIN_NAME published to MavenCentral."
                 else
-                    printf %"s\n\n" "Error publishing $PLUGIN_NAME, check $LOG_OUTPUT for more info! Manual publication review may be necessary at the Sonatype Repository Manager https://s01.oss.sonatype.org/"
+                    printf %"s\n" "Error publishing, check $LOG_OUTPUT for more info! Manually review and release from the Central Portal may be necessary https://central.sonatype.com/publishing/deployments/"
                     cat $LOG_OUTPUT
                     exit 1
                 fi

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -42,7 +42,7 @@ publish_plugin () {
                 if grep --quiet "BUILD SUCCESSFUL" $LOG_OUTPUT; then
                     printf %"s\n\n" "Success: $PLUGIN_NAME published to MavenCentral."
                 else
-                    printf %"s\n" "Error publishing, check $LOG_OUTPUT for more info! Manually review and release from the Central Portal may be necessary https://central.sonatype.com/publishing/deployments/"
+                    printf %"s\n\n" "Error publishing $PLUGIN_NAME, check $LOG_OUTPUT for more info! Manually review and release from the Central Portal may be necessary https://central.sonatype.com/publishing/deployments/"
                     cat $LOG_OUTPUT
                     exit 1
                 fi


### PR DESCRIPTION
We currently publish in Maven Central through OSSRH, however this needs to be changed due OSSRH being shutdown in after June 30th 2025.

Migration of `com.capacitor` namespace to Central Portal has already been done, this PR takes care of updating the publishing logic - which uses a new token that is now accessed in different github secrets.

Relevant References:

- https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/
- https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central