### PR TITLE
chore(ci): update for 7.x branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - 7.x
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/publish-npm-latest-from-pre.yml
+++ b/.github/workflows/publish-npm-latest-from-pre.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   deploy-npm-latest-from-pre:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/7.x'
     runs-on: macos-15
     timeout-minutes: 30
     steps:

--- a/.github/workflows/publish-npm-latest.yml
+++ b/.github/workflows/publish-npm-latest.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   deploy-npm-latest:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/7.x'
     runs-on: macos-15
     timeout-minutes: 30
     steps:

--- a/.github/workflows/publish-npm-nightly.yml
+++ b/.github/workflows/publish-npm-nightly.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   deploy-npm-nightly:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/7.x'
     runs-on: macos-15
     timeout-minutes: 30
     steps:

--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,7 @@
       "npmClientArgs": ["--no-package-lock"]
     },
     "version": {
-      "allowBranch": "main",
+      "allowBranch": "7.x",
       "conventionalCommits": true,
       "createRelease": "github",
       "message": "chore(release): publish [skip ci]",


### PR DESCRIPTION
Now that 7.x branch exists, the github actions and lerna need to be updated to point to 7.x instead of main.