### PR TITLE
chore(dev-deps): Update @capacitor/cli to 7.x

### DIFF
--- a/keyboard/package.json
+++ b/keyboard/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@capacitor/android": "^7.0.0",
-    "@capacitor/cli": "^6.0.0",
+    "@capacitor/cli": "^7.0.0",
     "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
     "@capacitor/ios": "^7.0.0",

--- a/local-notifications/package.json
+++ b/local-notifications/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@capacitor/android": "^7.0.0",
-    "@capacitor/cli": "^6.0.0",
+    "@capacitor/cli": "^7.0.0",
     "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
     "@capacitor/ios": "^7.0.0",

--- a/push-notifications/package.json
+++ b/push-notifications/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@capacitor/android": "^7.0.0",
-    "@capacitor/cli": "^6.0.0",
+    "@capacitor/cli": "^7.0.0",
     "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
     "@capacitor/ios": "^7.0.0",

--- a/splash-screen/package.json
+++ b/splash-screen/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@capacitor/android": "^7.0.0",
-    "@capacitor/cli": "^6.0.0",
+    "@capacitor/cli": "^7.0.0",
     "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
     "@capacitor/ios": "^7.0.0",

--- a/status-bar/package.json
+++ b/status-bar/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@capacitor/android": "^7.0.0",
+    "@capacitor/cli": "^7.0.0",
     "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "0.2.2",
     "@capacitor/ios": "^7.0.0",


### PR DESCRIPTION
Install `@capacitor/cli` in status bar plugin since it has a configuration option that depends on it but wasn't installed.
Update it to 7.x for the rest of packages that had it installed.