### PR TITLE
chore: update eslint to v10 and @ionic/eslint-config to v0.5.0

### DIFF
--- a/action-sheet/.eslintignore
+++ b/action-sheet/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/action-sheet/package.json
+++ b/action-sheet/package.json
@@ -51,7 +51,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/action-sheet/package.json
+++ b/action-sheet/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api ActionSheetPlugin --output-readme README.md --output-json dist/docs.json",
@@ -51,10 +51,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -67,9 +67,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/app-launcher/.eslintignore
+++ b/app-launcher/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/app-launcher/package.json
+++ b/app-launcher/package.json
@@ -51,7 +51,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/app-launcher/package.json
+++ b/app-launcher/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api AppLauncherPlugin --output-readme README.md --output-json dist/docs.json",
@@ -51,10 +51,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -67,9 +67,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/app/.eslintignore
+++ b/app/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/app/package.json
+++ b/app/package.json
@@ -52,7 +52,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api AppPlugin --output-readme README.md",
@@ -52,10 +52,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -68,9 +68,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/browser/.eslintignore
+++ b/browser/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/browser/package.json
+++ b/browser/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api BrowserPlugin --output-readme README.md --output-json dist/docs.json",
@@ -51,10 +51,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -67,9 +67,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/browser/package.json
+++ b/browser/package.json
@@ -51,7 +51,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/clipboard/.eslintignore
+++ b/clipboard/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/clipboard/package.json
+++ b/clipboard/package.json
@@ -51,7 +51,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/clipboard/package.json
+++ b/clipboard/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api ClipboardPlugin --output-readme README.md --output-json dist/docs.json",
@@ -51,10 +51,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -67,9 +67,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/clipboard/src/web.ts
+++ b/clipboard/src/web.ts
@@ -27,7 +27,7 @@ export class ClipboardWeb extends WebPlugin implements ClipboardPlugin {
           const blob = await (await fetch(options.image)).blob();
           const clipboardItemInput = new ClipboardItem({ [blob.type]: blob });
           await navigator.clipboard.write([clipboardItemInput]);
-        } catch (err) {
+        } catch {
           throw new Error('Failed to write image');
         }
       } else {
@@ -50,7 +50,7 @@ export class ClipboardWeb extends WebPlugin implements ClipboardPlugin {
         const clipboardBlob = await clipboardItems[0].getType(type);
         const data = await this._getBlobData(clipboardBlob, type);
         return { value: data, type };
-      } catch (err) {
+      } catch {
         return this.readText();
       }
     } else {

--- a/device/.eslintignore
+++ b/device/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/device/package.json
+++ b/device/package.json
@@ -52,7 +52,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/device/package.json
+++ b/device/package.json
@@ -37,7 +37,7 @@
     "verify:web": "npm run build && npm test",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api DevicePlugin --output-readme README.md --output-json dist/docs.json",
@@ -52,10 +52,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -70,9 +70,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/device/src/web.ts
+++ b/device/src/web.ts
@@ -57,7 +57,7 @@ export class DeviceWeb extends WebPlugin implements DevicePlugin {
 
     try {
       battery = await navigator.getBattery();
-    } catch (e) {
+    } catch {
       // Let it fail, we don't care
     }
 

--- a/dialog/.eslintignore
+++ b/dialog/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/dialog/package.json
+++ b/dialog/package.json
@@ -51,7 +51,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/dialog/package.json
+++ b/dialog/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api DialogPlugin --output-readme README.md --output-json dist/docs.json",
@@ -51,10 +51,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -67,9 +67,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,15 @@
+const ionic = require('@ionic/eslint-config/recommended');
+
+module.exports = [
+  {
+    ignores: [
+      '**/build/**',
+      '**/dist/**',
+      // lint TypeScript only
+      '**/*.js',
+      '**/*.mjs',
+      '**/*.cjs',
+    ],
+  },
+  ...ionic,
+];

--- a/motion/.eslintignore
+++ b/motion/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/motion/package.json
+++ b/motion/package.json
@@ -43,7 +43,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "eslint": "^10.0.0",
     "prettier": "^3.6.2",

--- a/motion/package.json
+++ b/motion/package.json
@@ -30,7 +30,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "docgen": "docgen --api MotionPlugin --output-readme README.md --output-json dist/docs.json",
     "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.mjs",
@@ -43,9 +43,9 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -56,9 +56,6 @@
     "@capacitor/core": ">=9.0.0-alpha.0"
   },
   "prettier": "@ionic/prettier-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {},
   "publishConfig": {
     "access": "public"

--- a/network/.eslintignore
+++ b/network/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/network/package.json
+++ b/network/package.json
@@ -51,7 +51,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/network/package.json
+++ b/network/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api NetworkPlugin --output-readme README.md --output-json dist/docs.json",
@@ -51,10 +51,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -67,9 +67,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/preferences/.eslintignore
+++ b/preferences/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/preferences/package.json
+++ b/preferences/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api PreferencesPlugin --output-readme README.md --output-json dist/docs.json",
@@ -51,10 +51,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -67,9 +67,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/preferences/package.json
+++ b/preferences/package.json
@@ -51,7 +51,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/push-notifications/.eslintignore
+++ b/push-notifications/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/push-notifications/package.json
+++ b/push-notifications/package.json
@@ -52,7 +52,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/push-notifications/package.json
+++ b/push-notifications/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api PushNotificationsPlugin --output-readme README.md --output-json dist/docs.json",
@@ -52,10 +52,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -68,9 +68,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/screen-orientation/.eslintignore
+++ b/screen-orientation/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/screen-orientation/package.json
+++ b/screen-orientation/package.json
@@ -51,7 +51,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/screen-orientation/package.json
+++ b/screen-orientation/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api ScreenOrientationPlugin --output-readme README.md --output-json dist/docs.json",
@@ -51,10 +51,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -67,9 +67,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/screen-reader/.eslintignore
+++ b/screen-reader/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/screen-reader/package.json
+++ b/screen-reader/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api ScreenReaderPlugin --output-readme README.md --output-json dist/docs.json",
@@ -51,10 +51,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -67,9 +67,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/screen-reader/package.json
+++ b/screen-reader/package.json
@@ -51,7 +51,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/share/.eslintignore
+++ b/share/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/share/package.json
+++ b/share/package.json
@@ -51,7 +51,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/share/package.json
+++ b/share/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api SharePlugin --output-readme README.md --output-json dist/docs.json",
@@ -51,10 +51,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -67,9 +67,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/splash-screen/.eslintignore
+++ b/splash-screen/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/splash-screen/package.json
+++ b/splash-screen/package.json
@@ -52,7 +52,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/splash-screen/package.json
+++ b/splash-screen/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api SplashScreenPlugin --output-readme README.md --output-json dist/docs.json",
@@ -52,10 +52,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -68,9 +68,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/status-bar/.eslintignore
+++ b/status-bar/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/status-bar/package.json
+++ b/status-bar/package.json
@@ -52,7 +52,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/status-bar/package.json
+++ b/status-bar/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api StatusBarPlugin --output-readme README.md --output-json dist/docs.json",
@@ -52,10 +52,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -68,9 +68,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/text-zoom/.eslintignore
+++ b/text-zoom/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/text-zoom/package.json
+++ b/text-zoom/package.json
@@ -51,7 +51,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/text-zoom/package.json
+++ b/text-zoom/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api TextZoomPlugin --output-readme README.md --output-json dist/docs.json",
@@ -51,10 +51,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -67,9 +67,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"

--- a/toast/.eslintignore
+++ b/toast/.eslintignore
@@ -1,2 +1,0 @@
-build
-dist

--- a/toast/package.json
+++ b/toast/package.json
@@ -51,7 +51,7 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^1.0.0",
+    "@ionic/eslint-config": "^0.5.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "eslint": "^10.0.0",

--- a/toast/package.json
+++ b/toast/package.json
@@ -36,7 +36,7 @@
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "eslint": "eslint .",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api ToastPlugin --output-readme README.md --output-json dist/docs.json",
@@ -51,10 +51,10 @@
     "@capacitor/core": "next",
     "@capacitor/docgen": "0.3.0",
     "@capacitor/ios": "next",
-    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/eslint-config": "^1.0.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^10.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
     "rimraf": "^6.1.0",
@@ -67,9 +67,6 @@
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
-  "eslintConfig": {
-    "extends": "@ionic/eslint-config/recommended"
-  },
   "capacitor": {
     "ios": {
       "src": "ios"


### PR DESCRIPTION
## Description
Updates eslint to v10 and `@ionic/eslint-config` to v0.5 across all 18 packages.

Flat config looks up the folder tree, so the 18 per-package setups become one config at the root. Each package loses its `eslintConfig` block and `.eslintignore`, and `--ext ts` comes out of the lint scripts. The root config ignores `.js` files instead, so we're still linting the same thing as before.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [X] Other (CI, chores, etc.)

## Rationale / Problems Fixed
https://outsystemsrd.atlassian.net/browse/RMET-4734

Eslint 10 removed the old eslintrc format, so the per-package configs had to be rewritten. Eslint 9 is also end of life as of August 2026.

## Platforms Affected
- [ ] Android
- [ ] iOS
- [X] Web

## Notes
Needs `@ionic/eslint-config@0.5.0` published first. Run `npm install` to update the lockfile.
