### PR TITLE
docs(motion): add orientation listener example to README

### DIFF
--- a/motion/README.md
+++ b/motion/README.md
@@ -23,10 +23,9 @@ import { Motion } from '@capacitor/motion';
 let accelHandler: PluginListenerHandle;
 let orientationHandler: PluginListenerHandle;
 
-myButton.addEventListener('click', async () => {
+myAccelerationButton.addEventListener('click', async () => {
   try {
     await DeviceMotionEvent.requestPermission();
-    await DeviceOrientationEvent.requestPermission();
   } catch (e) {
     // Handle error
     return;
@@ -36,17 +35,31 @@ myButton.addEventListener('click', async () => {
   accelHandler = await Motion.addListener('accel', event => {
     console.log('Device motion event:', event);
   });
+});
 
+myOrientationButton.addEventListener('click', async () => {
+  try {
+    await DeviceOrientationEvent.requestPermission();
+  } catch (e) {
+    // Handle error
+    return;
+  }
+
+  // Once the user approves, can start listening:
   orientationHandler = await Motion.addListener('orientation', event => {
     console.log('Device orientation event:', event);
   });
 });
 
-// Stop a specific listener
-const stopListening = () => {
+// Stop the acceleration listener
+const stopAcceleration = () => {
   if (accelHandler) {
     accelHandler.remove();
   }
+};
+
+// Stop the orientation listener
+const stopOrientation = () => {
   if (orientationHandler) {
     orientationHandler.remove();
   }

--- a/motion/README.md
+++ b/motion/README.md
@@ -12,7 +12,7 @@ npx cap sync
 ## Permissions
 
 This plugin is currently implemented using Web APIs. Most browsers require
-permission before using this API. To request permission, prompt the user for
+permission before using these APIs. To request permission, prompt the user for
 permission on any user-initiated action (such as a button click):
 
 ```typescript
@@ -21,10 +21,12 @@ import { Motion } from '@capacitor/motion';
 
 
 let accelHandler: PluginListenerHandle;
+let orientationHandler: PluginListenerHandle;
 
 myButton.addEventListener('click', async () => {
   try {
     await DeviceMotionEvent.requestPermission();
+    await DeviceOrientationEvent.requestPermission();
   } catch (e) {
     // Handle error
     return;
@@ -34,12 +36,19 @@ myButton.addEventListener('click', async () => {
   accelHandler = await Motion.addListener('accel', event => {
     console.log('Device motion event:', event);
   });
+
+  orientationHandler = await Motion.addListener('orientation', event => {
+    console.log('Device orientation event:', event);
+  });
 });
 
-// Stop the acceleration listener
-const stopAcceleration = () => {
+// Stop a specific listener
+const stopListening = () => {
   if (accelHandler) {
     accelHandler.remove();
+  }
+  if (orientationHandler) {
+    orientationHandler.remove();
   }
 };
 
@@ -51,7 +60,10 @@ const removeListeners = () => {
 
 See the
 [`DeviceMotionEvent`](https://developer.mozilla.org/en-US/docs/Web/API/DeviceMotionEvent)
-API to understand the data supplied in the 'accel' event.
+and
+[`DeviceOrientationEvent`](https://developer.mozilla.org/en-US/docs/Web/API/DeviceOrientationEvent)
+APIs to understand the data supplied in the `'accel'` and `'orientation'`
+events respectively.
 
 ## API
 

--- a/motion/README.md
+++ b/motion/README.md
@@ -11,10 +11,10 @@ npx cap sync
 
 ## Permissions
 
-This plugin is currently implemented using Web APIs. On iOS, permission must
-be requested before accessing device motion or orientation events. Other
-platforms do not require the check. To request permission, prompt the user
-on any user-initiated action (such as a button click):
+This plugin is currently implemented using Web APIs. On iOS devices,
+permission must be requested before accessing device motion or orientation
+events. To request permission, prompt the user on any user-initiated action
+(such as a button click):
 
 ```typescript
 import { PluginListenerHandle } from '@capacitor/core';

--- a/motion/README.md
+++ b/motion/README.md
@@ -11,9 +11,10 @@ npx cap sync
 
 ## Permissions
 
-This plugin is currently implemented using Web APIs. Most browsers require
-permission before using these APIs. To request permission, prompt the user for
-permission on any user-initiated action (such as a button click):
+This plugin is currently implemented using Web APIs. On iOS, permission must
+be requested before accessing device motion or orientation events. Other
+platforms do not require the check. To request permission, prompt the user
+on any user-initiated action (such as a button click):
 
 ```typescript
 import { PluginListenerHandle } from '@capacitor/core';
@@ -24,11 +25,14 @@ let accelHandler: PluginListenerHandle;
 let orientationHandler: PluginListenerHandle;
 
 myAccelerationButton.addEventListener('click', async () => {
-  try {
-    await DeviceMotionEvent.requestPermission();
-  } catch (e) {
-    // Handle error
-    return;
+  if (typeof DeviceMotionEvent.requestPermission === 'function') {
+    try {
+      const permission = await DeviceMotionEvent.requestPermission();
+      if (permission !== 'granted') return;
+    } catch (e) {
+      // Handle error
+      return;
+    }
   }
 
   // Once the user approves, can start listening:
@@ -38,11 +42,14 @@ myAccelerationButton.addEventListener('click', async () => {
 });
 
 myOrientationButton.addEventListener('click', async () => {
-  try {
-    await DeviceOrientationEvent.requestPermission();
-  } catch (e) {
-    // Handle error
-    return;
+  if (typeof DeviceOrientationEvent.requestPermission === 'function') {
+    try {
+      const permission = await DeviceOrientationEvent.requestPermission();
+      if (permission !== 'granted') return;
+    } catch (e) {
+      // Handle error
+      return;
+    }
   }
 
   // Once the user approves, can start listening:


### PR DESCRIPTION
   README

## Description
<!--- Describe your changes in detail -->
Add an 'orientation' listener example to the Motion plugin README alongside the existing 'accel' one.

Closes #2539.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [x] Documentation
- [ ] Other (CI, chores, etc.)


## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->

 Plan to backport to 7.x.
