### PR TITLE
refactor(push-notifications)!: remove unneeded code

### DIFF
--- a/push-notifications/README.md
+++ b/push-notifications/README.md
@@ -61,7 +61,7 @@ Android Studio has an icon generator you can use to create your Push Notificatio
 
 ## Push Notification channel
 
-From Android 8.0 (API level 26) and higher, notification channels are supported and recommended. The SDK will derive the `channelId` for incoming push notifications in the following order:
+The SDK will derive the `channelId` for incoming push notifications in the following order:
 
 1. **Firstly it will check if the incoming notification has a `channelId` set.**
    When sending a push notification from either the FCM dashboard, or through their API, it's possible to specify a `channelId`.
@@ -295,7 +295,7 @@ createChannel(channel: Channel) => Promise<void>
 
 Create a notification channel.
 
-Only available on Android O or newer (SDK 26+).
+Only available on Android.
 
 | Param         | Type                                        |
 | ------------- | ------------------------------------------- |
@@ -314,7 +314,7 @@ deleteChannel(args: { id: string; }) => Promise<void>
 
 Delete a notification channel.
 
-Only available on Android O or newer (SDK 26+).
+Only available on Android.
 
 | Param      | Type                         |
 | ---------- | ---------------------------- |
@@ -333,7 +333,7 @@ listChannels() => Promise<ListChannelsResult>
 
 List the available notification channels.
 
-Only available on Android O or newer (SDK 26+).
+Only available on Android.
 
 **Returns:** <code>Promise&lt;<a href="#listchannelsresult">ListChannelsResult</a>&gt;</code>
 

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/NotificationChannelManager.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/NotificationChannelManager.java
@@ -6,24 +6,19 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.media.AudioAttributes;
 import android.net.Uri;
-import android.os.Build;
-import android.provider.Settings;
 import androidx.core.app.NotificationCompat;
 import com.getcapacitor.*;
 import com.getcapacitor.util.WebColor;
-import java.util.Arrays;
 import java.util.List;
 
 public class NotificationChannelManager {
 
     private Context context;
     private NotificationManager notificationManager;
-    private PluginConfig config;
 
-    public NotificationChannelManager(Context context, NotificationManager manager, PluginConfig config) {
+    public NotificationChannelManager(Context context, NotificationManager manager) {
         this.context = context;
         this.notificationManager = manager;
-        this.config = config;
     }
 
     private static String CHANNEL_ID = "id";
@@ -37,104 +32,90 @@ public class NotificationChannelManager {
     private static String CHANNEL_LIGHT_COLOR = "lightColor";
 
     public void createChannel(PluginCall call) {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            JSObject channel = new JSObject();
-            if (call.getString(CHANNEL_ID) != null) {
-                channel.put(CHANNEL_ID, call.getString(CHANNEL_ID));
-            } else {
-                call.reject("Channel missing identifier");
-                return;
-            }
-            if (call.getString(CHANNEL_NAME) != null) {
-                channel.put(CHANNEL_NAME, call.getString(CHANNEL_NAME));
-            } else {
-                call.reject("Channel missing name");
-                return;
-            }
-
-            channel.put(CHANNEL_IMPORTANCE, call.getInt(CHANNEL_IMPORTANCE, NotificationManager.IMPORTANCE_DEFAULT));
-            channel.put(CHANNEL_DESCRIPTION, call.getString(CHANNEL_DESCRIPTION, ""));
-            channel.put(CHANNEL_VISIBILITY, call.getInt(CHANNEL_VISIBILITY, NotificationCompat.VISIBILITY_PUBLIC));
-            channel.put(CHANNEL_SOUND, call.getString(CHANNEL_SOUND, null));
-            channel.put(CHANNEL_VIBRATE, call.getBoolean(CHANNEL_VIBRATE, false));
-            channel.put(CHANNEL_USE_LIGHTS, call.getBoolean(CHANNEL_USE_LIGHTS, false));
-            channel.put(CHANNEL_LIGHT_COLOR, call.getString(CHANNEL_LIGHT_COLOR, null));
-            createChannel(channel);
-            call.resolve();
+        JSObject channel = new JSObject();
+        if (call.getString(CHANNEL_ID) != null) {
+            channel.put(CHANNEL_ID, call.getString(CHANNEL_ID));
         } else {
-            call.unavailable();
+            call.reject("Channel missing identifier");
+            return;
         }
+        if (call.getString(CHANNEL_NAME) != null) {
+            channel.put(CHANNEL_NAME, call.getString(CHANNEL_NAME));
+        } else {
+            call.reject("Channel missing name");
+            return;
+        }
+
+        channel.put(CHANNEL_IMPORTANCE, call.getInt(CHANNEL_IMPORTANCE, NotificationManager.IMPORTANCE_DEFAULT));
+        channel.put(CHANNEL_DESCRIPTION, call.getString(CHANNEL_DESCRIPTION, ""));
+        channel.put(CHANNEL_VISIBILITY, call.getInt(CHANNEL_VISIBILITY, NotificationCompat.VISIBILITY_PUBLIC));
+        channel.put(CHANNEL_SOUND, call.getString(CHANNEL_SOUND, null));
+        channel.put(CHANNEL_VIBRATE, call.getBoolean(CHANNEL_VIBRATE, false));
+        channel.put(CHANNEL_USE_LIGHTS, call.getBoolean(CHANNEL_USE_LIGHTS, false));
+        channel.put(CHANNEL_LIGHT_COLOR, call.getString(CHANNEL_LIGHT_COLOR, null));
+        createChannel(channel);
+        call.resolve();
     }
 
     public void createChannel(JSObject channel) {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            NotificationChannel notificationChannel = new NotificationChannel(
-                channel.getString(CHANNEL_ID),
-                channel.getString(CHANNEL_NAME),
-                channel.getInteger(CHANNEL_IMPORTANCE)
-            );
-            notificationChannel.setDescription(channel.getString(CHANNEL_DESCRIPTION));
-            notificationChannel.setLockscreenVisibility(channel.getInteger(CHANNEL_VISIBILITY));
-            notificationChannel.enableVibration(channel.getBool(CHANNEL_VIBRATE));
-            notificationChannel.enableLights(channel.getBool(CHANNEL_USE_LIGHTS));
-            String lightColor = channel.getString(CHANNEL_LIGHT_COLOR);
-            if (lightColor != null) {
-                try {
-                    notificationChannel.setLightColor(WebColor.parseColor(lightColor));
-                } catch (IllegalArgumentException ex) {
-                    Logger.error(Logger.tags("NotificationChannel"), "Invalid color provided for light color.", null);
-                }
+        NotificationChannel notificationChannel = new NotificationChannel(
+            channel.getString(CHANNEL_ID),
+            channel.getString(CHANNEL_NAME),
+            channel.getInteger(CHANNEL_IMPORTANCE)
+        );
+        notificationChannel.setDescription(channel.getString(CHANNEL_DESCRIPTION));
+        notificationChannel.setLockscreenVisibility(channel.getInteger(CHANNEL_VISIBILITY));
+        notificationChannel.enableVibration(channel.getBool(CHANNEL_VIBRATE));
+        notificationChannel.enableLights(channel.getBool(CHANNEL_USE_LIGHTS));
+        String lightColor = channel.getString(CHANNEL_LIGHT_COLOR);
+        if (lightColor != null) {
+            try {
+                notificationChannel.setLightColor(WebColor.parseColor(lightColor));
+            } catch (IllegalArgumentException ex) {
+                Logger.error(Logger.tags("NotificationChannel"), "Invalid color provided for light color.", null);
             }
-            String sound = channel.getString(CHANNEL_SOUND, null);
-            if (sound != null && !sound.isEmpty()) {
-                if (sound.contains(".")) {
-                    sound = sound.substring(0, sound.lastIndexOf('.'));
-                }
-                AudioAttributes audioAttributes = new AudioAttributes.Builder()
-                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                    .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                    .build();
-                Uri soundUri = Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + context.getPackageName() + "/raw/" + sound);
-                notificationChannel.setSound(soundUri, audioAttributes);
-            }
-            notificationManager.createNotificationChannel(notificationChannel);
         }
+        String sound = channel.getString(CHANNEL_SOUND, null);
+        if (sound != null && !sound.isEmpty()) {
+            if (sound.contains(".")) {
+                sound = sound.substring(0, sound.lastIndexOf('.'));
+            }
+            AudioAttributes audioAttributes = new AudioAttributes.Builder()
+                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                .build();
+            Uri soundUri = Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + context.getPackageName() + "/raw/" + sound);
+            notificationChannel.setSound(soundUri, audioAttributes);
+        }
+        notificationManager.createNotificationChannel(notificationChannel);
     }
 
     public void deleteChannel(PluginCall call) {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            String channelId = call.getString("id");
-            notificationManager.deleteNotificationChannel(channelId);
-            call.resolve();
-        } else {
-            call.unavailable();
-        }
+        String channelId = call.getString("id");
+        notificationManager.deleteNotificationChannel(channelId);
+        call.resolve();
     }
 
     public void listChannels(PluginCall call) {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            List<NotificationChannel> notificationChannels = notificationManager.getNotificationChannels();
-            JSArray channels = new JSArray();
-            for (NotificationChannel notificationChannel : notificationChannels) {
-                JSObject channel = new JSObject();
-                channel.put(CHANNEL_ID, notificationChannel.getId());
-                channel.put(CHANNEL_NAME, notificationChannel.getName());
-                channel.put(CHANNEL_DESCRIPTION, notificationChannel.getDescription());
-                channel.put(CHANNEL_IMPORTANCE, notificationChannel.getImportance());
-                channel.put(CHANNEL_VISIBILITY, notificationChannel.getLockscreenVisibility());
-                channel.put(CHANNEL_SOUND, notificationChannel.getSound());
-                channel.put(CHANNEL_VIBRATE, notificationChannel.shouldVibrate());
-                channel.put(CHANNEL_USE_LIGHTS, notificationChannel.shouldShowLights());
-                channel.put(CHANNEL_LIGHT_COLOR, String.format("#%06X", (0xFFFFFF & notificationChannel.getLightColor())));
-                Logger.debug(Logger.tags("NotificationChannel"), "visibility " + notificationChannel.getLockscreenVisibility());
-                Logger.debug(Logger.tags("NotificationChannel"), "importance " + notificationChannel.getImportance());
-                channels.put(channel);
-            }
-            JSObject result = new JSObject();
-            result.put("channels", channels);
-            call.resolve(result);
-        } else {
-            call.unavailable();
+        List<NotificationChannel> notificationChannels = notificationManager.getNotificationChannels();
+        JSArray channels = new JSArray();
+        for (NotificationChannel notificationChannel : notificationChannels) {
+            JSObject channel = new JSObject();
+            channel.put(CHANNEL_ID, notificationChannel.getId());
+            channel.put(CHANNEL_NAME, notificationChannel.getName());
+            channel.put(CHANNEL_DESCRIPTION, notificationChannel.getDescription());
+            channel.put(CHANNEL_IMPORTANCE, notificationChannel.getImportance());
+            channel.put(CHANNEL_VISIBILITY, notificationChannel.getLockscreenVisibility());
+            channel.put(CHANNEL_SOUND, notificationChannel.getSound());
+            channel.put(CHANNEL_VIBRATE, notificationChannel.shouldVibrate());
+            channel.put(CHANNEL_USE_LIGHTS, notificationChannel.shouldShowLights());
+            channel.put(CHANNEL_LIGHT_COLOR, String.format("#%06X", (0xFFFFFF & notificationChannel.getLightColor())));
+            Logger.debug(Logger.tags("NotificationChannel"), "visibility " + notificationChannel.getLockscreenVisibility());
+            Logger.debug(Logger.tags("NotificationChannel"), "importance " + notificationChannel.getImportance());
+            channels.put(channel);
         }
+        JSObject result = new JSObject();
+        result.put("channels", channels);
+        call.resolve(result);
     }
 }

--- a/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
+++ b/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications/PushNotificationsPlugin.java
@@ -51,7 +51,7 @@ public class PushNotificationsPlugin extends Plugin {
             lastMessage = null;
         }
 
-        notificationChannelManager = new NotificationChannelManager(getActivity(), notificationManager, getConfig());
+        notificationChannelManager = new NotificationChannelManager(getActivity(), notificationManager);
     }
 
     @Override

--- a/push-notifications/src/definitions.ts
+++ b/push-notifications/src/definitions.ts
@@ -75,7 +75,7 @@ export interface PushNotificationsPlugin {
   /**
    * Create a notification channel.
    *
-   * Only available on Android O or newer (SDK 26+).
+   * Only available on Android.
    *
    * @since 1.0.0
    */
@@ -84,7 +84,7 @@ export interface PushNotificationsPlugin {
   /**
    * Delete a notification channel.
    *
-   * Only available on Android O or newer (SDK 26+).
+   * Only available on Android.
    *
    * @since 1.0.0
    */
@@ -93,7 +93,7 @@ export interface PushNotificationsPlugin {
   /**
    * List the available notification channels.
    *
-   * Only available on Android O or newer (SDK 26+).
+   * Only available on Android.
    *
    * @since 1.0.0
    */


### PR DESCRIPTION
remove code for Android < 26/O

breaking because I removed config from `NotificationChannelManager` constructor, since it was not being used anymore (config usage was not removed on my PR but 3 years ago)