### PR TITLE
fix: AGP 9.0 no longer supporting `proguard-android.txt`

### DIFF
--- a/haptics/android/build.gradle
+++ b/haptics/android/build.gradle
@@ -42,7 +42,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/keyboard/android/build.gradle
+++ b/keyboard/android/build.gradle
@@ -42,7 +42,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {


### PR DESCRIPTION
Similar to https://github.com/ionic-team/capacitor-haptics/pull/21 and https://github.com/ionic-team/capacitor-keyboard/pull/47, but for 7.x in this repo (the standalone repos were only in effect since 8.x)