### PR TITLE
fix(statusbar): using window size instead of screen size for resize bounds

### DIFF
--- a/status-bar/ios/Sources/StatusBarPlugin/StatusBar.swift
+++ b/status-bar/ios/Sources/StatusBarPlugin/StatusBar.swift
@@ -124,9 +124,17 @@ public class StatusBar {
     }
 
     private func resizeWebView() {
+        var bounds: CGRect? = nil
+        
+        if #available(iOS 15.0, *) {
+            bounds = bridge.viewController?.view.window?.windowScene?.keyWindow?.bounds
+        } else {
+            bounds = bridge.viewController?.view.window?.windowScene?.screen.bounds
+        }
+        
         guard
             let webView = bridge.webView,
-            let bounds = bridge.viewController?.view.window?.windowScene?.screen.bounds
+            let bounds = bounds
         else { return }
         bridge.viewController?.view.frame = bounds
         webView.frame = bounds


### PR DESCRIPTION
This PR fixes an issue on iPad 26 that prevents the WebView / Status Bar from properly resizing when using the new windowing mode.

