### PR TITLE
chore: bump version to 8.0.0-alpha.0

### DIFF
--- a/action-sheet/package.json
+++ b/action-sheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/action-sheet",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Action Sheet API provides access to native Action Sheets, which come up from the bottom of the screen and display actions a user can take.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/app-launcher/package.json
+++ b/app-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/app-launcher",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The AppLauncher API allows to open other apps",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/app",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The App API handles high level App state and events.For example, this API emits events when the app enters and leaves the foreground, handles deeplinks, opens other apps, and manages persisted plugin state.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/browser/package.json
+++ b/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/browser",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Browser API provides the ability to open an in-app browser and subscribe to browser events.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/camera/package.json
+++ b/camera/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/camera",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Camera API provides the ability to take a photo with the camera or choose an existing one from the photo album.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/clipboard/package.json
+++ b/clipboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/clipboard",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Clipboard API enables copy and pasting to/from the system clipboard.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/device/package.json
+++ b/device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/device",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Device API exposes internal information about the device, such as the model and operating system version, along with user information such as unique ids.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/dialog/package.json
+++ b/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/dialog",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Dialog API provides methods for triggering native dialog windows for alerts, confirmations, and input prompts",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/haptics/package.json
+++ b/haptics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/haptics",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Haptics API provides physical feedback to the user through touch or vibration.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/keyboard/package.json
+++ b/keyboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/keyboard",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Keyboard API provides keyboard display and visibility control, along with event tracking when the keyboard shows and hides.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/local-notifications/package.json
+++ b/local-notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/local-notifications",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Local Notifications API provides a way to schedule device notifications locally (i.e. without a server sending push notifications).",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/motion/package.json
+++ b/motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/motion",
-  "version": "7.0.1",
+  "version": "8.0.0-alpha.0",
   "description": "The Motion API tracks accelerometer and device orientation (compass heading, etc.)",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/network/package.json
+++ b/network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/network",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Network API provides network and connectivity information.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/preferences/package.json
+++ b/preferences/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/preferences",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Preferences API provides a simple key/value persistent store for lightweight data.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/push-notifications/package.json
+++ b/push-notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/push-notifications",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Push Notifications API provides access to native push notifications.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/screen-orientation/package.json
+++ b/screen-orientation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/screen-orientation",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Screen Orientation API provides methods to lock and unlock the screen orientation.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/screen-reader/package.json
+++ b/screen-reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/screen-reader",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Screen Reader API provides access to TalkBack/VoiceOver/etc. and provides simple text-to-speech capabilities for visual accessibility.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/share/package.json
+++ b/share/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/share",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Share API provides methods for sharing content in any sharing-enabled apps the user may have installed.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/splash-screen/package.json
+++ b/splash-screen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/splash-screen",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Splash Screen API provides methods for showing or hiding a Splash image.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/status-bar/package.json
+++ b/status-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/status-bar",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The StatusBar API Provides methods for configuring the style of the Status Bar, along with showing or hiding it.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/text-zoom/package.json
+++ b/text-zoom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/text-zoom",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Text Zoom API provides the ability to change Web View text size for visual accessibility.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/toast/package.json
+++ b/toast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/toast",
-  "version": "7.0.2",
+  "version": "8.0.0-alpha.0",
   "description": "The Toast API provides a notification pop up for displaying important information to a user. Just like real toast!",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
To start Cap 8 alpha support of plugins, major version must be manually updated.