### PR TITLE
chore(android): update action-sheet and browser dependencies

### DIFF
--- a/action-sheet/README.md
+++ b/action-sheet/README.md
@@ -13,7 +13,7 @@ npx cap sync
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-- `androidxMaterialVersion`: version of `com.google.android.material:material` (default: `1.13.0`)
+- `androidxMaterialVersion`: version of `com.google.android.material:material` (default: `1.14.0`)
 
 ## PWA Notes
 

--- a/action-sheet/android/build.gradle
+++ b/action-sheet/android/build.gradle
@@ -2,7 +2,7 @@ ext {
     capacitorVersion = System.getenv('CAPACITOR_VERSION')
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.7.1'
-    androidxMaterialVersion = project.hasProperty('androidxMaterialVersion') ? rootProject.ext.androidxMaterialVersion : '1.13.0'
+    androidxMaterialVersion = project.hasProperty('androidxMaterialVersion') ? rootProject.ext.androidxMaterialVersion : '1.14.0'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.3.0'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
 }

--- a/browser/README.md
+++ b/browser/README.md
@@ -17,7 +17,7 @@ npx cap sync
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-- `androidxBrowserVersion`: version of `androidx.browser:browser` (default: `1.9.0`)
+- `androidxBrowserVersion`: version of `androidx.browser:browser` (default: `1.10.0`)
 
 ## Example
 

--- a/browser/android/build.gradle
+++ b/browser/android/build.gradle
@@ -4,7 +4,7 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.7.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.3.0'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
-    androidxBrowserVersion = project.hasProperty('androidxBrowserVersion') ? rootProject.ext.androidxBrowserVersion : '1.9.0'
+    androidxBrowserVersion = project.hasProperty('androidxBrowserVersion') ? rootProject.ext.androidxBrowserVersion : '1.10.0'
 }
 
 buildscript {


### PR DESCRIPTION
## Description

This PR updates some plugin android dependencies (not covered by updates to dependencies in capacitor template's `variables.gradle`:

- [chore(android): update action-sheet material to 1.14.0](https://github.com/ionic-team/capacitor-plugins/commit/7e8a48f406308289ffb302e51a5bf6f78c5236c9) 
- [chore(android): update browser plugin androidx.browser to 1.10.0](https://github.com/ionic-team/capacitor-plugins/commit/eb24e9f6b707d7b856e81e3303b42f4b3ed5159e)

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [x] Other (CI, chores, etc.)

## Rationale / Problems Fixed

Internal Jira reference: https://outsystemsrd.atlassian.net/browse/RMET-5329

Push notifications plugin could have technically had a dependency update for cloud messaging Android SDK, but it comes with deprecations that are quite troublesome to fix, and might be too early to do. The internal Jira ticket will have more context, but those updates will not be done in this PR (and possibly not in Capacitor 9).

## Tests or Reproductions

Used testapp based on https://github.com/ionic-team/capacitor-testapp/pull/788 to confirm that plugins build and run correctly after these updates.

## Screenshots / Media

N/A

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

