### PR TITLE
fix(ios): handle deprecation warning on status-bar

### DIFF
--- a/status-bar/ios/Sources/StatusBarPlugin/StatusBar.swift
+++ b/status-bar/ios/Sources/StatusBarPlugin/StatusBar.swift
@@ -154,7 +154,7 @@ public class StatusBar {
     }
 
     private func getStatusBarFrame() -> CGRect {
-        return UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.windowScene?.statusBarManager?.statusBarFrame ?? .zero
+        return bridge.viewController?.view.window?.windowScene?.statusBarManager?.statusBarFrame ?? .zero
     }
 
     private func initializeBackgroundViewIfNeeded() {


### PR DESCRIPTION
We had a ticket about handling the deprecation warnings on status-bar plugin but none appeared and I closed the issue as couldn't reproduce.
But now I'm seeing the warning appearing again, so handing it now.