### PR TITLE
feat(@capacitor/device): Added batteryChargingStateChange event

### DIFF
--- a/device/README.md
+++ b/device/README.md
@@ -36,6 +36,8 @@ const logBatteryInfo = async () => {
 * [`getBatteryInfo()`](#getbatteryinfo)
 * [`getLanguageCode()`](#getlanguagecode)
 * [`getLanguageTag()`](#getlanguagetag)
+* [`addListener('batteryStateChange', ...)`](#addlistenerbatterystatechange-)
+* [`removeAllListeners()`](#removealllisteners)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 
@@ -119,6 +121,39 @@ Get the device's current language locale tag.
 --------------------
 
 
+### addListener('batteryStateChange', ...)
+
+```typescript
+addListener(eventName: 'batteryStateChange', listenerFunc: BatteryStateChangeListener) => Promise<PluginListenerHandle>
+```
+
+Listen for changes to whether the device is charging (including when the battery becomes full while plugged in).
+
+| Param              | Type                                                                              |
+| ------------------ | --------------------------------------------------------------------------------- |
+| **`eventName`**    | <code>'batteryStateChange'</code>                                                 |
+| **`listenerFunc`** | <code><a href="#batterystatechangelistener">BatteryStateChangeListener</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+**Since:** 8.1.0
+
+--------------------
+
+
+### removeAllListeners()
+
+```typescript
+removeAllListeners() => Promise<void>
+```
+
+Remove all listeners for this plugin.
+
+**Since:** 8.1.0
+
+--------------------
+
+
 ### Interfaces
 
 
@@ -168,11 +203,25 @@ Get the device's current language locale tag.
 | **`value`** | <code>string</code> | Returns a well-formed IETF BCP 47 language tag. | 4.0.0 |
 
 
+#### PluginListenerHandle
+
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
+
+
 ### Type Aliases
 
 
 #### OperatingSystem
 
 <code>'ios' | 'android' | 'windows' | 'mac' | 'unknown'</code>
+
+
+#### BatteryStateChangeListener
+
+Callback for battery charging state changes.
+
+<code>(info: <a href="#batteryinfo">BatteryInfo</a>): void</code>
 
 </docgen-api>

--- a/device/README.md
+++ b/device/README.md
@@ -36,7 +36,7 @@ const logBatteryInfo = async () => {
 * [`getBatteryInfo()`](#getbatteryinfo)
 * [`getLanguageCode()`](#getlanguagecode)
 * [`getLanguageTag()`](#getlanguagetag)
-* [`addListener('batteryStateChange', ...)`](#addlistenerbatterystatechange-)
+* [`addListener('batteryChargingStateChange', ...)`](#addlistenerbatterychargingstatechange-)
 * [`removeAllListeners()`](#removealllisteners)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
@@ -121,18 +121,18 @@ Get the device's current language locale tag.
 --------------------
 
 
-### addListener('batteryStateChange', ...)
+### addListener('batteryChargingStateChange', ...)
 
 ```typescript
-addListener(eventName: 'batteryStateChange', listenerFunc: BatteryStateChangeListener) => Promise<PluginListenerHandle>
+addListener(eventName: 'batteryChargingStateChange', listenerFunc: BatteryChargingStateChangeListener) => Promise<PluginListenerHandle>
 ```
 
 Listen for changes to whether the device is charging (including when the battery becomes full while plugged in).
 
-| Param              | Type                                                                              |
-| ------------------ | --------------------------------------------------------------------------------- |
-| **`eventName`**    | <code>'batteryStateChange'</code>                                                 |
-| **`listenerFunc`** | <code><a href="#batterystatechangelistener">BatteryStateChangeListener</a></code> |
+| Param              | Type                                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code>'batteryChargingStateChange'</code>                                                         |
+| **`listenerFunc`** | <code><a href="#batterychargingstatechangelistener">BatteryChargingStateChangeListener</a></code> |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 
@@ -218,7 +218,7 @@ Remove all listeners for this plugin.
 <code>'ios' | 'android' | 'windows' | 'mac' | 'unknown'</code>
 
 
-#### BatteryStateChangeListener
+#### BatteryChargingStateChangeListener
 
 Callback for battery charging state changes.
 

--- a/device/android/src/main/java/com/capacitorjs/plugins/device/DevicePlugin.java
+++ b/device/android/src/main/java/com/capacitorjs/plugins/device/DevicePlugin.java
@@ -1,5 +1,10 @@
 package com.capacitorjs.plugins.device;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.BatteryManager;
 import android.os.Build;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
@@ -11,11 +16,63 @@ import java.util.Locale;
 @CapacitorPlugin(name = "Device")
 public class DevicePlugin extends Plugin {
 
+    public static final String BATTERY_STATE_CHANGE_EVENT = "batteryStateChange";
+
     private Device implementation;
+    private Boolean lastBatteryChargingState;
+
+    private final BroadcastReceiver batteryStateReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (intent == null || !Intent.ACTION_BATTERY_CHANGED.equals(intent.getAction())) {
+                return;
+            }
+            int status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
+            boolean charging =
+                status == BatteryManager.BATTERY_STATUS_CHARGING || status == BatteryManager.BATTERY_STATUS_FULL;
+            if (lastBatteryChargingState == null) {
+                lastBatteryChargingState = charging;
+                return;
+            }
+            if (lastBatteryChargingState != charging) {
+                lastBatteryChargingState = charging;
+                notifyBatteryStateChange(intent);
+            }
+        }
+    };
 
     @Override
     public void load() {
         implementation = new Device(getContext());
+        IntentFilter filter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getContext().registerReceiver(batteryStateReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            getContext().registerReceiver(batteryStateReceiver, filter);
+        }
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        try {
+            getContext().unregisterReceiver(batteryStateReceiver);
+        } catch (IllegalArgumentException e) {
+            // Receiver was not registered
+        }
+    }
+
+    private void notifyBatteryStateChange(Intent batteryIntent) {
+        int level = batteryIntent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
+        int scale = batteryIntent.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
+        float batteryLevel = level >= 0 && scale > 0 ? level / (float) scale : -1;
+        int status = batteryIntent.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
+        boolean isCharging =
+            status == BatteryManager.BATTERY_STATUS_CHARGING || status == BatteryManager.BATTERY_STATUS_FULL;
+
+        JSObject data = new JSObject();
+        data.put("batteryLevel", batteryLevel);
+        data.put("isCharging", isCharging);
+        notifyListeners(BATTERY_STATE_CHANGE_EVENT, data);
     }
 
     @PluginMethod

--- a/device/android/src/main/java/com/capacitorjs/plugins/device/DevicePlugin.java
+++ b/device/android/src/main/java/com/capacitorjs/plugins/device/DevicePlugin.java
@@ -16,7 +16,7 @@ import java.util.Locale;
 @CapacitorPlugin(name = "Device")
 public class DevicePlugin extends Plugin {
 
-    public static final String BATTERY_STATE_CHANGE_EVENT = "batteryStateChange";
+    public static final String BATTERY_CHARGING_STATE_CHANGE_EVENT = "batteryChargingStateChange";
 
     private Device implementation;
     private Boolean lastBatteryChargingState;
@@ -36,7 +36,7 @@ public class DevicePlugin extends Plugin {
             }
             if (lastBatteryChargingState != charging) {
                 lastBatteryChargingState = charging;
-                notifyBatteryStateChange(intent);
+                notifyBatteryChargingStateChange(intent);
             }
         }
     };
@@ -61,7 +61,7 @@ public class DevicePlugin extends Plugin {
         }
     }
 
-    private void notifyBatteryStateChange(Intent batteryIntent) {
+    private void notifyBatteryChargingStateChange(Intent batteryIntent) {
         int level = batteryIntent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
         int scale = batteryIntent.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
         float batteryLevel = level >= 0 && scale > 0 ? level / (float) scale : -1;
@@ -72,7 +72,7 @@ public class DevicePlugin extends Plugin {
         JSObject data = new JSObject();
         data.put("batteryLevel", batteryLevel);
         data.put("isCharging", isCharging);
-        notifyListeners(BATTERY_STATE_CHANGE_EVENT, data);
+        notifyListeners(BATTERY_CHARGING_STATE_CHANGE_EVENT, data);
     }
 
     @PluginMethod

--- a/device/ios/Sources/DevicePlugin/DevicePlugin.swift
+++ b/device/ios/Sources/DevicePlugin/DevicePlugin.swift
@@ -4,7 +4,7 @@ import Capacitor
 
 @objc(DevicePlugin)
 public class DevicePlugin: CAPPlugin, CAPBridgedPlugin {
-    public static let batteryStateChangeEvent = "batteryStateChange"
+    public static let batteryChargingStateChangeEvent = "batteryChargingStateChange"
 
     public let identifier = "DevicePlugin"
     public let jsName = "Device"
@@ -45,7 +45,7 @@ public class DevicePlugin: CAPPlugin, CAPBridgedPlugin {
         }
         if lastBatteryChargingState != charging {
             lastBatteryChargingState = charging
-            notifyListeners(DevicePlugin.batteryStateChangeEvent, data: [
+            notifyListeners(DevicePlugin.batteryChargingStateChangeEvent, data: [
                 "batteryLevel": UIDevice.current.batteryLevel,
                 "isCharging": charging
             ])

--- a/device/ios/Sources/DevicePlugin/DevicePlugin.swift
+++ b/device/ios/Sources/DevicePlugin/DevicePlugin.swift
@@ -1,8 +1,11 @@
 import Foundation
+import UIKit
 import Capacitor
 
 @objc(DevicePlugin)
 public class DevicePlugin: CAPPlugin, CAPBridgedPlugin {
+    public static let batteryStateChangeEvent = "batteryStateChange"
+
     public let identifier = "DevicePlugin"
     public let jsName = "Device"
     public let pluginMethods: [CAPPluginMethod] = [
@@ -13,6 +16,41 @@ public class DevicePlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getLanguageTag", returnType: CAPPluginReturnPromise)
     ]
     private let implementation = Device()
+    private var lastBatteryChargingState: Bool?
+
+    override public func load() {
+        UIDevice.current.isBatteryMonitoringEnabled = true
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(batteryStateDidChange),
+            name: UIDevice.batteryStateDidChangeNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        UIDevice.current.isBatteryMonitoringEnabled = false
+    }
+
+    @objc private func batteryStateDidChange() {
+        let state = UIDevice.current.batteryState
+        if state == .unknown {
+            return
+        }
+        let charging = state == .charging || state == .full
+        if lastBatteryChargingState == nil {
+            lastBatteryChargingState = charging
+            return
+        }
+        if lastBatteryChargingState != charging {
+            lastBatteryChargingState = charging
+            notifyListeners(DevicePlugin.batteryStateChangeEvent, data: [
+                "batteryLevel": UIDevice.current.batteryLevel,
+                "isCharging": charging
+            ])
+        }
+    }
 
     @objc func getId(_ call: CAPPluginCall) {
         if let uuid = UIDevice.current.identifierForVendor {
@@ -57,8 +95,6 @@ public class DevicePlugin: CAPPlugin, CAPBridgedPlugin {
             "batteryLevel": UIDevice.current.batteryLevel,
             "isCharging": UIDevice.current.batteryState == .charging || UIDevice.current.batteryState == .full
         ])
-
-        UIDevice.current.isBatteryMonitoringEnabled = false
     }
 
     @objc func getLanguageCode(_ call: CAPPluginCall) {

--- a/device/src/definitions.ts
+++ b/device/src/definitions.ts
@@ -1,3 +1,5 @@
+import type { PluginListenerHandle } from '@capacitor/core';
+
 export type OperatingSystem = 'ios' | 'android' | 'windows' | 'mac' | 'unknown';
 
 export interface DeviceId {
@@ -123,6 +125,13 @@ export interface BatteryInfo {
   isCharging?: boolean;
 }
 
+/**
+ * Callback for battery charging state changes.
+ *
+ * @since 8.1.0
+ */
+export type BatteryStateChangeListener = (info: BatteryInfo) => void;
+
 export interface GetLanguageCodeResult {
   /**
    * Two character language code.
@@ -176,4 +185,21 @@ export interface DevicePlugin {
    * @since 4.0.0
    */
   getLanguageTag(): Promise<LanguageTag>;
+
+  /**
+   * Listen for changes to whether the device is charging (including when the battery becomes full while plugged in).
+   *
+   * @since 8.1.0
+   */
+  addListener(
+    eventName: 'batteryStateChange',
+    listenerFunc: BatteryStateChangeListener,
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * Remove all listeners for this plugin.
+   *
+   * @since 8.1.0
+   */
+  removeAllListeners(): Promise<void>;
 }

--- a/device/src/definitions.ts
+++ b/device/src/definitions.ts
@@ -130,7 +130,7 @@ export interface BatteryInfo {
  *
  * @since 8.1.0
  */
-export type BatteryStateChangeListener = (info: BatteryInfo) => void;
+export type BatteryChargingStateChangeListener = (info: BatteryInfo) => void;
 
 export interface GetLanguageCodeResult {
   /**
@@ -192,8 +192,8 @@ export interface DevicePlugin {
    * @since 8.1.0
    */
   addListener(
-    eventName: 'batteryStateChange',
-    listenerFunc: BatteryStateChangeListener,
+    eventName: 'batteryChargingStateChange',
+    listenerFunc: BatteryChargingStateChangeListener,
   ): Promise<PluginListenerHandle>;
 
   /**

--- a/device/src/web.ts
+++ b/device/src/web.ts
@@ -4,7 +4,7 @@ import type { PluginListenerHandle } from '@capacitor/core';
 
 import type {
   BatteryInfo,
-  BatteryStateChangeListener,
+  BatteryChargingStateChangeListener,
   DeviceId,
   DeviceInfo,
   DevicePlugin,
@@ -34,7 +34,7 @@ export class DeviceWeb extends WebPlugin implements DevicePlugin {
     if (!this.batteryApi) {
       return;
     }
-    this.notifyListeners('batteryStateChange', {
+    this.notifyListeners('batteryChargingStateChange', {
       batteryLevel: this.batteryApi.level,
       isCharging: this.batteryApi.charging,
     });
@@ -62,10 +62,10 @@ export class DeviceWeb extends WebPlugin implements DevicePlugin {
   }
 
   async addListener(
-    eventName: 'batteryStateChange',
-    listenerFunc: BatteryStateChangeListener,
+    eventName: 'batteryChargingStateChange',
+    listenerFunc: BatteryChargingStateChangeListener,
   ): Promise<PluginListenerHandle> {
-    if (eventName === 'batteryStateChange') {
+    if (eventName === 'batteryChargingStateChange') {
       void this.attachBatteryListeners();
     }
     return super.addListener(eventName, listenerFunc);

--- a/device/src/web.ts
+++ b/device/src/web.ts
@@ -1,7 +1,10 @@
 import { WebPlugin } from '@capacitor/core';
 
+import type { PluginListenerHandle } from '@capacitor/core';
+
 import type {
   BatteryInfo,
+  BatteryStateChangeListener,
   DeviceId,
   DeviceInfo,
   DevicePlugin,
@@ -24,6 +27,55 @@ declare global {
 }
 
 export class DeviceWeb extends WebPlugin implements DevicePlugin {
+  private batteryApi: any = null;
+  private batteryListenersAttached = false;
+
+  private readonly handleBatteryChargingChange = (): void => {
+    if (!this.batteryApi) {
+      return;
+    }
+    this.notifyListeners('batteryStateChange', {
+      batteryLevel: this.batteryApi.level,
+      isCharging: this.batteryApi.charging,
+    });
+  };
+
+  private async attachBatteryListeners(): Promise<void> {
+    if (this.batteryListenersAttached || typeof navigator === 'undefined' || !navigator.getBattery) {
+      return;
+    }
+    try {
+      this.batteryApi = await navigator.getBattery();
+      this.batteryApi.addEventListener('chargingchange', this.handleBatteryChargingChange);
+      this.batteryListenersAttached = true;
+    } catch (e) {
+      // Battery Status API unavailable or denied
+    }
+  }
+
+  private detachBatteryListeners(): void {
+    if (this.batteryApi && this.batteryListenersAttached) {
+      this.batteryApi.removeEventListener('chargingchange', this.handleBatteryChargingChange);
+      this.batteryListenersAttached = false;
+      this.batteryApi = null;
+    }
+  }
+
+  async addListener(
+    eventName: 'batteryStateChange',
+    listenerFunc: BatteryStateChangeListener,
+  ): Promise<PluginListenerHandle> {
+    if (eventName === 'batteryStateChange') {
+      void this.attachBatteryListeners();
+    }
+    return super.addListener(eventName, listenerFunc);
+  }
+
+  async removeAllListeners(): Promise<void> {
+    this.detachBatteryListeners();
+    return super.removeAllListeners();
+  }
+
   async getId(): Promise<DeviceId> {
     return {
       identifier: this.getUid(),


### PR DESCRIPTION
## Description
I've added an `batteryChargingStateChange` listener, available on IOS, Android and Web. It triggers every time the device detects when it's charging/not charging anymore. I've personally implemented it on my app for my needs and it works great, i find that very usefull for users that want to keep a status of the devices battery without having to use `getBatteryInfo()` all of the time...

## Change Type
- [ ] Fix
- [X] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Platforms Affected
- [X] Android
- [X] iOS
- [X] Web