### PR TITLE
fix(camera): requestPermissions on Android 13+

### DIFF
--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -256,13 +256,7 @@ public class CameraPlugin extends Plugin {
 
     @Override
     protected void requestPermissionForAliases(@NonNull String[] aliases, @NonNull PluginCall call, @NonNull String callbackName) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            for (int i = 0; i < aliases.length; i++) {
-                if (aliases[i].equals(SAVE_GALLERY)) {
-                    aliases[i] = PHOTOS;
-                }
-            }
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             for (int i = 0; i < aliases.length; i++) {
                 if (aliases[i].equals(SAVE_GALLERY)) {
                     aliases[i] = READ_EXTERNAL_STORAGE;
@@ -809,11 +803,12 @@ public class CameraPlugin extends Plugin {
                 } catch (JSONException e) {}
             }
 
-            if (permsList != null && permsList.size() == 1 && (permsList.contains(CAMERA) || permsList.contains(PHOTOS))) {
-                // the only thing being asked for was the camera so we can just return the current state
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ||
+                    (permsList != null && permsList.size() == 1 && (permsList.contains(CAMERA) || permsList.contains(PHOTOS)))) {
+                // either we're on Android 13+ (storage permissions do not apply)
+                // or the only thing being asked for was the camera so we can just return the current state
                 checkPermissions(call);
             } else {
-                // we need to ask about gallery so request storage permissions
                 requestPermissionForAlias(SAVE_GALLERY, call, "checkPermissions");
             }
         }

--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/CameraPlugin.java
@@ -803,8 +803,10 @@ public class CameraPlugin extends Plugin {
                 } catch (JSONException e) {}
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ||
-                    (permsList != null && permsList.size() == 1 && (permsList.contains(CAMERA) || permsList.contains(PHOTOS)))) {
+            if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ||
+                (permsList != null && permsList.size() == 1 && (permsList.contains(CAMERA) || permsList.contains(PHOTOS)))
+            ) {
                 // either we're on Android 13+ (storage permissions do not apply)
                 // or the only thing being asked for was the camera so we can just return the current state
                 checkPermissions(call);


### PR DESCRIPTION
Addresses https://github.com/ionic-team/capacitor-plugins/issues/2140 and https://github.com/ionic-team/capacitor-plugins/issues/2339 

Android 13+ no longer has storage permission requests, and a permission request for "photos" alias was being requested, but because this alias has no permissions, nothing would happen.

This PR fixes the logic to instead call `checkPermissions` in such a scenario.