### PR TITLE
chore: remove local-notifications from manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,7 +6,6 @@
   "clipboard": "9.0.0-alpha.2",
   "device": "9.0.0-alpha.2",
   "dialog": "9.0.0-alpha.2",
-  "local-notifications": "9.0.0-alpha.2",
   "motion": "9.0.0-alpha.2",
   "network": "9.0.0-alpha.2",
   "preferences": "9.0.0-alpha.2",


### PR DESCRIPTION
local-notifications code has been removed from the repository, remove it from the release-please-manifest.json file