### PR TITLE
fix(android): fixed issues on android 15+ white space above keyboard

### DIFF
--- a/keyboard/android/src/main/java/com/capacitorjs/plugins/keyboard/KeyboardPlugin.java
+++ b/keyboard/android/src/main/java/com/capacitorjs/plugins/keyboard/KeyboardPlugin.java
@@ -18,7 +18,7 @@ public class KeyboardPlugin extends Plugin {
         execute(
             () -> {
                 boolean resizeOnFullScreen = getConfig().getBoolean("resizeOnFullScreen", false);
-                implementation = new Keyboard(getActivity(), resizeOnFullScreen);
+                implementation = new Keyboard(getBridge(), resizeOnFullScreen);
 
                 implementation.setKeyboardEventListener(this::onKeyboardEvent);
             }


### PR DESCRIPTION
On android 15+ we need to take the gesture bar into account (as well as the three button nav)

Closes: https://github.com/kensodemann/issue-53807

Testing notes (screenshots on Jira ticket):
Pixel 9 (physical, gesture navigation) → ✅
Pixel 9 (physical, 3 button navigation) → ✅
Pixel 8 pro emulator → ✅
Pixel 4 (android 14, emulator) → ✅
Pixel 4 (android 13, emulator) → ✅
Pixel 7a (android 15, emulator) → ✅