### PR TITLE
fix(share): present share sheet from the topmost view controller on iOS

### DIFF
--- a/share/ios/Sources/SharePlugin/SharePlugin.swift
+++ b/share/ios/Sources/SharePlugin/SharePlugin.swift
@@ -64,12 +64,28 @@ public class SharePlugin: CAPPlugin, CAPBridgedPlugin {
                 }
 
             }
-            if self?.bridge?.viewController?.presentedViewController != nil {
-                call.reject("Can't share while sharing is in progress")
-                return
+            // Present from the topmost presented view controller so the share sheet appears
+            // above any view controller the app has presented over the webview. With nothing
+            // presented this resolves to the bridge view controller, i.e. unchanged behaviour.
+            // A share is only in progress when a share sheet is already presented.
+            var presenter = self?.bridge?.viewController
+            while let presented = presenter?.presentedViewController {
+                if presented is UIActivityViewController {
+                    call.reject("Can't share while sharing is in progress")
+                    return
+                }
+                presenter = presented
             }
-            self?.setCenteredPopover(actionController)
-            self?.bridge?.viewController?.present(actionController, animated: true, completion: nil)
+            // `setCenteredPopover` anchors to the bridge view controller's view, which is not in
+            // the presenter's hierarchy when presenting from a different view controller. Anchor
+            // the popover to the presenting view controller's own view instead, centered and
+            // without an arrow, matching `setCenteredPopover` behaviour.
+            if let popover = actionController.popoverPresentationController, let presenterView = presenter?.view {
+                popover.sourceView = presenterView
+                popover.sourceRect = CGRect(x: presenterView.bounds.midX, y: presenterView.bounds.midY, width: 0, height: 0)
+                popover.permittedArrowDirections = []
+            }
+            presenter?.present(actionController, animated: true, completion: nil)
         }
     }
 }


### PR DESCRIPTION
## Description

On iOS, `Share.share()` rejects with `"Can't share while sharing is in progress"` whenever *any* view controller is presented over the bridge view controller - not only when a share sheet is open.

`share/ios/Sources/SharePlugin/SharePlugin.swift`:

```swift
if self?.bridge?.viewController?.presentedViewController != nil {
    call.reject("Can't share while sharing is in progress")
    return
}
```

`presentedViewController != nil` is true for any presented view controller. The guard tests presentation state but reports it as share state, so any app presenting a native modal over the webview - an in-app browser, a camera or document picker, a secondary `WKWebView`, a native auth session — cannot share while that modal is on screen, and the error points developers at a stuck share that never existed.

Removing the guard alone would not fix it: `bridge.viewController` cannot present while it already has a `presentedViewController`, so UIKit logs "Attempt to present … which is already presenting …" and no sheet appears. The sheet has to be presented from the topmost view controller.


## Inconsistent with Android

`share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java` tracks a real flag - `isPresenting`, set before `startActivityForResult` and reset in `activityResult` - and rejects only during an actual share. Android shares fine over a presented activity; iOS does not. Both platforms emit the same error string for different conditions, so identical app code behaves differently per platform. This PR makes iOS match Android.

## Fix

Walk the presentation chain, reject only if a `UIActivityViewController` is actually in it, and present from the topmost view controller. When nothing is presented, `presenter` resolves to `bridge.viewController` and behaviour is identical to today.

## iPad popover

`setCenteredPopover` (`CAPPlugin.m`) hardcodes `sourceView` to `bridge.viewController.view`. When presenting from a different view controller that view is not in the presenter's hierarchy, which is invalid for a popover. The popover is therefore anchored to the presenting controller's own view, centered with `permittedArrowDirections = []` - the same result `setCenteredPopover` produces, relative to the correct view.

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Platforms Affected
- [ ] Android
- [x] iOS
- [ ] Web