### PR TITLE
Keyboard plugin - replace setWindowInsetsAnimationCallback with setOnApplyWindowInsetsListener

### DIFF
--- a/keyboard/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
+++ b/keyboard/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
@@ -9,14 +9,11 @@ import android.view.View;
 import android.view.Window;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.FrameLayout;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsAnimationCompat;
 import androidx.core.view.WindowInsetsCompat;
 import com.getcapacitor.Bridge;
-import java.util.List;
 
 public class Keyboard {
 
@@ -57,57 +54,25 @@ public class Keyboard {
         FrameLayout content = activity.getWindow().getDecorView().findViewById(android.R.id.content);
         rootView = content.getRootView();
 
-        ViewCompat.setWindowInsetsAnimationCallback(
+        ViewCompat.setOnApplyWindowInsetsListener(
             rootView,
-            new WindowInsetsAnimationCompat.Callback(WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_STOP) {
-                @NonNull
-                @Override
-                public WindowInsetsCompat onProgress(
-                    @NonNull WindowInsetsCompat insets,
-                    @NonNull List<WindowInsetsAnimationCompat> runningAnimations
-                ) {
-                    return insets;
+            (View view, WindowInsetsCompat insets) -> {
+                boolean showingKeyboard = insets.isVisible(WindowInsetsCompat.Type.ime());
+                int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+                DisplayMetrics dm = activity.getResources().getDisplayMetrics();
+                final float density = dm.density;
+
+                if (resizeOnFullScreen) {
+                    possiblyResizeChildOfContent(showingKeyboard);
                 }
 
-                @NonNull
-                @Override
-                public WindowInsetsAnimationCompat.BoundsCompat onStart(
-                    @NonNull WindowInsetsAnimationCompat animation,
-                    @NonNull WindowInsetsAnimationCompat.BoundsCompat bounds
-                ) {
-                    boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
-                    WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(rootView);
-                    int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
-                    DisplayMetrics dm = activity.getResources().getDisplayMetrics();
-                    final float density = dm.density;
-
-                    if (resizeOnFullScreen) {
-                        possiblyResizeChildOfContent(showingKeyboard);
-                    }
-
-                    if (showingKeyboard) {
-                        keyboardEventListener.onKeyboardEvent(EVENT_KB_WILL_SHOW, Math.round(imeHeight / density));
-                    } else {
-                        keyboardEventListener.onKeyboardEvent(EVENT_KB_WILL_HIDE, 0);
-                    }
-                    return super.onStart(animation, bounds);
+                if (showingKeyboard) {
+                    keyboardEventListener.onKeyboardEvent(EVENT_KB_WILL_SHOW, Math.round(imeHeight / density));
+                } else {
+                    keyboardEventListener.onKeyboardEvent(EVENT_KB_WILL_HIDE, 0);
                 }
 
-                @Override
-                public void onEnd(@NonNull WindowInsetsAnimationCompat animation) {
-                    super.onEnd(animation);
-                    boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
-                    WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(rootView);
-                    int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
-                    DisplayMetrics dm = activity.getResources().getDisplayMetrics();
-                    final float density = dm.density;
-
-                    if (showingKeyboard) {
-                        keyboardEventListener.onKeyboardEvent(EVENT_KB_DID_SHOW, Math.round(imeHeight / density));
-                    } else {
-                        keyboardEventListener.onKeyboardEvent(EVENT_KB_DID_HIDE, 0);
-                    }
-                }
+                return insets;
             }
         );
 


### PR DESCRIPTION
I noticed an issue with the Keyboard plugin inaccurately resizing the view when the number row is enabled in my Gboard. The Keyboard plugin doesn't resize the view properly in this case. The reason is that the number row is added after the keyboard opening lifecycle is finished. Since the Keyboard plugin listens to `setWindowInsetsAnimationCallback` events (onStart and onEnd) to update the view height, it misses this last inset change after the keyboard opening animation is complete.

I propose replacing the current listener with `setOnApplyWindowInsetsListener`, which listens to all inset changes, enabling the plugin to properly adjust the view height whenever the keyboard height changes.

Device: Pixel 9 Pro running API level 36

Dependencies:
- @capacitor/android: 7.4.2
- @capacitor/app: 7.0.2
- @capacitor/core: 7.4.2
- @capacitor/keyboard: 7.0.2

Gboard number row option: Settings -> System -> Keyboard -> On-screen keyboard -> Gboard -> Preferences -> Number row

Capacitor configs:
- resizeOnFullScreen: true
- adjustMarginsForEdgeToEdge: "force"