### PR TITLE
chore: do not publish camera to CocoaPods

### DIFF
--- a/camera/package.json
+++ b/camera/package.json
@@ -43,8 +43,7 @@
     "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.mjs",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build",
-    "publish:cocoapod": "echo 'This repository does not publish the camera plugin. Refer to https://github.com/ionic-team/capacitor-camera'"
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@capacitor/android": "^8.0.0",

--- a/camera/package.json
+++ b/camera/package.json
@@ -44,7 +44,7 @@
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build",
-    "publish:cocoapod": "pod trunk push ./CapacitorCamera.podspec --allow-warnings"
+    "publish:cocoapod": "echo 'This repository does not publish the camera plugin. Refer to https://github.com/ionic-team/capacitor-camera'"
   },
   "devDependencies": {
     "@capacitor/android": "^8.0.0",


### PR DESCRIPTION
## Description

Remove the cocoa pods publish command for Camera Plugin.

Because CocoaPods Publish workflow is triggered per plugin directory, removing this command means that if someone tries to push Camera to Trunk from this Repo (needs to explicitly list camera in plugin list input to workflow), the GitHub action will fail.

After this one is approved / merged I will also open a PR for 7.x, for filesystem and geolocation.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [x] Other

## Rationale / Problems Fixed

Capacitor camera is now housed in https://github.com/ionic-team/capacitor-camera, and `main` / `8.x` in this repo is meant to serve only for historical purposes.

To avoid GitHub Workflow failures and unforeseen issues, we should not try to push camera plugin 8.x to Trunk from this repo.

## Notes / Comments

In terms of avoiding GitHub Workflow failures in Android, refer to https://github.com/ionic-team/capacitor-plugins/pull/2512
