### PR TITLE
refactor(screen-orientation): remove unneeded iOS code

### DIFF
--- a/screen-orientation/ios/Sources/ScreenOrientationPlugin/ScreenOrientation.swift
+++ b/screen-orientation/ios/Sources/ScreenOrientationPlugin/ScreenOrientation.swift
@@ -21,49 +21,33 @@ public class ScreenOrientation: NSObject {
         return fromDeviceOrientationToOrientationType(currentOrientation)
     }
 
-    private func lockLegacy(_ orientation: Int) {
-        UIDevice.current.setValue(orientation, forKey: "orientation")
-        UINavigationController.attemptRotationToDeviceOrientation()
-    }
-
     public func lock(_ orientationType: String, completion: @escaping (Error?) -> Void) {
         DispatchQueue.main.async {
             let orientation = self.fromOrientationTypeToInt(orientationType)
             self.capViewController?.supportedOrientations = [orientation]
             let mask = self.fromOrientationTypeToMask(orientationType)
-            if #available(iOS 16.0, *) {
-                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
-                    windowScene.keyWindow?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
-                    windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: mask)) { error in
-                        completion(error)
-                    }
-                } else {
-                    completion(ScreenOrientationError.noWindowScene)
-                }
-            } else {
-                self.lockLegacy(orientation)
-            }
-            completion(nil)
+            self.requestGeometryUpdate(mask, completion: completion)
         }
     }
 
     public func unlock(completion: @escaping (Error?) -> Void) {
         DispatchQueue.main.async {
             self.capViewController?.supportedOrientations = self.supportedOrientations
-            if #available(iOS 16.0, *) {
-                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
-                    windowScene.keyWindow?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
-                    windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: .all)) { error in
-                        completion(error)
-                    }
-                } else {
-                    completion(ScreenOrientationError.noWindowScene)
-                }
-            } else {
-                UINavigationController.attemptRotationToDeviceOrientation()
-            }
-            completion(nil)
+            self.requestGeometryUpdate(.all, completion: completion)
         }
+    }
+
+    private func requestGeometryUpdate(_ mask: UIInterfaceOrientationMask, completion: @escaping (Error?) -> Void) {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+            completion(ScreenOrientationError.noWindowScene)
+            return
+        }
+        windowScene.keyWindow?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+        var requestError: Error?
+        windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: mask)) { error in
+            requestError = error
+        }
+        completion(requestError)
     }
 
     private func fromDeviceOrientationToOrientationType(_ orientation: UIDeviceOrientation) -> String {

--- a/screen-orientation/ios/Sources/ScreenOrientationPlugin/ScreenOrientationPlugin.swift
+++ b/screen-orientation/ios/Sources/ScreenOrientationPlugin/ScreenOrientationPlugin.swift
@@ -41,16 +41,17 @@ public class ScreenOrientationPlugin: CAPPlugin, CAPBridgedPlugin {
         implementation.lock(lockToOrientation) { error in
             if let error = error {
                 call.reject(error.localizedDescription)
+                return
             }
             call.resolve()
         }
-
     }
 
     @objc public func unlock(_ call: CAPPluginCall) {
         implementation.unlock { error in
             if let error = error {
                 call.reject(error.localizedDescription)
+                return
             }
             call.resolve()
         }


### PR DESCRIPTION
The plugin's deployment target is iOS 16.0 (`Package.swift` and the podspec), so the two `#available(iOS 16.0, *)` checks in `ScreenOrientation.swift` always pass and their fallback branches were unreachable.

### Removed

- `lockLegacy(_:)`, which set the orientation through KVC on `UIDevice` (`setValue(_:forKey: "orientation")`) and called `UINavigationController.attemptRotationToDeviceOrientation()`, deprecated in iOS 16
- the `attemptRotationToDeviceOrientation()` fallback in `unlock`
- both `#available(iOS 16.0, *)` checks

`fromOrientationTypeToInt(_:)` is kept: it is still used to set `supportedOrientations` on the bridge view controller.

### Deduplicated

The geometry update was identical in `lock` and `unlock`, so it moved to a single `requestGeometryUpdate(_:completion:)` helper.

### Fixed along the way

`completion(nil)` ran unconditionally right after the request was made, so on failure the completion was invoked twice and the call resolved before it rejected. `requestGeometryUpdate`'s error handler only runs when the request is rejected, so its result is now reported once, after the request. The plugin layer was missing a `return` after `call.reject`, which had the same effect one level up.

### Verification

- `xcodebuild build -scheme CapacitorScreenOrientation -destination generic/platform=iOS`: succeeds with no warnings. Before this change it emitted `'attemptRotationToDeviceOrientation()' was deprecated in iOS 16.0`.
- `swiftlint lint --strict screen-orientation/ios`: 0 violations.

Android is untouched: `getLegacyDisplayRotation()` looks similar but is still reachable, since `minSdkVersion` is 26 and the check guards API 30.

RMET-5352