### PR TITLE
chore(ci): download iOS simulators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
         plugin: ${{ fromJson(needs.setup.outputs.plugins) }}
     steps:
       - run: sudo xcode-select --switch ${{ matrix.xcode }}
+      - run: xcrun simctl list > /dev/null
+      - run: xcodebuild -downloadPlatform iOS
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -16,6 +16,8 @@ jobs:
         plugin: ${{ fromJson(github.event.inputs.plugins) }}
     steps:
       - run: sudo xcode-select --switch /Applications/Xcode_26.0.app
+      - run: xcrun simctl list > /dev/null
+      - run: xcodebuild -downloadPlatform iOS
       - uses: actions/setup-node@v6
         with:
           node-version: 22


### PR DESCRIPTION
github removed the simulators for Xcode 26.0 too, so we need to revert the PR that removed the workaround

Reverts ionic-team/capacitor-plugins#2466

