### PR TITLE
fix(local-notifications): honor autoCancel when a notification is tapped

### DIFF
--- a/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
+++ b/local-notifications/android/src/main/java/com/capacitorjs/plugins/localnotifications/LocalNotificationManager.java
@@ -83,8 +83,6 @@ public class LocalNotificationManager {
         }
         String menuAction = data.getStringExtra(LocalNotificationManager.ACTION_INTENT_KEY);
 
-        dismissVisibleNotification(notificationId);
-
         dataJson.put("actionId", menuAction);
         JSONObject request = null;
         try {
@@ -93,6 +91,15 @@ public class LocalNotificationManager {
                 request = new JSObject(notificationJsonString);
             }
         } catch (JSONException e) {}
+
+        // Only dismiss the tapped notification when autoCancel allows it; the
+        // builder already applies setAutoCancel(), but this explicit cancel used
+        // to run unconditionally, making `autoCancel: false` a no-op on tap.
+        boolean autoCancel = request == null || request.optBoolean("autoCancel", true);
+        if (autoCancel) {
+            dismissVisibleNotification(notificationId);
+        }
+
         dataJson.put("notification", request);
         return dataJson;
     }


### PR DESCRIPTION
Closes https://github.com/ionic-team/capacitor-local-notifications/issues/10

## What

On Android, `handleNotificationActionPerformed` dismissed the tapped notification unconditionally via `dismissVisibleNotification(notificationId)`, which made `autoCancel: false` a no-op on the tap path — the notification disappeared from the shade on every tap regardless of the flag (the builder's `setAutoCancel(false)` never got a chance to matter, since the plugin issues its own explicit `NotificationManager.cancel()`).

## How

Read `autoCancel` from the notification payload the tap intent already carries (`NOTIFICATION_OBJ_INTENT_KEY`) and only call `dismissVisibleNotification` when it is `true`. The default stays `true` (also when the payload is absent or unparseable), so behavior is unchanged for every caller that didn't explicitly set `autoCancel: false`.

## Testing

Manually on a physical device (Android 14, Capacitor 8.4.2):

- `schedule({ notifications: [{ id, title, body, autoCancel: false }] })` → tap → app opens, notification stays in the shade.
- Same without `autoCancel` and with `autoCancel: true` → tap → notification is dismissed (unchanged behavior).
- Re-scheduling with the same `id` still replaces the delivered notification in place.

## Context

Fixes the behavior reported in ionic-team/capacitor-plugins#1384 (closed by the bot for lack of reproduction, locked; the code path is unchanged since then).
