### PR TITLE
feat(local-notifications): add presentationOptions config support for iOS

### DIFF
--- a/local-notifications/README.md
+++ b/local-notifications/README.md
@@ -36,13 +36,14 @@ For more information about the behavior changes of your app related to the priva
 <docgen-config>
 <!--Update the source file JSDoc comments and rerun docgen to update the docs below-->
 
-On Android, the Local Notifications can be configured with the following options:
+The Local Notifications can be configured with the following options:
 
-| Prop            | Type                | Description                                                                                                                                                                                                                                                                                                              | Since |
-| --------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
-| **`smallIcon`** | <code>string</code> | Set the default status bar icon for notifications. Icons should be placed in your app's `res/drawable` folder. The value for this option should be the drawable resource ID, which is the filename without an extension. Only available for Android.                                                                     | 1.0.0 |
-| **`iconColor`** | <code>string</code> | Set the default color of status bar icons for notifications. Only available for Android.                                                                                                                                                                                                                                 | 1.0.0 |
-| **`sound`**     | <code>string</code> | Set the default notification sound for notifications. On Android 8+ it sets the default channel sound and can't be changed unless the app is uninstalled. If the audio file is not found, it will result in the default system sound being played on Android 7.x and no sound on Android 8+. Only available for Android. | 1.0.0 |
+| Prop                      | Type                                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                    | Since |
+| ------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| **`smallIcon`**           | <code>string</code>                                | Set the default status bar icon for notifications. Icons should be placed in your app's `res/drawable` folder. The value for this option should be the drawable resource ID, which is the filename without an extension. Only available for Android.                                                                                                                                                                                           | 1.0.0 |
+| **`iconColor`**           | <code>string</code>                                | Set the default color of status bar icons for notifications. Only available for Android.                                                                                                                                                                                                                                                                                                                                                       | 1.0.0 |
+| **`sound`**               | <code>string</code>                                | Set the default notification sound for notifications. On Android 8+ it sets the default channel sound and can't be changed unless the app is uninstalled. If the audio file is not found, it will result in the default system sound being played on Android 7.x and no sound on Android 8+. Only available for Android.                                                                                                                       | 1.0.0 |
+| **`presentationOptions`** | <code>LocalNotificationPresentationOption[]</code> | This is an array of strings you can combine. Possible values in the array are: - `badge`: badge count on the app icon is updated (default value) - `sound`: the device will ring/vibrate when the notification is received - `banner`: the notification is displayed as a banner - `list`: the notification is displayed in the notification center An empty array can be provided if none of the options are desired. Only available for iOS. | 8.2.0 |
 
 ### Examples
 
@@ -54,7 +55,8 @@ In `capacitor.config.json`:
     "LocalNotifications": {
       "smallIcon": "ic_stat_icon_config_sample",
       "iconColor": "#488AFF",
-      "sound": "beep.wav"
+      "sound": "beep.wav",
+      "presentationOptions": ["badge", "sound", "banner", "list"]
     }
   }
 }
@@ -73,6 +75,7 @@ const config: CapacitorConfig = {
       smallIcon: "ic_stat_icon_config_sample",
       iconColor: "#488AFF",
       sound: "beep.wav",
+      presentationOptions: ["badge", "sound", "banner", "list"],
     },
   },
 };

--- a/local-notifications/ios/Sources/LocalNotificationsPlugin/LocalNotificationsHandler.swift
+++ b/local-notifications/ios/Sources/LocalNotificationsPlugin/LocalNotificationsHandler.swift
@@ -35,10 +35,32 @@ public class LocalNotificationsHandler: NSObject, NotificationHandlerProtocol {
             }
         }
 
+        if let optionsArray = self.plugin?.getConfig().getArray("presentationOptions") as? [String] {
+            var presentationOptions = UNNotificationPresentationOptions.init()
+
+            optionsArray.forEach { option in
+                switch option {
+                case "banner":
+                    presentationOptions.insert(.banner)
+                case "list":
+                    presentationOptions.insert(.list)
+                case "badge":
+                    presentationOptions.insert(.badge)
+                case "sound":
+                    presentationOptions.insert(.sound)
+                default:
+                    print("Unrecognized presentation option: \(option)")
+                }
+            }
+
+            return presentationOptions
+        }
+
         return [
             .badge,
             .sound,
-            .alert
+            .banner,
+            .list
         ]
     }
 

--- a/local-notifications/src/definitions.ts
+++ b/local-notifications/src/definitions.ts
@@ -2,10 +2,12 @@
 
 import type { PermissionState, PluginListenerHandle } from '@capacitor/core';
 
+export type LocalNotificationPresentationOption = 'badge' | 'sound' | 'banner' | 'list';
+
 declare module '@capacitor/cli' {
   export interface PluginsConfig {
     /**
-     * On Android, the Local Notifications can be configured with the following options:
+     * The Local Notifications can be configured with the following options:
      */
     LocalNotifications?: {
       /**
@@ -47,6 +49,22 @@ declare module '@capacitor/cli' {
        * @example "beep.wav"
        */
       sound?: string;
+
+      /**
+       * This is an array of strings you can combine. Possible values in the array are:
+       *   - `badge`: badge count on the app icon is updated (default value)
+       *   - `sound`: the device will ring/vibrate when the notification is received
+       *   - `banner`: the notification is displayed as a banner
+       *   - `list`: the notification is displayed in the notification center
+       *
+       * An empty array can be provided if none of the options are desired.
+       *
+       * Only available for iOS.
+       *
+       * @since 8.2.0
+       * @example ["badge", "sound", "banner", "list"]
+       */
+      presentationOptions?: LocalNotificationPresentationOption[];
     };
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added `presentationOptions` config support to local-notifications on iOS, replacing the hardcoded `[.badge, .sound, .alert]` in `willPresent`. The deprecated `.alert` is not exposed, only `.badge`, `.sound`, `.banner` and `.list` are available. 
Default behaviour (when no config is provided) is `[.badge, .sound, .banner, .list]`, equivalent to the previous behaviour.

Reference: https://outsystemsrd.atlassian.net/browse/RMET-5103

## Change Type
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->
`.alert` in `UNNotificationPresentationOptions` is deprecated since iOS 14. Since `presentationOptions` is being introduced from scratch in `local-notifications`, only the non deprecated values are exposed (`badge`, `sound`, `banner` and `list`), skipping `alert` entirely.

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->
Tested on a physical iOS device with the following `presentationOptions` combinations:

- `["banner", "list", "sound"]`: banner appears + sound plays + notification in notification center
- `["banner", "sound"]`: banner appears + sound plays
- `["list", "sound"]`: no banner + sound plays + notification in notification center
- not set: default behaviour (badge + sound + banner + list)

## Platforms Affected
- [ ] Android
- [x] iOS
- [ ] Web