### PR TITLE
docs(preferences): clarify that stored data is unencrypted and point to secure alternatives

### DIFF
--- a/preferences/README.md
+++ b/preferences/README.md
@@ -16,6 +16,8 @@ on Android. Stored data is cleared if the app is uninstalled.
 stores a lot of data, has high read/write load, or requires complex querying,
 we recommend taking a look at a SQLite-based solution. One such solution is [Ionic Secure Storage](https://ionic.io/docs/secure-storage), a SQLite-based engine with full encryption support. The [Capacitor Community](https://github.com/capacitor-community/) has also built a number of other storage engines.
 
+Also note that data stored with this API is _not_ encrypted: it is persisted via `UserDefaults` on iOS and `SharedPreferences` on Android, both of which store values in plain text. For sensitive values such as tokens or credentials, consider an encrypted key/value solution such as the [Capawesome Secure Preferences](https://capawesome.io/docs/sdks/capacitor/secure-preferences/) plugin, which encrypts values using the Android Keystore and iOS Keychain.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Description
Adds a short note to the Preferences README clarifying that data stored through this API is not encrypted, and points readers to an encrypted key/value alternative for sensitive data.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [x] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
A recurring question from developers is whether Preferences is safe for storing tokens, credentials, or other sensitive values. The current note covers the "don't use this as a database" case and links SQLite-based alternatives, but doesn't address the encryption question directly, which leads people to store sensitive data here assuming it's protected.
