### PR TITLE
chore(ci): Check every maven central version for android publish

### DIFF
--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -20,9 +20,8 @@ publish_plugin () {
             # Get latest plugin info from MavenCentral
             PLUGIN_PUBLISHED_URL="https://repo1.maven.org/maven2/com/capacitorjs/$PLUGIN_NAME/maven-metadata.xml"
             PLUGIN_PUBLISHED_DATA=$(curl -s $PLUGIN_PUBLISHED_URL)
-            PLUGIN_PUBLISHED_VERSION="$(perl -ne 'print and last if s/.*<latest>(.*)<\/latest>.*/\1/;' <<< $PLUGIN_PUBLISHED_DATA)"
 
-            if [[ $PLUGIN_VERSION == $PLUGIN_PUBLISHED_VERSION ]]; then
+            if echo "$PLUGIN_PUBLISHED_DATA" | grep -q "<version>$PLUGIN_VERSION</version>"; then
                 printf %"s\n\n" "Duplicate: a published plugin $PLUGIN_NAME exists for version $PLUGIN_VERSION, skipping..."
             else
                 # Make log dir if doesnt exist


### PR DESCRIPTION
## Description

This is a simple PR to check for all versions published to maven central, instead of just the latest one.

After this PR is merged, I'll still need to:

1. Cherry-pick to 7.x (not relevant for now, but since we may start doing native publish on maintenance branches it will be relevant one day)
2. Open equivalent PRs for other repositories.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [x] Other

## Rationale / Problems Fixed

In a situation where `package.json` version is older than the latest version on Maven Central (can happen if we trigger native android publish from a maintenance branch, or for plugins that have migrated from this repository like camera did recently), the publishing script was assuming that the version needed to be published, and would often fail because said version would already exist in Maven Central.

## Tests or Reproductions

I ran it locally and also [dry-ran in GitHub actions](https://github.com/ionic-team/capacitor-plugins/actions/runs/24396873975/job/71256818399) (without publishing part), it is correctly detecting the plugins that have the latest version in maven central, the ones who don't, and the ones who have the version in maven central that's not the latest (for `main` branch, the one example of that is camera, of which latest is 8.1.0, `main` has 8.0.2; prior to this PR it would try to publish 8.0.2 and fail with message that 8.0.2 already exists)