### PR TITLE
feat(network): expose connection condition flags

### DIFF
--- a/network/README.md
+++ b/network/README.md
@@ -99,6 +99,8 @@ Represents the state and type of the network connection.
 | -------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----- |
 | **`connected`**      | <code>boolean</code>                                      | Whether there is an active connection or not.                                                                                 | 1.0.0 |
 | **`connectionType`** | <code><a href="#connectiontype">ConnectionType</a></code> | The type of network connection currently in use. If there is no active network connection, `connectionType` will be `'none'`. | 1.0.0 |
+| **`constrained`**    | <code>boolean</code>                                      | Whether the active connection is constrained by platform data-saving or bandwidth-reduction signals.                          | 8.1.0 |
+| **`expensive`**      | <code>boolean</code>                                      | Whether the active connection is considered expensive or metered by the platform.                                             | 8.1.0 |
 
 
 #### PluginListenerHandle

--- a/network/android/src/main/java/com/capacitorjs/plugins/network/Network.java
+++ b/network/android/src/main/java/com/capacitorjs/plugins/network/Network.java
@@ -2,9 +2,12 @@ package com.capacitorjs.plugins.network;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.ConnectivityManager.NetworkCallback;
 import android.net.NetworkCapabilities;
+import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -38,7 +41,7 @@ public class Network {
     private ConnectivityCallback connectivityCallback;
     private Context context;
     private ConnectivityManager connectivityManager;
-    private BroadcastReceiver receiver;
+    private BroadcastReceiver restrictBackgroundReceiver;
 
     /**
      * Create network monitoring object.
@@ -48,6 +51,14 @@ public class Network {
         this.context = context;
         this.connectivityManager = (ConnectivityManager) this.context.getSystemService(Context.CONNECTIVITY_SERVICE);
         this.connectivityCallback = new ConnectivityCallback();
+        this.restrictBackgroundReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                if (ConnectivityManager.ACTION_RESTRICT_BACKGROUND_CHANGED.equals(intent.getAction()) && statusChangeListener != null) {
+                    statusChangeListener.onNetworkStatusChanged(false);
+                }
+            }
+        };
     }
 
     /**
@@ -75,11 +86,17 @@ public class Network {
         NetworkStatus networkStatus = new NetworkStatus();
         if (this.connectivityManager != null) {
             android.net.Network activeNetwork = this.connectivityManager.getActiveNetwork();
-            NetworkCapabilities capabilities = this.connectivityManager.getNetworkCapabilities(this.connectivityManager.getActiveNetwork());
+            NetworkCapabilities capabilities = this.connectivityManager.getNetworkCapabilities(activeNetwork);
             if (activeNetwork != null && capabilities != null) {
                 networkStatus.connected =
                     capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) &&
                     capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
+                networkStatus.expensive = !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED);
+                networkStatus.constrained = isConstrained(
+                    connectivityManager.getRestrictBackgroundStatus(),
+                    networkStatus.expensive,
+                    isBandwidthConstrained(capabilities)
+                );
                 if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
                     networkStatus.connectionType = NetworkStatus.ConnectionType.WIFI;
                 } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
@@ -90,6 +107,17 @@ public class Network {
             }
         }
         return networkStatus;
+    }
+
+    static boolean isConstrained(int restrictBackgroundStatus, boolean expensive, boolean bandwidthConstrained) {
+        return (expensive && restrictBackgroundStatus == ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED) || bandwidthConstrained;
+    }
+
+    private static boolean isBandwidthConstrained(NetworkCapabilities capabilities) {
+        return (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM &&
+            !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_BANDWIDTH_CONSTRAINED)
+        );
     }
 
     @SuppressWarnings("deprecation")
@@ -113,6 +141,12 @@ public class Network {
      */
     public void startMonitoring() {
         connectivityManager.registerDefaultNetworkCallback(connectivityCallback);
+        IntentFilter filter = new IntentFilter(ConnectivityManager.ACTION_RESTRICT_BACKGROUND_CHANGED);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(restrictBackgroundReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(restrictBackgroundReceiver, filter);
+        }
     }
 
     /**
@@ -120,5 +154,6 @@ public class Network {
      */
     public void stopMonitoring() {
         connectivityManager.unregisterNetworkCallback(connectivityCallback);
+        context.unregisterReceiver(restrictBackgroundReceiver);
     }
 }

--- a/network/android/src/main/java/com/capacitorjs/plugins/network/NetworkPlugin.java
+++ b/network/android/src/main/java/com/capacitorjs/plugins/network/NetworkPlugin.java
@@ -1,6 +1,5 @@
 package com.capacitorjs.plugins.network;
 
-import android.os.Build;
 import android.util.Log;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
@@ -26,6 +25,8 @@ public class NetworkPlugin extends Plugin {
                 JSObject jsObject = new JSObject();
                 jsObject.put("connected", false);
                 jsObject.put("connectionType", "none");
+                jsObject.put("constrained", false);
+                jsObject.put("expensive", false);
                 notifyListeners(NETWORK_CHANGE_EVENT, jsObject);
             } else {
                 updateNetworkStatus();
@@ -89,6 +90,8 @@ public class NetworkPlugin extends Plugin {
         JSObject jsObject = new JSObject();
         jsObject.put("connected", networkStatus.connected);
         jsObject.put("connectionType", networkStatus.connectionType.getConnectionType());
+        jsObject.put("constrained", networkStatus.constrained);
+        jsObject.put("expensive", networkStatus.expensive);
         return jsObject;
     }
 }

--- a/network/android/src/main/java/com/capacitorjs/plugins/network/NetworkStatus.java
+++ b/network/android/src/main/java/com/capacitorjs/plugins/network/NetworkStatus.java
@@ -21,4 +21,6 @@ public class NetworkStatus {
 
     public boolean connected = false;
     public ConnectionType connectionType = ConnectionType.NONE;
+    public boolean constrained = false;
+    public boolean expensive = false;
 }

--- a/network/android/src/test/java/com/capacitorjs/plugins/network/NetworkTest.java
+++ b/network/android/src/test/java/com/capacitorjs/plugins/network/NetworkTest.java
@@ -1,0 +1,31 @@
+package com.capacitorjs.plugins.network;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.net.ConnectivityManager;
+import org.junit.Test;
+
+public class NetworkTest {
+
+    @Test
+    public void isConstrainedReturnsTrueWhenMeteredBackgroundDataIsRestricted() {
+        assertTrue(Network.isConstrained(ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED, true, false));
+    }
+
+    @Test
+    public void isConstrainedReturnsFalseWhenUnmeteredBackgroundDataIsRestricted() {
+        assertFalse(Network.isConstrained(ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED, false, false));
+    }
+
+    @Test
+    public void isConstrainedReturnsTrueWhenBandwidthIsConstrained() {
+        assertTrue(Network.isConstrained(ConnectivityManager.RESTRICT_BACKGROUND_STATUS_DISABLED, false, true));
+    }
+
+    @Test
+    public void isConstrainedReturnsFalseWhenBackgroundDataIsUnrestricted() {
+        assertFalse(Network.isConstrained(ConnectivityManager.RESTRICT_BACKGROUND_STATUS_DISABLED, true, false));
+        assertFalse(Network.isConstrained(ConnectivityManager.RESTRICT_BACKGROUND_STATUS_WHITELISTED, true, false));
+    }
+}

--- a/network/ios/Sources/NetworkPlugin/Network.swift
+++ b/network/ios/Sources/NetworkPlugin/Network.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 
 public typealias NetworkConnectionChangedObserver = (Network.Connection) -> Void
 
@@ -9,9 +10,22 @@ public class Network {
     public enum Connection {
         case unavailable, wifi, cellular
     }
+    struct ConnectionDetails {
+        var constrained = false
+        var expensive = false
+    }
 
     internal private(set) var reachability: Reachability?
+    private let pathMonitor = NWPathMonitor()
+    private let pathMonitorQueue = DispatchQueue(label: "capacitor.network.pathMonitor")
+    private let connectionDetailsQueue = DispatchQueue(label: "capacitor.network.connectionDetails")
+    private let observerQueue = DispatchQueue(label: "capacitor.network.observer")
+    private var details = ConnectionDetails()
+    private var observerNotificationPending = false
     var statusObserver: NetworkConnectionChangedObserver?
+    var connectionDetails: ConnectionDetails {
+        return connectionDetailsQueue.sync { details }
+    }
 
     init() throws {
         reachability = try Reachability()
@@ -19,17 +33,63 @@ public class Network {
             throw NetworkError.initializationFailed
         }
         // setup our callback(s) and start notifications
-        reachability?.whenReachable = { [weak self] reachable in
-            self?.statusObserver?(reachable.connection.equivalentEnum)
+        reachability?.whenReachable = { [weak self] _ in
+            self?.notifyStatusObserver()
         }
         reachability?.whenUnreachable = { [weak self] _ in
-            self?.statusObserver?(Connection.unavailable)
+            self?.notifyStatusObserver()
         }
+        pathMonitor.pathUpdateHandler = { [weak self] path in
+            if self?.updateConnectionDetails(path) == true {
+                self?.notifyStatusObserver()
+            }
+        }
+        pathMonitor.start(queue: pathMonitorQueue)
+        _ = updateConnectionDetails(pathMonitor.currentPath)
         try reachability?.startNotifier()
+    }
+
+    deinit {
+        pathMonitor.cancel()
     }
 
     func currentStatus() -> Network.Connection {
         return reachability?.connection.equivalentEnum ?? Connection.unavailable
+    }
+
+    private func updateConnectionDetails(_ path: NWPath) -> Bool {
+        let nextDetails = ConnectionDetails(constrained: path.isConstrained, expensive: path.isExpensive)
+        return connectionDetailsQueue.sync {
+            guard details.constrained != nextDetails.constrained || details.expensive != nextDetails.expensive else {
+                return false
+            }
+            details = nextDetails
+            return true
+        }
+    }
+
+    private func notifyStatusObserver() {
+        var shouldNotify = false
+        observerQueue.sync {
+            if !observerNotificationPending {
+                observerNotificationPending = true
+                shouldNotify = true
+            }
+        }
+
+        guard shouldNotify else {
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.observerQueue.sync {
+                self.observerNotificationPending = false
+            }
+            self.statusObserver?(self.currentStatus())
+        }
     }
 }
 

--- a/network/ios/Sources/NetworkPlugin/NetworkPlugin.swift
+++ b/network/ios/Sources/NetworkPlugin/NetworkPlugin.swift
@@ -16,10 +16,7 @@ public class NetworkPlugin: CAPPlugin, CAPBridgedPlugin {
             implementation = try Network()
             implementation?.statusObserver = { [weak self] status in
                 CAPLog.print(status.logMessage)
-                self?.notifyListeners("networkStatusChange", data: [
-                    "connected": status.isConnected,
-                    "connectionType": status.jsStringValue
-                ])
+                self?.notifyListeners("networkStatusChange", data: self?.statusData(status) ?? [:])
             }
         } catch let error {
             CAPLog.print("Unable to start network monitor: \(error)")
@@ -28,7 +25,17 @@ public class NetworkPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func getStatus(_ call: CAPPluginCall) {
         let status = implementation?.currentStatus() ?? Network.Connection.unavailable
-        call.resolve(["connected": status.isConnected, "connectionType": status.jsStringValue])
+        call.resolve(statusData(status))
+    }
+
+    private func statusData(_ status: Network.Connection) -> [String: Any] {
+        let details = status.isConnected ? (implementation?.connectionDetails ?? Network.ConnectionDetails()) : Network.ConnectionDetails()
+        return [
+            "connected": status.isConnected,
+            "connectionType": status.jsStringValue,
+            "constrained": details.constrained,
+            "expensive": details.expensive
+        ]
     }
 }
 

--- a/network/ios/Tests/NetworkPluginTests/PluginTests.swift
+++ b/network/ios/Tests/NetworkPluginTests/PluginTests.swift
@@ -34,4 +34,14 @@ class NetworkTests: XCTestCase {
             XCTFail("Network initialization failed! \(error)")
         }
     }
+
+    func testConnectionConditionDefaults() {
+        do {
+            let implementation = try Network()
+            XCTAssertFalse(implementation.connectionDetails.constrained)
+            XCTAssertFalse(implementation.connectionDetails.expensive)
+        } catch let error {
+            XCTFail("Network initialization failed! \(error)")
+        }
+    }
 }

--- a/network/src/definitions.ts
+++ b/network/src/definitions.ts
@@ -47,6 +47,20 @@ export interface ConnectionStatus {
    * @since 1.0.0
    */
   connectionType: ConnectionType;
+
+  /**
+   * Whether the active connection is constrained by platform data-saving or bandwidth-reduction signals.
+   *
+   * @since 8.1.0
+   */
+  constrained?: boolean;
+
+  /**
+   * Whether the active connection is considered expensive or metered by the platform.
+   *
+   * @since 8.1.0
+   */
+  expensive?: boolean;
 }
 
 /**

--- a/network/src/web.ts
+++ b/network/src/web.ts
@@ -49,6 +49,14 @@ function translatedConnection(): ConnectionType {
   return result;
 }
 
+function connectionDetails(): Pick<ConnectionStatus, 'constrained' | 'expensive'> {
+  const connection = window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection;
+  return {
+    constrained: !!connection?.saveData,
+    expensive: false,
+  };
+}
+
 export class NetworkWeb extends WebPlugin implements NetworkPlugin {
   constructor() {
     super();
@@ -69,6 +77,7 @@ export class NetworkWeb extends WebPlugin implements NetworkPlugin {
     const status: ConnectionStatus = {
       connected,
       connectionType: connected ? connectionType : 'none',
+      ...connectionDetails(),
     };
 
     return status;
@@ -80,6 +89,7 @@ export class NetworkWeb extends WebPlugin implements NetworkPlugin {
     const status: ConnectionStatus = {
       connected: true,
       connectionType: connectionType,
+      ...connectionDetails(),
     };
 
     this.notifyListeners('networkStatusChange', status);
@@ -89,6 +99,8 @@ export class NetworkWeb extends WebPlugin implements NetworkPlugin {
     const status: ConnectionStatus = {
       connected: false,
       connectionType: 'none',
+      constrained: false,
+      expensive: false,
     };
 
     this.notifyListeners('networkStatusChange', status);


### PR DESCRIPTION
## Description

Adds optional `constrained` and `expensive` fields to `Network.getStatus()` and `networkStatusChange`.

This keeps `connectionType` unchanged and exposes connection condition signals separately:

- iOS uses `NWPath.isConstrained` and `NWPath.isExpensive`
- Android uses metered network capabilities, Data Saver restrictions, and Android 15 bandwidth-constrained capabilities
- Web uses `navigator.connection.saveData` for `constrained`

Offline status reports both fields as `false`.

## Change Type

- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed

Some apps need to adjust network behavior based on more than connection type. For example, a connection can still be Wi-Fi or cellular while also being metered, expensive, or under a platform data-saving mode.

This adds platform-backed condition flags without changing the existing `connectionType` API.

## Tests or Reproductions

Tested with:

- `CAP_PLUGIN_PUBLISH=true CAPACITOR_VERSION=8.4.1 npm run verify`
- `npm run lint`
- `xcodebuild test -scheme CapacitorNetwork -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5'`
- `xcodebuild build -scheme CapacitorNetwork -destination 'id=00008150-001155E01191401C'`

Also verified the iOS target builds for a physical iPhone 17 Pro on iOS 26.5.1.

## Screenshots / Media

N/A

## Platforms Affected

- [x] Android
- [x] iOS
- [x] Web

## Notes / Comments

No related issue that I could find.