### PR TITLE
fix(share): Add nonce validation to broadcast receiver on Android

### DIFF
--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -39,12 +39,13 @@ public class SharePlugin extends Plugin {
             @Override
             public void onReceive(Context context, Intent intent) {
                 // Validate nonce to prevent spoofing from other apps
+                //  Reference: https://github.com/ionic-team/capacitor-plugins/pull/2592
                 String receivedNonce = intent.getStringExtra(NONCE_EXTRA_KEY);
                 if (receivedNonce == null || !receivedNonce.equals(expectedNonce)) {
-                    return; // Reject broadcasts that don't have the correct nonce
+                    // Reject broadcasts that don't have the correct nonce
+                    return;
                 }
 
-                // Extract chosen component
                 ComponentName component;
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     component = intent.getParcelableExtra(Intent.EXTRA_CHOSEN_COMPONENT, ComponentName.class);

--- a/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+++ b/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
@@ -19,25 +19,43 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import org.json.JSONException;
 
 @CapacitorPlugin(name = "Share")
 public class SharePlugin extends Plugin {
 
+    private static final String NONCE_EXTRA_KEY = "_share_nonce";
+
     private BroadcastReceiver broadcastReceiver;
     private boolean stopped = false;
     private boolean isPresenting = false;
     private ComponentName chosenComponent;
+    private String expectedNonce;
 
     @Override
     public void load() {
         broadcastReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
+                // Validate nonce to prevent spoofing from other apps
+                String receivedNonce = intent.getStringExtra(NONCE_EXTRA_KEY);
+                if (receivedNonce == null || !receivedNonce.equals(expectedNonce)) {
+                    return; // Reject broadcasts that don't have the correct nonce
+                }
+
+                // Extract chosen component
+                ComponentName component;
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    chosenComponent = intent.getParcelableExtra(Intent.EXTRA_CHOSEN_COMPONENT, ComponentName.class);
+                    component = intent.getParcelableExtra(Intent.EXTRA_CHOSEN_COMPONENT, ComponentName.class);
                 } else {
-                    chosenComponent = getParcelableExtraLegacy(intent, Intent.EXTRA_CHOSEN_COMPONENT);
+                    component = getParcelableExtraLegacy(intent, Intent.EXTRA_CHOSEN_COMPONENT);
+                }
+
+                // Only clear nonce if we successfully got the component data
+                if (component != null) {
+                    chosenComponent = component;
+                    expectedNonce = null;
                 }
             }
         };
@@ -64,6 +82,7 @@ public class SharePlugin extends Plugin {
             call.resolve(callResult);
         }
         isPresenting = false;
+        expectedNonce = null;
     }
 
     @PluginMethod
@@ -117,6 +136,12 @@ public class SharePlugin extends Plugin {
             if (files != null && files.length() != 0) {
                 shareFiles(files, intent, call);
             }
+
+            // Generate a random nonce to prevent spoofing via exported receiver
+            expectedNonce = UUID.randomUUID().toString();
+            Intent callbackIntent = new Intent(Intent.EXTRA_CHOSEN_COMPONENT);
+            callbackIntent.putExtra(NONCE_EXTRA_KEY, expectedNonce);
+
             int flags = PendingIntent.FLAG_UPDATE_CURRENT;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 flags = flags | PendingIntent.FLAG_MUTABLE;
@@ -126,7 +151,7 @@ public class SharePlugin extends Plugin {
             }
 
             // requestCode parameter is not used. Providing 0
-            PendingIntent pi = PendingIntent.getBroadcast(getContext(), 0, new Intent(Intent.EXTRA_CHOSEN_COMPONENT), flags);
+            PendingIntent pi = PendingIntent.getBroadcast(getContext(), 0, callbackIntent, flags);
             Intent chooser = Intent.createChooser(intent, dialogTitle, pi.getIntentSender());
             chosenComponent = null;
             chooser.addCategory(Intent.CATEGORY_DEFAULT);
@@ -180,6 +205,7 @@ public class SharePlugin extends Plugin {
 
     @Override
     protected void handleOnDestroy() {
+        expectedNonce = null;
         if (broadcastReceiver != null) {
             getActivity().unregisterReceiver(broadcastReceiver);
         }


### PR DESCRIPTION
## Description

> ⚠️ 🤖 AI-Assisted Development with Claude, with manual review and testing done by me

Validates nonce to prevent other apps from spoofing the chosen component via exported receiver for the share plugin.

Keep `RECEIVER_EXPORTED` because Android 14+ requires it for system callbacks via `PendingIntent.fillIn()`. Add nonce validation instead: each share request generates a unique UUID included in the callback `PendingIntent`. Only broadcasts with a matching nonce are accepted.

The system always delivers the same extras that were provided in the `PendingIntent`, which is why this solution works.

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed

Closes https://github.com/ionic-team/capacitor-plugins/issues/2591

## Tests or Reproductions

You may use the test app from https://github.com/ionic-team/capacitor-testapp/pull/790 to test (may require `--legacy-peer-deps` in `npm install`).

Tested across multiple Android versions (Android 9 to 17), with devices from different manufacturers:

  - ✅ Samsung
  - ✅ OnePlus
  - ✅ Google Pixel
  - ✅ HMD
  - ✅ Xiaomi
  - ✅ Lenovo
  - ✅ Oppo
  - ✅ Vivo
  - ✅ realme
  - ✅ Motorola
  - ⚠️ Huawei: No intent is received, but from my tests this already happens before this PR, so I'm attributing this to the actual OEM; nothing to do here.

## Platforms Affected

- [x] Android
- [ ] iOS
- [ ] Web
