### PR TITLE
feat(push-notifications): add banner and list presentation options for iOS

### DIFF
--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -87,9 +87,9 @@ From Android 8.0 (API level 26) and higher, notification channels are supported 
 
 You can configure the way the push notifications are displayed when the app is in foreground.
 
-| Prop                      | Type                              | Description                                                                                                                                                                                                                                                                                                                                                                                          | Since |
-| ------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| **`presentationOptions`** | <code>PresentationOption[]</code> | This is an array of strings you can combine. Possible values in the array are: - `badge`: badge count on the app icon is updated (default value) - `sound`: the device will ring/vibrate when the push notification is received - `alert`: the push notification is displayed in a native dialog An empty array can be provided if none of the options are desired. badge is only available for iOS. | 1.0.0 |
+| Prop                      | Type                              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Since |
+| ------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`presentationOptions`** | <code>PresentationOption[]</code> | This is an array of strings you can combine. Possible values in the array are: - `badge`: badge count on the app icon is updated (default value) - `sound`: the device will ring/vibrate when the push notification is received - `alert`: **Deprecated on iOS.** Use `banner` and `list` instead. On Android, this value is still used to display the notification. - `banner`: the push notification is displayed as a banner - `list`: the push notification is displayed in the notification center An empty array can be provided if none of the options are desired. badge is only available for iOS. | 1.0.0 |
 
 ### Examples
 
@@ -99,7 +99,7 @@ In `capacitor.config.json`:
 {
   "plugins": {
     "PushNotifications": {
-      "presentationOptions": ["badge", "sound", "alert"]
+      "presentationOptions": ["badge", "sound", "alert", "banner", "list"]
     }
   }
 }
@@ -115,7 +115,7 @@ import { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   plugins: {
     PushNotifications: {
-      presentationOptions: ["badge", "sound", "alert"],
+      presentationOptions: ["badge", "sound", "alert", "banner", "list"],
     },
   },
 };

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -20,6 +20,7 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.NotificationParams;
 import com.google.firebase.messaging.RemoteMessage;
 import java.util.Arrays;
+import java.util.List;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -247,7 +248,8 @@ public class PushNotificationsPlugin extends Plugin {
             String body = notification.getBody();
             String[] presentation = getConfig().getArray("presentationOptions");
             if (presentation != null) {
-                if (Arrays.asList(presentation).contains("alert")) {
+                List<String> presentationList = Arrays.asList(presentation);
+                if (presentationList.contains("alert") || presentationList.contains("banner") || presentationList.contains("list")) {
                     Bundle bundle = null;
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                         try {

--- a/push-notifications/ios/Sources/PushNotificationsPlugin/PushNotificationsHandler.swift
+++ b/push-notifications/ios/Sources/PushNotificationsPlugin/PushNotificationsHandler.swift
@@ -34,11 +34,15 @@ public class PushNotificationsHandler: NSObject, NotificationHandlerProtocol {
 
             optionsArray.forEach { option in
                 switch option {
+                case "banner":
+                    presentationOptions.insert(.banner)
+                case "list":
+                    presentationOptions.insert(.list)
                 case "alert":
-                    presentationOptions.insert(.alert)
+                    presentationOptions.insert(.banner)
+                    presentationOptions.insert(.list)
                 case "badge":
                     presentationOptions.insert(.badge)
-
                 case "sound":
                     presentationOptions.insert(.sound)
                 default:

--- a/push-notifications/src/definitions.ts
+++ b/push-notifications/src/definitions.ts
@@ -15,8 +15,8 @@ declare module '@capacitor/cli' {
        *   - `badge`: badge count on the app icon is updated (default value)
        *   - `sound`: the device will ring/vibrate when the push notification is received
        *   - `alert`: **Deprecated on iOS.** Use `banner` and `list` instead. On Android, this value is still used to display the notification.
-       *   - `banner`: the push notification is displayed as a banner
-       *   - `list`: the push notification is displayed in the notification center
+       *   - `banner`: the push notification is displayed as a banner. On Android, defaults to the same behavior as `alert`.
+       *   - `list`: the push notification is displayed in the notification center. On Android, defaults to the same behavior as `alert`.
        *
        * An empty array can be provided if none of the options are desired.
        *

--- a/push-notifications/src/definitions.ts
+++ b/push-notifications/src/definitions.ts
@@ -2,7 +2,7 @@
 
 import type { PermissionState, PluginListenerHandle } from '@capacitor/core';
 
-export type PresentationOption = 'badge' | 'sound' | 'alert';
+export type PresentationOption = 'badge' | 'sound' | 'alert' | 'banner' | 'list';
 
 declare module '@capacitor/cli' {
   export interface PluginsConfig {
@@ -14,14 +14,16 @@ declare module '@capacitor/cli' {
        * This is an array of strings you can combine. Possible values in the array are:
        *   - `badge`: badge count on the app icon is updated (default value)
        *   - `sound`: the device will ring/vibrate when the push notification is received
-       *   - `alert`: the push notification is displayed in a native dialog
+       *   - `alert`: **Deprecated on iOS.** Use `banner` and `list` instead. On Android, this value is still used to display the notification.
+       *   - `banner`: the push notification is displayed as a banner
+       *   - `list`: the push notification is displayed in the notification center
        *
        * An empty array can be provided if none of the options are desired.
        *
        * badge is only available for iOS.
        *
        * @since 1.0.0
-       * @example ["badge", "sound", "alert"]
+       * @example ["badge", "sound", "alert", "banner", "list"]
        */
       presentationOptions: PresentationOption[];
     };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added `.banner` and `.list` as new `presentationOptions` values for iOS, replacing the deprecated `.alert` presentation option. For backwards compatibility, `.alert` is kept but now maps to both `.banner` and `.list` on iOS. 
On Android, `.banner` and `.list` trigger the same behavior as `.alert`.

Reference: https://outsystemsrd.atlassian.net/browse/RMET-5102

## Change Type
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->
`.alert` in `UNNotificationPresentationOptions` is deprecated since iOS 14 and replaced by the more granular `.banner` and `.list`. 
This PR adds support for the new values while keeping `.alert` working for backwards compatibility.


## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->
Tested on a physical iOS device using the Xcode Push Notifications Console with the following `presentationOptions` combinations:

- `["banner", "list", "sound"]`: banner appears + sound plays + notification in notification center
- `["banner", "sound"]`: banner appears + sound plays
- `["list", "sound"]`: no banner + sound plays + notification in notification center
- `["alert", "sound"]`: backwards compatibility behaves like `["banner", "list", "sound"]`

## Platforms Affected
- [x] Android
- [x] iOS
- [ ] Web
