### PR TITLE
feat(app): Add support enabling predictive back gesture on Android

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -174,9 +174,11 @@ Only available for Android.
 togglePredictiveBack(options: TogglePredictiveBackOptions) => Promise<void>
 ```
 
-Toggles support for Android's predictive back button support.
+Toggles support for Android's predictive back gesture.
 
-Only available for Android.
+Enabling this will disable this plugin's `backButton` listener.
+
+Only available for Android 15+.
 
 | Param         | Type                                                                                |
 | ------------- | ----------------------------------------------------------------------------------- |
@@ -386,9 +388,9 @@ Remove all native listeners for this plugin
 
 #### TogglePredictiveBackOptions
 
-| Prop          | Type                 |
-| ------------- | -------------------- |
-| **`enabled`** | <code>boolean</code> |
+| Prop          | Type                 | Description                                                             | Since |
+| ------------- | -------------------- | ----------------------------------------------------------------------- | ----- |
+| **`enabled`** | <code>boolean</code> | Indicates whether to enable or disable predictive back gesture support. | 8.0.0 |
 
 
 #### PluginListenerHandle

--- a/app/README.md
+++ b/app/README.md
@@ -76,6 +76,7 @@ const checkAppLaunchUrl = async () => {
 * [`getState()`](#getstate)
 * [`getLaunchUrl()`](#getlaunchurl)
 * [`minimizeApp()`](#minimizeapp)
+* [`togglePredictiveBack(...)`](#togglepredictiveback)
 * [`addListener('appStateChange', ...)`](#addlistenerappstatechange-)
 * [`addListener('pause', ...)`](#addlistenerpause-)
 * [`addListener('resume', ...)`](#addlistenerresume-)
@@ -163,6 +164,25 @@ Minimizes the application.
 Only available for Android.
 
 **Since:** 1.1.0
+
+--------------------
+
+
+### togglePredictiveBack(...)
+
+```typescript
+togglePredictiveBack(options: TogglePredictiveBackOptions) => Promise<void>
+```
+
+Toggles support for Android's predictive back button support.
+
+Only available for Android.
+
+| Param         | Type                                                                                |
+| ------------- | ----------------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#togglepredictivebackoptions">TogglePredictiveBackOptions</a></code> |
+
+**Since:** 8.0.0
 
 --------------------
 
@@ -362,6 +382,13 @@ Remove all native listeners for this plugin
 | Prop      | Type                | Description                   | Since |
 | --------- | ------------------- | ----------------------------- | ----- |
 | **`url`** | <code>string</code> | The url used to open the app. | 1.0.0 |
+
+
+#### TogglePredictiveBackOptions
+
+| Prop          | Type                 |
+| ------------- | -------------------- |
+| **`enabled`** | <code>boolean</code> |
 
 
 #### PluginListenerHandle

--- a/app/android/src/main/java/com/capacitorjs/plugins/app/AppPlugin.java
+++ b/app/android/src/main/java/com/capacitorjs/plugins/app/AppPlugin.java
@@ -25,6 +25,8 @@ public class AppPlugin extends Plugin {
     private static final String EVENT_RESUME = "resume";
     private boolean hasPausedEver = false;
 
+    private OnBackPressedCallback onbackPressedCallback;
+    
     public void load() {
         bridge
             .getApp()
@@ -59,7 +61,10 @@ public class AppPlugin extends Plugin {
                 }
             }
         };
+
         getActivity().getOnBackPressedDispatcher().addCallback(getActivity(), callback);
+
+        this.onbackPressedCallback = callback;
     }
 
     @PluginMethod
@@ -109,6 +114,19 @@ public class AppPlugin extends Plugin {
     @PluginMethod
     public void minimizeApp(PluginCall call) {
         getActivity().moveTaskToBack(true);
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void togglePredictiveBack(PluginCall call) {
+        if (this.onbackPressedCallback == null) {
+            call.resolve();
+            return;
+        }
+
+        Boolean enabled = call.getBoolean("enabled");
+
+        this.onbackPressedCallback.setEnabled(!enabled);
         call.resolve();
     }
 

--- a/app/src/definitions.ts
+++ b/app/src/definitions.ts
@@ -126,6 +126,11 @@ export interface BackButtonListenerEvent {
 }
 
 export interface TogglePredictiveBackOptions {
+  /**
+   * Indicates whether to enable or disable predictive back gesture support.
+   *
+   * @since 8.0.0
+   */
   enabled: boolean;
 }
 
@@ -176,9 +181,11 @@ export interface AppPlugin {
   minimizeApp(): Promise<void>;
 
   /**
-   * Toggles support for Android's predictive back button support.
+   * Toggles support for Android's predictive back gesture.
    *
-   * Only available for Android.
+   * Enabling this will disable this plugin's `backButton` listener.
+   *
+   * Only available for Android 15+.
    *
    * @since 8.0.0
    */

--- a/app/src/definitions.ts
+++ b/app/src/definitions.ts
@@ -125,6 +125,10 @@ export interface BackButtonListenerEvent {
   canGoBack: boolean;
 }
 
+export interface TogglePredictiveBackOptions {
+  enabled: boolean;
+}
+
 export type StateChangeListener = (state: AppState) => void;
 export type URLOpenListener = (event: URLOpenListenerEvent) => void;
 export type RestoredListener = (event: RestoredListenerEvent) => void;
@@ -170,6 +174,15 @@ export interface AppPlugin {
    * @since 1.1.0
    */
   minimizeApp(): Promise<void>;
+
+  /**
+   * Toggles support for Android's predictive back button support.
+   *
+   * Only available for Android.
+   *
+   * @since 8.0.0
+   */
+  togglePredictiveBack(options: TogglePredictiveBackOptions): Promise<void>;
 
   /**
    * Listen for changes in the app or the activity states.

--- a/app/src/web.ts
+++ b/app/src/web.ts
@@ -32,6 +32,10 @@ export class AppWeb extends WebPlugin implements AppPlugin {
     throw this.unimplemented('Not implemented on web.');
   }
 
+  async togglePredictiveBack(): Promise<void> {
+    throw this.unimplemented('Not implemented on web.');
+  }
+
   private handleVisibilityChange = () => {
     const data = {
       isActive: document.hidden !== true,


### PR DESCRIPTION
This PR adds a function to toggle on and off support for Android 15+ predictive back gesture, allowing developers to use that gesture functionality at the right time of their choosing in their application.

`togglePredictiveBack()` in essence temporarily disables the `OnBackPressedCallback` listener.