### PR TITLE
fix(ci): Update default Capacitor version range to [8.0,9.0)

### DIFF
--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # The default Capacitor version(s) the plugin should depend on. Latest published in a range will be pulled by the user
-DEFAULT_CAPACITOR_VERSION="[7.0,8.0)"
+DEFAULT_CAPACITOR_VERSION="[8.0,9.0)"
 
 publish_plugin () {
     PLUGIN_PATH=$1


### PR DESCRIPTION
Latest 8.x published plugins are configured to use capacitorjs:core 7.x, this fixes it so next publish uses 8.x