### PR TITLE
chore(ci): download iOS simulators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
         plugin: ${{ fromJson(needs.setup.outputs.plugins) }}
     steps:
       - run: sudo xcode-select --switch ${{ matrix.xcode }}
+      - run: xcrun simctl list > /dev/null
+      - run: xcodebuild -downloadPlatform iOS
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -16,6 +16,8 @@ jobs:
         plugin: ${{ fromJson(github.event.inputs.plugins) }}
     steps:
       - run: sudo xcode-select --switch /Applications/Xcode_16.app
+      - run: xcrun simctl list > /dev/null
+      - run: xcodebuild -downloadPlatform iOS
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
Xcode 16.0 no longer includes simulators, added `xcodebuild -downloadPlatform iOS` to download them and `xcrun simctl list > /dev/null` is a workaround for some problem on some macos-15 runners that fail to connect to the simulators without that line.