### PR TITLE
chore(ci): remove Xcode 16 workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,6 @@ jobs:
         plugin: ${{ fromJson(needs.setup.outputs.plugins) }}
     steps:
       - run: sudo xcode-select --switch ${{ matrix.xcode }}
-      - run: xcrun simctl list > /dev/null
-      - run: xcodebuild -downloadPlatform iOS
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -16,8 +16,6 @@ jobs:
         plugin: ${{ fromJson(github.event.inputs.plugins) }}
     steps:
       - run: sudo xcode-select --switch /Applications/Xcode_26.0.app
-      - run: xcrun simctl list > /dev/null
-      - run: xcodebuild -downloadPlatform iOS
       - uses: actions/setup-node@v6
         with:
           node-version: 22


### PR DESCRIPTION
Those lines [were added ](https://github.com/ionic-team/capacitor-plugins/pull/2402)because Xcode 16.0 didn't include simulators, so it needed to install them.
Since the ci was updated to use Xcode 26.0 it's no longer needed and removing this should speed up the tasks as downloading the simulators takes some time.