### PR TITLE
chore: add dist to root gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+dist
 .DS_Store
 package-lock.json
 Podfile.lock


### PR DESCRIPTION
Plugins already have `dist` inside their own .gitignore, this is to prevent `dist` files appearing untracked after switching to a branch that doesn't have a certain plugin. A current example:

1. Have the camera plugin in `main` branch with build `dist` folder.
2. Switch to `next` branch where camera was removed
3. Without this PR, you'll find `camera` folder in untracked files, because of the `dist` folder that wasn't in source control therefore it was never technically removed.

With `dist` in root .gitignore we won't accidentally commit those files.